### PR TITLE
espn_id corrections and additions.

### DIFF
--- a/files/missing_ids.json
+++ b/files/missing_ids.json
@@ -51,10 +51,9 @@
   },
   {
     "mfl_id": 6254,
-    "sleeper_id": 3527,
     "gsis_id": "00-0032848",
     "pff_id": 11302,
-    "espn_id": 2977742,
+    "sleeper_id": 3527,
     "yahoo_id": 29924
   },
   {
@@ -79,9 +78,9 @@
   },
   {
     "mfl_id": 6606,
-    "pfr_id": "JohnDe22",
     "gsis_id": "00-0029435",
     "pff_id": 8070,
+    "pfr_id": "JohnDe22",
     "ras_id": 1836
   },
   {
@@ -146,17 +145,17 @@
   },
   {
     "mfl_id": 8590,
-    "sleeper_id": 53,
     "gsis_id": "00-0022999",
     "pff_id": 2686,
+    "sleeper_id": 53,
     "ras_id": 7143,
     "otc_id": 1119
   },
   {
     "mfl_id": 8723,
-    "pfr_id": "BookLo00",
     "gsis_id": "00-0025458",
-    "pff_id": 3687
+    "pff_id": 3687,
+    "pfr_id": "BookLo00"
   },
   {
     "mfl_id": 8817,
@@ -165,10 +164,10 @@
   },
   {
     "mfl_id": 8911,
-    "sleeper_id": 215,
-    "pfr_id": "SnelJa00",
     "gsis_id": "00-0025631",
     "pff_id": 3860,
+    "sleeper_id": 215,
+    "pfr_id": "SnelJa00",
     "ras_id": 7835,
     "otc_id": 807
   },
@@ -189,10 +188,10 @@
   },
   {
     "mfl_id": 9193,
-    "sleeper_id": 25,
-    "pfr_id": "FeltJe00",
     "gsis_id": "00-0026286",
     "pff_id": 4460,
+    "sleeper_id": 25,
+    "pfr_id": "FeltJe00",
     "ras_id": 8216,
     "otc_id": 1951
   },
@@ -208,18 +207,18 @@
   },
   {
     "mfl_id": 9308,
-    "sleeper_id": 491,
-    "pfr_id": "AmenDa00",
     "gsis_id": "00-0026035",
     "pff_id": 4717,
+    "sleeper_id": 491,
+    "pfr_id": "AmenDa00",
     "ras_id": 8128,
     "otc_id": 402
   },
   {
     "mfl_id": 9315,
-    "sleeper_id": 182,
     "gsis_id": "00-0026069",
     "pff_id": 4740,
+    "sleeper_id": 182,
     "ras_id": 8314,
     "otc_id": 1186
   },
@@ -230,27 +229,27 @@
   },
   {
     "mfl_id": 9616,
-    "sleeper_id": 659,
-    "pfr_id": "PeerCe00",
     "gsis_id": "00-0026932",
     "pff_id": 5109,
+    "sleeper_id": 659,
+    "pfr_id": "PeerCe00",
     "ras_id": 8453,
     "otc_id": 1968
   },
   {
     "mfl_id": 9802,
-    "sleeper_id": 126,
     "gsis_id": "00-0026393",
     "pff_id": 4702,
+    "sleeper_id": 126,
     "ras_id": 8283,
     "otc_id": 1283
   },
   {
     "mfl_id": 9856,
-    "sleeper_id": 564,
-    "pfr_id": "McClDe00",
     "gsis_id": "00-0027651",
     "pff_id": 5561,
+    "sleeper_id": 564,
+    "pfr_id": "McClDe00",
     "ras_id": 8899,
     "otc_id": 500
   },
@@ -261,9 +260,9 @@
   },
   {
     "mfl_id": 10067,
-    "sleeper_id": 609,
     "gsis_id": "00-0026855",
     "pff_id": 5440,
+    "sleeper_id": 609,
     "ras_id": 8418,
     "otc_id": 505
   },
@@ -274,19 +273,19 @@
   },
   {
     "mfl_id": 10301,
-    "sleeper_id": 895,
-    "pfr_id": "TodmJo00",
     "gsis_id": "00-0028121",
     "pff_id": 6335,
+    "sleeper_id": 895,
+    "pfr_id": "TodmJo00",
     "ras_id": 9447,
     "otc_id": 940
   },
   {
     "mfl_id": 10437,
-    "sleeper_id": 982,
-    "pfr_id": "MillBr02",
     "gsis_id": "00-0028149",
     "pff_id": 6363,
+    "sleeper_id": 982,
+    "pfr_id": "MillBr02",
     "otc_id": 57
   },
   {
@@ -296,9 +295,9 @@
   },
   {
     "mfl_id": 10530,
-    "sleeper_id": 863,
     "gsis_id": "00-0028409",
     "pff_id": 6595,
+    "sleeper_id": 863,
     "ras_id": 9367,
     "otc_id": 1104
   },
@@ -309,10 +308,10 @@
   },
   {
     "mfl_id": 10881,
-    "sleeper_id": 1307,
-    "pfr_id": "HerrDa00",
     "gsis_id": "00-0029588",
     "pff_id": 7179,
+    "sleeper_id": 1307,
+    "pfr_id": "HerrDa00",
     "ras_id": 9837,
     "otc_id": 172
   },
@@ -323,53 +322,57 @@
   },
   {
     "mfl_id": 10932,
-    "sleeper_id": 1034,
-    "pfr_id": "BoldBr00",
     "gsis_id": "00-0029239",
     "pff_id": 7469,
+    "sleeper_id": 1034,
+    "espn_id": 15478,
+    "pfr_id": "BoldBr00",
     "ras_id": 9739,
-    "otc_id": 1202
+    "otc_id": 1202,
+    "espn_id_new": 15478
   },
   {
     "mfl_id": 10940,
-    "sleeper_id": 1718,
-    "pfr_id": "CarrDe00",
     "gsis_id": "00-0029119",
     "pff_id": 7406,
+    "sleeper_id": 1718,
+    "pfr_id": "CarrDe00",
     "ras_id": 9866,
     "otc_id": 743
   },
   {
     "mfl_id": 10961,
-    "sleeper_id": 1284,
     "gsis_id": "00-0029004",
     "pff_id": 7332,
+    "sleeper_id": 1284,
     "ras_id": 10087,
     "otc_id": 641
   },
   {
     "mfl_id": 10973,
-    "sleeper_id": 1144,
-    "pfr_id": "BeasCo00",
     "gsis_id": "00-0029000",
     "pff_id": 7330,
+    "sleeper_id": 1144,
+    "espn_id": 15349,
+    "pfr_id": "BeasCo00",
     "ras_id": 9814,
-    "otc_id": 613
+    "otc_id": 613,
+    "espn_id_new": 15349
   },
   {
     "mfl_id": 10975,
-    "sleeper_id": 1275,
     "gsis_id": "00-0029510",
     "pff_id": 7585,
+    "sleeper_id": 1275,
     "ras_id": 10019,
     "otc_id": 939
   },
   {
     "mfl_id": 10983,
-    "sleeper_id": 1329,
-    "pfr_id": "HogaCh00",
     "gsis_id": "00-0028237",
     "pff_id": 6468,
+    "sleeper_id": 1329,
+    "pfr_id": "HogaCh00",
     "ras_id": 8107,
     "otc_id": 216
   },
@@ -380,9 +383,9 @@
   },
   {
     "mfl_id": 11083,
-    "sleeper_id": 1293,
     "gsis_id": "00-0029441",
     "pff_id": 7534,
+    "sleeper_id": 1293,
     "ras_id": 9990,
     "otc_id": 2152
   },
@@ -393,66 +396,65 @@
   },
   {
     "mfl_id": 11183,
-    "espn_id": 16495,
     "yahoo_id": 27311
   },
   {
     "mfl_id": 11332,
-    "sleeper_id": 1698,
     "gsis_id": "00-0029104",
     "pff_id": 7393,
+    "sleeper_id": 1698,
     "ras_id": 10017,
     "otc_id": 693
   },
   {
     "mfl_id": 11337,
-    "sleeper_id": 1592,
-    "pfr_id": "FellDa01",
     "gsis_id": "00-0029738",
     "pff_id": 8549,
+    "sleeper_id": 1592,
+    "pfr_id": "FellDa01",
     "otc_id": 2426
   },
   {
     "mfl_id": 11448,
-    "sleeper_id": 1619,
-    "pfr_id": "HarrDe03",
     "gsis_id": "00-0030155",
     "pff_id": 8524,
+    "sleeper_id": 1619,
+    "pfr_id": "HarrDe03",
     "ras_id": 10487,
     "otc_id": 2736
   },
   {
     "mfl_id": 11466,
-    "sleeper_id": 1720,
     "gsis_id": "00-0030348",
     "pff_id": 8514,
+    "sleeper_id": 1720,
     "ras_id": 10673,
     "otc_id": 2592
   },
   {
     "mfl_id": 11516,
-    "sleeper_id": 1706,
-    "pfr_id": "DoylJa00",
     "gsis_id": "00-0030181",
     "pff_id": 8520,
+    "sleeper_id": 1706,
+    "pfr_id": "DoylJa00",
     "ras_id": 10557,
     "otc_id": 2520
   },
   {
     "mfl_id": 11529,
-    "sleeper_id": 1777,
-    "pfr_id": "HillJo02",
     "gsis_id": "00-0030216",
     "pff_id": 8200,
+    "sleeper_id": 1777,
+    "pfr_id": "HillJo02",
     "ras_id": 10629,
     "otc_id": 2594
   },
   {
     "mfl_id": 11705,
-    "sleeper_id": 1793,
-    "pfr_id": "BurtTr01",
     "gsis_id": "00-0030710",
     "pff_id": 9185,
+    "sleeper_id": 1793,
+    "pfr_id": "BurtTr01",
     "ras_id": 11621,
     "otc_id": 3521
   },
@@ -466,70 +468,76 @@
   },
   {
     "mfl_id": 11886,
-    "sleeper_id": 1833,
-    "pfr_id": "WillDa05",
     "gsis_id": "00-0030874",
     "pff_id": 9205,
+    "sleeper_id": 1833,
+    "espn_id": 17359,
+    "pfr_id": "WillDa05",
     "ras_id": 11153,
-    "otc_id": 3444
+    "otc_id": 3444,
+    "espn_id_new": 17359
   },
   {
     "mfl_id": 11890,
-    "sleeper_id": 2025,
-    "pfr_id": "WilsAl02",
     "gsis_id": "00-0030669",
     "pff_id": 8943,
+    "sleeper_id": 2025,
+    "pfr_id": "WilsAl02",
     "ras_id": 11001,
     "otc_id": 3428
   },
   {
     "mfl_id": 11901,
-    "sleeper_id": 1928,
     "gsis_id": "00-0030789",
     "pff_id": 9014,
+    "sleeper_id": 1928,
     "ras_id": 11027,
     "otc_id": 3600
   },
   {
     "mfl_id": 11938,
-    "sleeper_id": 1689,
-    "pfr_id": "ThieAd00",
     "gsis_id": "00-0030035",
     "pff_id": 8288,
+    "sleeper_id": 1689,
+    "espn_id": 16460,
+    "pfr_id": "ThieAd00",
     "ras_id": 10337,
-    "otc_id": 2766
+    "otc_id": 2766,
+    "espn_id_new": 16460
   },
   {
     "mfl_id": 11942,
-    "sleeper_id": 2193,
     "gsis_id": "00-0031123",
     "pff_id": 9006,
+    "sleeper_id": 2193,
     "ras_id": 11161,
     "otc_id": 3283
   },
   {
     "mfl_id": 11951,
-    "sleeper_id": 1911,
-    "pfr_id": "SneaWi00",
     "gsis_id": "00-0030663",
     "pff_id": 8999,
+    "sleeper_id": 1911,
+    "espn_id": 17258,
+    "pfr_id": "SneaWi00",
     "ras_id": 1271,
-    "otc_id": 3315
+    "otc_id": 3315,
+    "espn_id_new": 17258
   },
   {
     "mfl_id": 11957,
-    "sleeper_id": 2291,
-    "pfr_id": "InmaDo00",
     "gsis_id": "00-0028411",
     "pff_id": 6597,
+    "sleeper_id": 2291,
+    "pfr_id": "InmaDo00",
     "ras_id": 9362,
     "otc_id": 2731
   },
   {
     "mfl_id": 11977,
-    "sleeper_id": 1819,
     "gsis_id": "00-0030860",
     "pff_id": 9173,
+    "sleeper_id": 1819,
     "ras_id": 11493,
     "otc_id": 3648
   },
@@ -539,12 +547,14 @@
   },
   {
     "mfl_id": 12110,
-    "sleeper_id": 2214,
-    "pfr_id": "BratCa00",
     "gsis_id": "00-0031273",
     "pff_id": 9207,
+    "sleeper_id": 2214,
+    "espn_id": 17453,
+    "pfr_id": "BratCa00",
     "ras_id": 11088,
-    "otc_id": 3770
+    "otc_id": 3770,
+    "espn_id_new": 17453
   },
   {
     "mfl_id": 12149,
@@ -562,40 +572,40 @@
   },
   {
     "mfl_id": 12215,
-    "espn_id": 3040479
+    "espn_id": 3040479,
+    "espn_id_new": 3040479
   },
   {
     "mfl_id": 12241,
-    "sleeper_id": 5822,
     "gsis_id": "00-0034887",
     "pff_id": 15267,
-    "espn_id": 2577712,
+    "sleeper_id": 5822,
     "yahoo_id": 31792
   },
   {
     "mfl_id": 12340,
-    "sleeper_id": 2489,
-    "pfr_id": "StewTo01",
     "gsis_id": "00-0032189",
-    "espn_id": 2576504,
-    "yahoo_id": 28576
+    "sleeper_id": 2489,
+    "yahoo_id": 28576,
+    "pfr_id": "StewTo01"
   },
   {
     "mfl_id": 12354,
-    "sleeper_id": 2508,
-    "pfr_id": "HerrAm00",
     "gsis_id": "00-0031613",
-    "espn_id": 2578542,
-    "yahoo_id": 28595
+    "sleeper_id": 2508,
+    "yahoo_id": 28595,
+    "pfr_id": "HerrAm00"
   },
   {
     "mfl_id": 12386,
-    "sleeper_id": 2588,
-    "pfr_id": "BrowMa03",
     "gsis_id": "00-0031806",
     "pff_id": 9902,
+    "sleeper_id": 2588,
+    "espn_id": 2570986,
+    "pfr_id": "BrowMa03",
     "ras_id": 12065,
-    "otc_id": 4363
+    "otc_id": 4363,
+    "espn_id_new": 2570986
   },
   {
     "mfl_id": 12387,
@@ -603,21 +613,23 @@
   },
   {
     "mfl_id": 12391,
-    "sleeper_id": 2583,
-    "pfr_id": "WillTy00",
     "gsis_id": "00-0032160",
     "pff_id": 10154,
+    "sleeper_id": 2583,
+    "pfr_id": "WillTy00",
     "ras_id": 12252,
     "otc_id": 4630
   },
   {
     "mfl_id": 12394,
-    "sleeper_id": 2750,
-    "pfr_id": "CartDe02",
     "gsis_id": "00-0031763",
     "pff_id": 9859,
+    "sleeper_id": 2750,
+    "espn_id": 2580216,
+    "pfr_id": "CartDe02",
     "ras_id": 11843,
-    "otc_id": 4390
+    "otc_id": 4390,
+    "espn_id_new": 2580216
   },
   {
     "mfl_id": 12395,
@@ -646,176 +658,169 @@
   },
   {
     "mfl_id": 12443,
-    "sleeper_id": 2821,
-    "pfr_id": "KumeJa00",
     "gsis_id": "00-0031787",
     "pff_id": 9883,
+    "sleeper_id": 2821,
+    "espn_id": 3085107,
+    "pfr_id": "KumeJa00",
     "ras_id": 11952,
-    "otc_id": 4455
+    "otc_id": 4455,
+    "espn_id_new": 3085107
   },
   {
     "mfl_id": 12447,
-    "sleeper_id": 2749,
-    "pfr_id": "MostRa00",
     "gsis_id": "00-0031687",
     "pff_id": 9783,
+    "sleeper_id": 2749,
+    "espn_id": 2576414,
+    "pfr_id": "MostRa00",
     "ras_id": 12142,
-    "otc_id": 4146
+    "otc_id": 4146,
+    "espn_id_new": 2576414
   },
   {
     "mfl_id": 12464,
-    "sleeper_id": 2673,
-    "pfr_id": "ByrdDa00",
     "gsis_id": "00-0031868",
     "pff_id": 9964,
+    "sleeper_id": 2673,
+    "espn_id": 2577667,
+    "pfr_id": "ByrdDa00",
     "ras_id": 11815,
-    "otc_id": 4599
+    "otc_id": 4599,
+    "espn_id_new": 2577667
   },
   {
     "mfl_id": 12476,
-    "sleeper_id": 2711,
-    "pfr_id": "HeinTa00",
     "gsis_id": "00-0031800",
     "pff_id": 9896,
+    "sleeper_id": 2711,
+    "espn_id": 2565969,
+    "pfr_id": "HeinTa00",
     "ras_id": 12202,
-    "otc_id": 4450
+    "otc_id": 4450,
+    "espn_id_new": 2565969
   },
   {
     "mfl_id": 12500,
-    "sleeper_id": 2642,
-    "pfr_id": "BateHo00",
     "gsis_id": "00-0032181",
-    "espn_id": 2516049,
-    "yahoo_id": 29121
+    "sleeper_id": 2642,
+    "yahoo_id": 29121,
+    "pfr_id": "BateHo00"
   },
   {
     "mfl_id": 12505,
-    "sleeper_id": 2822,
-    "pfr_id": "HumpAd00",
     "gsis_id": "00-0032009",
     "pff_id": 10075,
+    "sleeper_id": 2822,
+    "pfr_id": "HumpAd00",
     "ras_id": 11672,
     "otc_id": 4567
   },
   {
     "mfl_id": 12585,
-    "sleeper_id": 2751,
-    "pfr_id": "BrowDa04",
     "gsis_id": "00-0032098",
-    "pff_id": 10144
+    "pff_id": 10144,
+    "sleeper_id": 2751,
+    "pfr_id": "BrowDa04"
   },
   {
     "mfl_id": 12592,
-    "sleeper_id": 3069,
-    "pfr_id": "TavaJ.00",
     "gsis_id": "00-0032044",
-    "espn_id": 2577264,
-    "yahoo_id": 29065
+    "sleeper_id": 3069,
+    "yahoo_id": 29065,
+    "pfr_id": "TavaJ.00"
   },
   {
     "mfl_id": 12605,
-    "pfr_id": "RoacTr00",
     "gsis_id": "00-0031791",
-    "espn_id": 2514179
+    "pfr_id": "RoacTr00"
   },
   {
     "mfl_id": 12637,
-    "sleeper_id": 3594,
-    "pfr_id": "BarbPe01",
     "gsis_id": "00-0032741",
     "pff_id": 10927,
+    "sleeper_id": 3594,
+    "pfr_id": "BarbPe01",
     "ras_id": 12906,
     "otc_id": 5023
   },
   {
     "mfl_id": 12640,
-    "sleeper_id": 3453,
-    "pfr_id": "FergJo02",
     "gsis_id": "00-0032377",
     "pff_id": 10907,
-    "espn_id": 2576165,
-    "yahoo_id": 29599
+    "sleeper_id": 3453,
+    "yahoo_id": 29599,
+    "pfr_id": "FergJo02"
   },
   {
     "mfl_id": 12641,
-    "pfr_id": "GreeAa01",
     "gsis_id": "00-0032672",
-    "espn_id": 2570994
+    "pfr_id": "GreeAa01"
   },
   {
     "mfl_id": 12642,
-    "sleeper_id": 3532,
-    "pfr_id": "FarrKe02",
     "gsis_id": "00-0032902",
     "pff_id": 10988,
-    "espn_id": 2575553,
-    "yahoo_id": 29518
+    "sleeper_id": 3532,
+    "yahoo_id": 29518,
+    "pfr_id": "FarrKe02"
   },
   {
     "mfl_id": 12644,
-    "sleeper_id": 3564,
     "gsis_id": "00-0032472",
     "pff_id": 11286,
-    "espn_id": 2577245,
+    "sleeper_id": 3564,
     "yahoo_id": 29821
   },
   {
     "mfl_id": 12649,
-    "sleeper_id": 3519,
-    "pfr_id": "LewiRo03",
     "gsis_id": "00-0032659",
     "pff_id": 11246,
-    "espn_id": 3125745,
-    "yahoo_id": 29855
+    "sleeper_id": 3519,
+    "yahoo_id": 29855,
+    "pfr_id": "LewiRo03"
   },
   {
     "mfl_id": 12653,
-    "pfr_id": "MarsJa01",
     "gsis_id": "00-0032694",
-    "espn_id": 3051400
+    "pfr_id": "MarsJa01"
   },
   {
     "mfl_id": 12661,
-    "sleeper_id": 3620,
     "gsis_id": "00-0032482",
     "pff_id": 11013,
-    "espn_id": 2971271,
+    "sleeper_id": 3620,
     "yahoo_id": 29616
   },
   {
     "mfl_id": 12663,
-    "pfr_id": "PaytJo00",
     "gsis_id": "00-0032974",
-    "espn_id": 2971588
+    "pfr_id": "PaytJo00"
   },
   {
     "mfl_id": 12665,
-    "sleeper_id": 3503,
-    "pfr_id": "AlliGe01",
     "gsis_id": "00-0032626",
     "pff_id": 11141,
-    "espn_id": 3115913,
-    "yahoo_id": 29719
+    "sleeper_id": 3503,
+    "yahoo_id": 29719,
+    "pfr_id": "AlliGe01"
   },
   {
     "mfl_id": 12667,
-    "sleeper_id": 3846,
     "gsis_id": "00-0032945",
     "pff_id": 11366,
-    "espn_id": 3115315,
+    "sleeper_id": 3846,
     "yahoo_id": 29973
   },
   {
     "mfl_id": 12669,
-    "pfr_id": "MitcMa01",
     "gsis_id": "00-0032400",
-    "espn_id": 2578553
+    "pfr_id": "MitcMa01"
   },
   {
     "mfl_id": 12672,
-    "pfr_id": "BravDa00",
     "gsis_id": "00-0032801",
-    "espn_id": 2973052
+    "pfr_id": "BravDa00"
   },
   {
     "mfl_id": 12675,
@@ -823,52 +828,45 @@
   },
   {
     "mfl_id": 12682,
-    "sleeper_id": 3514,
     "gsis_id": "00-0032997",
     "pff_id": 11010,
-    "espn_id": 2512657,
+    "sleeper_id": 3514,
     "yahoo_id": 29504
   },
   {
     "mfl_id": 12683,
-    "sleeper_id": 3481,
     "gsis_id": "00-0032606",
     "pff_id": 10977,
-    "espn_id": 2582138,
+    "sleeper_id": 3481,
     "yahoo_id": 29537
   },
   {
     "mfl_id": 12685,
-    "sleeper_id": 3668,
-    "pfr_id": "PerkJo02",
     "gsis_id": "00-0032599",
     "pff_id": 11051,
-    "espn_id": 2578377,
-    "yahoo_id": 29654
+    "sleeper_id": 3668,
+    "yahoo_id": 29654,
+    "pfr_id": "PerkJo02"
   },
   {
     "mfl_id": 12689,
-    "pfr_id": "DoddKe00",
     "gsis_id": "00-0033074",
-    "espn_id": 2977682
+    "pfr_id": "DoddKe00"
   },
   {
     "mfl_id": 12704,
-    "pfr_id": "WrigSc00",
     "gsis_id": "00-0032979",
-    "espn_id": 3056472
+    "pfr_id": "WrigSc00"
   },
   {
     "mfl_id": 12708,
-    "pfr_id": "PerrJo01",
     "gsis_id": "00-0032894",
-    "espn_id": 2976306
+    "pfr_id": "PerrJo01"
   },
   {
     "mfl_id": 12709,
-    "pfr_id": "AlexDo01",
     "gsis_id": "00-0032983",
-    "espn_id": 3052651
+    "pfr_id": "AlexDo01"
   },
   {
     "mfl_id": 12765,
@@ -880,3804 +878,3654 @@
   },
   {
     "mfl_id": 12793,
-    "pfr_id": "SancZa00",
     "gsis_id": "00-0032973",
-    "espn_id": 2976596
+    "pfr_id": "SancZa00"
   },
   {
     "mfl_id": 12797,
-    "sleeper_id": 3308,
     "gsis_id": "00-0032781",
     "pff_id": 10786,
-    "espn_id": 2976263,
+    "sleeper_id": 3308,
     "yahoo_id": 29386
   },
   {
     "mfl_id": 12818,
-    "pfr_id": "ForrJo00",
     "gsis_id": "00-0033113",
-    "espn_id": 2576678
+    "pfr_id": "ForrJo00"
   },
   {
     "mfl_id": 12820,
-    "pfr_id": "JameCo00",
     "gsis_id": "00-0033056",
-    "espn_id": 2575663
+    "pfr_id": "JameCo00"
   },
   {
     "mfl_id": 12822,
-    "sleeper_id": 3353,
     "gsis_id": "00-0032794",
     "pff_id": 10831,
-    "espn_id": 2974365,
+    "sleeper_id": 3353,
     "yahoo_id": 29431
   },
   {
     "mfl_id": 12825,
-    "pfr_id": "NicoDa00",
     "gsis_id": "00-0032796",
-    "espn_id": 3929954
+    "pfr_id": "NicoDa00"
   },
   {
     "mfl_id": 12844,
-    "sleeper_id": 3390,
     "gsis_id": "00-0032449",
     "pff_id": 10869,
-    "espn_id": 3061740,
+    "sleeper_id": 3390,
     "yahoo_id": 29469
   },
   {
     "mfl_id": 12859,
-    "sleeper_id": 3496,
-    "pfr_id": "AndeSt01",
     "gsis_id": "00-0032725",
     "pff_id": 11160,
+    "sleeper_id": 3496,
+    "espn_id": 2576854,
+    "pfr_id": "AndeSt01",
     "ras_id": 13003,
-    "otc_id": 5264
+    "otc_id": 5264,
+    "espn_id_new": 2576854
   },
   {
     "mfl_id": 12860,
-    "sleeper_id": 3451,
     "gsis_id": "00-0032726",
+    "sleeper_id": 3451,
+    "yahoo_id": 29792,
     "espn_id": 2971573,
-    "yahoo_id": 29792
+    "espn_id_new": 2971573
   },
   {
     "mfl_id": 12863,
-    "pfr_id": "McRoPa00",
     "gsis_id": "00-0032679",
-    "espn_id": 2975817
+    "pfr_id": "McRoPa00"
   },
   {
     "mfl_id": 12864,
-    "sleeper_id": 3491,
     "gsis_id": "00-0032964",
     "pff_id": 11076,
-    "espn_id": 2971289,
+    "sleeper_id": 3491,
     "yahoo_id": 29680
   },
   {
     "mfl_id": 12865,
-    "pfr_id": "WillWe00",
     "gsis_id": "00-0032739",
-    "espn_id": 3933497
+    "pfr_id": "WillWe00"
   },
   {
     "mfl_id": 12867,
-    "sleeper_id": 3573,
-    "pfr_id": "WildBr01",
     "gsis_id": "00-0032593",
     "pff_id": 11057,
-    "espn_id": 2577692,
-    "yahoo_id": 29661
+    "sleeper_id": 3573,
+    "yahoo_id": 29661,
+    "pfr_id": "WildBr01"
   },
   {
     "mfl_id": 12868,
-    "sleeper_id": 3465,
-    "pfr_id": "BrauBe00",
     "gsis_id": "00-0032661",
     "pff_id": 11335,
-    "espn_id": 2969241,
-    "yahoo_id": 29913
+    "sleeper_id": 3465,
+    "yahoo_id": 29913,
+    "pfr_id": "BrauBe00"
   },
   {
     "mfl_id": 12870,
-    "sleeper_id": 3436,
-    "pfr_id": "CashJe00",
     "gsis_id": "00-0032994",
     "pff_id": 11007,
-    "espn_id": 2576378,
-    "yahoo_id": 29501
+    "sleeper_id": 3436,
+    "yahoo_id": 29501,
+    "pfr_id": "CashJe00"
   },
   {
     "mfl_id": 12871,
-    "sleeper_id": 3488,
-    "pfr_id": "FostD.01",
     "gsis_id": "00-0032577",
     "pff_id": 11214,
-    "espn_id": 2978124,
-    "yahoo_id": 29872
+    "sleeper_id": 3488,
+    "yahoo_id": 29872,
+    "pfr_id": "FostD.01"
   },
   {
     "mfl_id": 12872,
-    "pfr_id": "McCoDe00",
     "gsis_id": "00-0032322",
-    "espn_id": 2470860
+    "pfr_id": "McCoDe00"
   },
   {
     "mfl_id": 12873,
-    "sleeper_id": 3702,
     "gsis_id": "00-0032707",
     "pff_id": 11123,
-    "espn_id": 2982761,
+    "sleeper_id": 3702,
     "yahoo_id": 29893
   },
   {
     "mfl_id": 12874,
-    "sleeper_id": 3612,
-    "pfr_id": "VallHa00",
     "gsis_id": "00-0032508",
     "pff_id": 10960,
-    "espn_id": 2567213,
-    "yahoo_id": 29587
+    "sleeper_id": 3612,
+    "yahoo_id": 29587,
+    "pfr_id": "VallHa00"
   },
   {
     "mfl_id": 12878,
-    "pfr_id": "BoykTr00",
-    "gsis_id": "00-0032462"
+    "gsis_id": "00-0032462",
+    "pfr_id": "BoykTr00"
   },
   {
     "mfl_id": 12879,
-    "sleeper_id": 3562,
     "gsis_id": "00-0032479",
     "pff_id": 11291,
-    "espn_id": 2976308,
+    "sleeper_id": 3562,
     "yahoo_id": 29833
   },
   {
     "mfl_id": 12884,
-    "sleeper_id": 3517,
     "gsis_id": "00-0032839",
     "pff_id": 11078,
-    "espn_id": 3125354,
+    "sleeper_id": 3517,
     "yahoo_id": 29682
   },
   {
     "mfl_id": 12887,
-    "sleeper_id": 3657,
-    "pfr_id": "KellRo00",
     "gsis_id": "00-0032371",
     "pff_id": 11090,
-    "espn_id": 2575408,
-    "yahoo_id": 29694
+    "sleeper_id": 3657,
+    "yahoo_id": 29694,
+    "pfr_id": "KellRo00"
   },
   {
     "mfl_id": 12888,
-    "sleeper_id": 3473,
     "gsis_id": "00-0032518",
     "pff_id": 10975,
-    "espn_id": 3057899,
+    "sleeper_id": 3473,
     "yahoo_id": 29559
   },
   {
     "mfl_id": 12890,
-    "sleeper_id": 3730,
     "gsis_id": "00-0032728",
     "pff_id": 11163,
-    "espn_id": 2586703,
+    "sleeper_id": 3730,
     "yahoo_id": 29795
   },
   {
     "mfl_id": 12894,
-    "sleeper_id": 3485,
-    "pfr_id": "KrieHe00",
     "gsis_id": "00-0032523",
     "pff_id": 11020,
-    "espn_id": 3144999,
-    "yahoo_id": 29623
+    "sleeper_id": 3485,
+    "yahoo_id": 29623,
+    "pfr_id": "KrieHe00"
   },
   {
     "mfl_id": 12896,
-    "pfr_id": "ScotRa01",
-    "gsis_id": "00-0032621"
+    "gsis_id": "00-0032621",
+    "pfr_id": "ScotRa01"
   },
   {
     "mfl_id": 12897,
-    "pfr_id": "BurkBr00",
-    "gsis_id": "00-0032844"
+    "gsis_id": "00-0032844",
+    "pfr_id": "BurkBr00"
   },
   {
     "mfl_id": 12899,
-    "sleeper_id": 3715,
-    "pfr_id": "WickCo00",
     "gsis_id": "00-0032562",
     "pff_id": 11139,
-    "espn_id": 2982151,
-    "yahoo_id": 29783
+    "sleeper_id": 3715,
+    "yahoo_id": 29783,
+    "pfr_id": "WickCo00"
   },
   {
     "mfl_id": 12900,
-    "sleeper_id": 3840,
     "gsis_id": "00-0032937",
     "pff_id": 11357,
-    "espn_id": 2969896,
+    "sleeper_id": 3840,
     "yahoo_id": 29961
   },
   {
     "mfl_id": 12906,
-    "sleeper_id": 3550,
-    "pfr_id": "WilsJa00",
     "gsis_id": "00-0032525",
     "pff_id": 10902,
-    "espn_id": 2970661,
-    "yahoo_id": 29514
+    "sleeper_id": 3550,
+    "yahoo_id": 29514,
+    "pfr_id": "WilsJa00"
   },
   {
     "mfl_id": 12908,
-    "sleeper_id": 2634,
-    "pfr_id": "BrowMa02",
     "gsis_id": "00-0032048",
     "pff_id": 10115,
-    "espn_id": 2512191,
-    "yahoo_id": 29085
+    "sleeper_id": 2634,
+    "yahoo_id": 29085,
+    "pfr_id": "BrowMa02"
   },
   {
     "mfl_id": 12912,
-    "sleeper_id": 3868,
-    "pfr_id": "RichJa01",
     "gsis_id": "00-0033025",
     "pff_id": 11395,
-    "espn_id": 2972091,
-    "yahoo_id": 30000
+    "sleeper_id": 3868,
+    "yahoo_id": 30000,
+    "pfr_id": "RichJa01"
   },
   {
     "mfl_id": 12913,
-    "sleeper_id": 3433,
-    "pfr_id": "EricAl01",
     "gsis_id": "00-0032543",
     "pff_id": 11107,
+    "sleeper_id": 3433,
+    "espn_id": 2977800,
+    "pfr_id": "EricAl01",
     "ras_id": 12295,
-    "otc_id": 5255
+    "otc_id": 5255,
+    "espn_id_new": 2977800
   },
   {
     "mfl_id": 12914,
-    "pfr_id": "HamlCo01",
-    "gsis_id": "00-0031732"
+    "gsis_id": "00-0031732",
+    "pfr_id": "HamlCo01"
   },
   {
     "mfl_id": 12916,
-    "sleeper_id": 3476,
-    "pfr_id": "HoltJo00",
     "gsis_id": "00-0032935",
     "pff_id": 11354,
-    "espn_id": 3056906,
-    "yahoo_id": 29958
+    "sleeper_id": 3476,
+    "yahoo_id": 29958,
+    "pfr_id": "HoltJo00"
   },
   {
     "mfl_id": 12917,
-    "sleeper_id": 3650,
-    "pfr_id": "HarrMa05",
     "gsis_id": "00-0032362",
     "pff_id": 11035,
-    "espn_id": 2576868,
-    "yahoo_id": 29638
+    "sleeper_id": 3650,
+    "yahoo_id": 29638,
+    "pfr_id": "HarrMa05"
   },
   {
     "mfl_id": 12918,
-    "sleeper_id": 3622,
     "gsis_id": "00-0032488",
     "pff_id": 11015,
-    "espn_id": 2977874,
+    "sleeper_id": 3622,
     "yahoo_id": 29618
   },
   {
     "mfl_id": 12921,
-    "sleeper_id": 3614,
-    "pfr_id": "LewiTo00",
     "gsis_id": "00-0032881",
     "pff_id": 11231,
-    "espn_id": 2574918,
-    "yahoo_id": 29854
+    "sleeper_id": 3614,
+    "yahoo_id": 29854,
+    "pfr_id": "LewiTo00"
   },
   {
     "mfl_id": 12923,
+    "gsis_id": "00-0032918",
+    "espn_id": 4012556,
     "pfr_id": "HamxC.00",
-    "gsis_id": "00-0032918"
+    "espn_id_new": 4012556
   },
   {
     "mfl_id": 12924,
-    "sleeper_id": 3836,
     "gsis_id": "00-0032929",
     "pff_id": 11351,
-    "espn_id": 2471470,
+    "sleeper_id": 3836,
     "yahoo_id": 29955
   },
   {
     "mfl_id": 12925,
-    "sleeper_id": 3717,
     "gsis_id": "00-0032630",
     "pff_id": 11144,
-    "espn_id": 3078660,
+    "sleeper_id": 3717,
     "yahoo_id": 29722
   },
   {
     "mfl_id": 12926,
-    "pfr_id": "KingDe00",
-    "gsis_id": "00-0032708"
+    "gsis_id": "00-0032708",
+    "pfr_id": "KingDe00"
   },
   {
     "mfl_id": 12927,
-    "pfr_id": "TurnPa01",
-    "gsis_id": "00-0032841"
+    "gsis_id": "00-0032841",
+    "pfr_id": "TurnPa01"
   },
   {
     "mfl_id": 12928,
-    "sleeper_id": 3598,
-    "pfr_id": "RhodLu00",
     "gsis_id": "00-0032753",
     "pff_id": 10940,
-    "espn_id": 2566045,
-    "yahoo_id": 29588
+    "sleeper_id": 3598,
+    "yahoo_id": 29588,
+    "pfr_id": "RhodLu00"
   },
   {
     "mfl_id": 12929,
-    "sleeper_id": 3934,
-    "pfr_id": "PopeTr00",
     "gsis_id": "00-0033164",
     "pff_id": 11473,
-    "espn_id": 2983319,
-    "yahoo_id": 30061
+    "sleeper_id": 3934,
+    "yahoo_id": 30061,
+    "pfr_id": "PopeTr00"
   },
   {
     "mfl_id": 12930,
-    "sleeper_id": 3423,
-    "pfr_id": "AndeRo04",
     "gsis_id": "00-0032688",
     "pff_id": 11254,
+    "sleeper_id": 3423,
+    "espn_id": 2574808,
+    "pfr_id": "AndeRo04",
     "ras_id": 12936,
-    "otc_id": 5208
+    "otc_id": 5208,
+    "espn_id_new": 2574808
   },
   {
     "mfl_id": 12931,
-    "sleeper_id": 3424,
-    "pfr_id": "HarrDe04",
     "gsis_id": "00-0032946",
     "pff_id": 11227,
-    "espn_id": 2972273,
-    "yahoo_id": 29847
+    "sleeper_id": 3424,
+    "yahoo_id": 29847,
+    "pfr_id": "HarrDe04"
   },
   {
     "mfl_id": 12934,
-    "sleeper_id": 3582,
-    "pfr_id": "RogeCh02",
     "gsis_id": "00-0032355",
     "pff_id": 10918,
+    "sleeper_id": 3582,
+    "pfr_id": "RogeCh02",
     "ras_id": 12407,
     "otc_id": 5086
   },
   {
     "mfl_id": 12936,
-    "sleeper_id": 3621,
     "gsis_id": "00-0032876",
     "pff_id": 11238,
-    "espn_id": 2972065,
+    "sleeper_id": 3621,
     "yahoo_id": 29865
   },
   {
     "mfl_id": 12938,
-    "sleeper_id": 3669,
-    "pfr_id": "PoolBr01",
     "gsis_id": "00-0032596",
     "pff_id": 11052,
-    "espn_id": 2980115,
-    "yahoo_id": 29655
+    "sleeper_id": 3669,
+    "yahoo_id": 29655,
+    "pfr_id": "PoolBr01"
   },
   {
     "mfl_id": 12939,
-    "pfr_id": "SmitTe03",
-    "gsis_id": "00-0032358"
+    "gsis_id": "00-0032358",
+    "pfr_id": "SmitTe03"
   },
   {
     "mfl_id": 12940,
-    "sleeper_id": 3716,
-    "pfr_id": "BricKe00",
     "gsis_id": "00-0032628",
     "pff_id": 11142,
-    "espn_id": 2971881,
-    "yahoo_id": 29720
+    "sleeper_id": 3716,
+    "yahoo_id": 29720,
+    "pfr_id": "BricKe00"
   },
   {
     "mfl_id": 12941,
-    "sleeper_id": 2784,
     "gsis_id": "00-0031755",
     "pff_id": 9851,
-    "espn_id": 2511832,
+    "sleeper_id": 2784,
     "yahoo_id": 29022
   },
   {
     "mfl_id": 12945,
-    "sleeper_id": 2990,
     "gsis_id": "00-0031420",
     "pff_id": 9155,
-    "espn_id": 17495,
+    "sleeper_id": 2990,
     "yahoo_id": 28307
   },
   {
     "mfl_id": 12946,
-    "sleeper_id": 3623,
     "gsis_id": "00-0032484",
     "pff_id": 11014,
-    "espn_id": 2574163,
+    "sleeper_id": 3623,
     "yahoo_id": 29617
   },
   {
     "mfl_id": 12947,
-    "pfr_id": "TregBr00",
-    "gsis_id": "00-0032724"
+    "gsis_id": "00-0032724",
+    "pfr_id": "TregBr00"
   },
   {
     "mfl_id": 12948,
-    "sleeper_id": 3502,
-    "pfr_id": "OkwaRo01",
     "gsis_id": "00-0032655",
     "pff_id": 11250,
+    "sleeper_id": 3502,
+    "yahoo_id": 29867,
     "espn_id": 2980147,
-    "yahoo_id": 29867
+    "pfr_id": "OkwaRo01",
+    "espn_id_new": 2980147
   },
   {
     "mfl_id": 12949,
-    "sleeper_id": 3788,
-    "pfr_id": "McEvTa01",
     "gsis_id": "00-0032475",
     "pff_id": 11288,
-    "espn_id": 2577684,
-    "yahoo_id": 29825
+    "sleeper_id": 3788,
+    "yahoo_id": 29825,
+    "pfr_id": "McEvTa01"
   },
   {
     "mfl_id": 12950,
-    "sleeper_id": 3446,
-    "pfr_id": "HeatJo00",
     "gsis_id": "00-0032727",
     "pff_id": 11162,
-    "espn_id": 2576267,
-    "yahoo_id": 29794
+    "sleeper_id": 3446,
+    "yahoo_id": 29794,
+    "pfr_id": "HeatJo00"
   },
   {
     "mfl_id": 12951,
-    "sleeper_id": 3745,
-    "pfr_id": "GrigNi01",
     "gsis_id": "00-0032674",
     "pff_id": 11187,
-    "espn_id": 2576660,
-    "yahoo_id": 29716
+    "sleeper_id": 3745,
+    "yahoo_id": 29716,
+    "pfr_id": "GrigNi01"
   },
   {
     "mfl_id": 12952,
-    "sleeper_id": 3681,
     "gsis_id": "00-0032574",
     "pff_id": 11101,
+    "sleeper_id": 3681,
+    "yahoo_id": 29759,
     "espn_id": 2972144,
-    "yahoo_id": 29759
+    "espn_id_new": 2972144
   },
   {
     "mfl_id": 12953,
-    "sleeper_id": 3659,
     "gsis_id": "00-0032369",
     "pff_id": 11409,
-    "espn_id": 2585962,
+    "sleeper_id": 3659,
     "yahoo_id": 29696
   },
   {
     "mfl_id": 12954,
-    "pfr_id": "BowmBr00",
-    "gsis_id": "00-0032515"
+    "gsis_id": "00-0032515",
+    "pfr_id": "BowmBr00"
   },
   {
     "mfl_id": 12955,
-    "sleeper_id": 3048,
-    "pfr_id": "ManhCh00",
     "gsis_id": "00-0031484",
-    "pff_id": 10211
+    "pff_id": 10211,
+    "sleeper_id": 3048,
+    "espn_id": 2531358,
+    "pfr_id": "ManhCh00",
+    "espn_id_new": 2531358
   },
   {
     "mfl_id": 12956,
-    "sleeper_id": 3678,
     "gsis_id": "00-0032569",
     "pff_id": 11096,
+    "sleeper_id": 3678,
+    "yahoo_id": 29754,
     "espn_id": 2985659,
-    "yahoo_id": 29754
+    "espn_id_new": 2985659
   },
   {
     "mfl_id": 12957,
-    "sleeper_id": 3426,
-    "pfr_id": "CrawKe02",
     "gsis_id": "00-0032875",
     "pff_id": 11224,
-    "espn_id": 2979612,
-    "yahoo_id": 29842
+    "sleeper_id": 3426,
+    "yahoo_id": 29842,
+    "pfr_id": "CrawKe02"
   },
   {
     "mfl_id": 12958,
-    "sleeper_id": 3513,
-    "pfr_id": "NorrJa00",
     "gsis_id": "00-0032998",
     "pff_id": 11011,
-    "espn_id": 2575997,
-    "yahoo_id": 29505
+    "sleeper_id": 3513,
+    "yahoo_id": 29505,
+    "pfr_id": "NorrJa00"
   },
   {
     "mfl_id": 12960,
-    "sleeper_id": 3784,
-    "pfr_id": "VaeaDe01",
     "gsis_id": "00-0032859",
     "pff_id": 11083,
-    "espn_id": 2978355,
-    "yahoo_id": 29687
+    "sleeper_id": 3784,
+    "yahoo_id": 29687,
+    "pfr_id": "VaeaDe01"
   },
   {
     "mfl_id": 12961,
-    "sleeper_id": 1830,
     "gsis_id": "00-0030871",
     "pff_id": 9310,
-    "espn_id": 17253,
+    "sleeper_id": 1830,
     "yahoo_id": 28109
   },
   {
     "mfl_id": 12962,
-    "pfr_id": "MaggCu00",
-    "gsis_id": "00-0032361"
+    "gsis_id": "00-0032361",
+    "pfr_id": "MaggCu00"
   },
   {
     "mfl_id": 12963,
-    "pfr_id": "BarnAd01",
-    "gsis_id": "00-0032552"
+    "gsis_id": "00-0032552",
+    "pfr_id": "BarnAd01"
   },
   {
     "mfl_id": 12964,
-    "sleeper_id": 3734,
-    "pfr_id": "ScarBr00",
     "gsis_id": "00-0032734",
     "pff_id": 11169,
-    "espn_id": 2576885,
-    "yahoo_id": 29807
+    "sleeper_id": 3734,
+    "yahoo_id": 29807,
+    "pfr_id": "ScarBr00"
   },
   {
     "mfl_id": 12965,
-    "sleeper_id": 3828,
-    "pfr_id": "EvanMa00",
     "gsis_id": "00-0032922",
     "pff_id": 11343,
-    "espn_id": 3053027,
-    "yahoo_id": 29952
+    "sleeper_id": 3828,
+    "yahoo_id": 29952,
+    "pfr_id": "EvanMa00"
   },
   {
     "mfl_id": 12966,
-    "sleeper_id": 3000,
     "gsis_id": "00-0031914",
     "pff_id": 10010,
-    "espn_id": 2579622,
+    "sleeper_id": 3000,
     "yahoo_id": 28694
   },
   {
     "mfl_id": 12967,
-    "pfr_id": "AlbrBr00",
-    "gsis_id": "00-0032491"
+    "gsis_id": "00-0032491",
+    "pfr_id": "AlbrBr00"
   },
   {
     "mfl_id": 12970,
-    "sleeper_id": 3474,
-    "pfr_id": "BoddBr01",
     "gsis_id": "00-0032517",
     "pff_id": 10903,
-    "espn_id": 2970694,
-    "yahoo_id": 29507
+    "sleeper_id": 3474,
+    "yahoo_id": 29507,
+    "pfr_id": "BoddBr01"
   },
   {
     "mfl_id": 12971,
-    "sleeper_id": 3597,
-    "pfr_id": "LambDa01",
     "gsis_id": "00-0032750",
     "pff_id": 10937,
-    "espn_id": 3121601,
-    "yahoo_id": 29581
+    "sleeper_id": 3597,
+    "yahoo_id": 29581,
+    "pfr_id": "LambDa01"
   },
   {
     "mfl_id": 12972,
-    "pfr_id": "ElliDe01",
-    "gsis_id": "00-0032465"
+    "gsis_id": "00-0032465",
+    "pfr_id": "ElliDe01"
   },
   {
     "mfl_id": 12976,
-    "sleeper_id": 3838,
     "gsis_id": "00-0032933",
     "pff_id": 11353,
+    "sleeper_id": 3838,
+    "yahoo_id": 29957,
     "espn_id": 3056354,
-    "yahoo_id": 29957
+    "espn_id_new": 3056354
   },
   {
     "mfl_id": 12977,
-    "pfr_id": "LouiLa00",
-    "gsis_id": "00-0032502"
+    "gsis_id": "00-0032502",
+    "pfr_id": "LouiLa00"
   },
   {
     "mfl_id": 12979,
-    "sleeper_id": 2827,
-    "pfr_id": "WillDe04",
     "gsis_id": "00-0031795",
     "pff_id": 9891,
+    "sleeper_id": 2827,
+    "yahoo_id": 28982,
     "espn_id": 2576508,
-    "yahoo_id": 28982
+    "pfr_id": "WillDe04",
+    "espn_id_new": 2576508
   },
   {
     "mfl_id": 12981,
-    "sleeper_id": 3633,
     "gsis_id": "00-0032463",
     "pff_id": 11027,
-    "espn_id": 3134288,
+    "sleeper_id": 3633,
     "yahoo_id": 29630
   },
   {
     "mfl_id": 12985,
-    "sleeper_id": 3747,
-    "pfr_id": "LittCo01",
     "gsis_id": "00-0032677",
     "pff_id": 11190,
+    "sleeper_id": 3747,
+    "yahoo_id": 29718,
     "espn_id": 2978304,
-    "yahoo_id": 29718
+    "pfr_id": "LittCo01",
+    "espn_id_new": 2978304
   },
   {
     "mfl_id": 12987,
-    "sleeper_id": 1857,
     "gsis_id": "00-0030946",
     "pff_id": 9045,
+    "sleeper_id": 1857,
+    "yahoo_id": 27862,
     "espn_id": 17068,
-    "yahoo_id": 27862
+    "espn_id_new": 17068
   },
   {
     "mfl_id": 12988,
-    "sleeper_id": 3415,
-    "pfr_id": "JoneJo03",
     "gsis_id": "00-0032580",
     "pff_id": 11217,
+    "sleeper_id": 3415,
+    "yahoo_id": 29875,
     "espn_id": 2971027,
-    "yahoo_id": 29875
+    "pfr_id": "JoneJo03",
+    "espn_id_new": 2971027
   },
   {
     "mfl_id": 12990,
-    "sleeper_id": 3605,
-    "pfr_id": "FarlMa00",
     "gsis_id": "00-0032496",
     "pff_id": 10953,
+    "sleeper_id": 3605,
+    "yahoo_id": 29574,
     "espn_id": 2579840,
-    "yahoo_id": 29574
+    "pfr_id": "FarlMa00",
+    "espn_id_new": 2579840
   },
   {
     "mfl_id": 12996,
-    "sleeper_id": 3595,
     "gsis_id": "00-0032745",
     "pff_id": 10931,
-    "espn_id": 2586700,
+    "sleeper_id": 3595,
     "yahoo_id": 29571
   },
   {
     "mfl_id": 12997,
-    "sleeper_id": 3721,
-    "pfr_id": "HawkJo00",
     "gsis_id": "00-0032635",
     "pff_id": 11149,
-    "espn_id": 2575523,
-    "yahoo_id": 29729
+    "sleeper_id": 3721,
+    "yahoo_id": 29729,
+    "pfr_id": "HawkJo00"
   },
   {
     "mfl_id": 12998,
-    "sleeper_id": 3764,
-    "pfr_id": "AdamAn00",
     "gsis_id": "00-0032637",
     "pff_id": 11240,
+    "sleeper_id": 3764,
+    "yahoo_id": 29841,
     "espn_id": 2576599,
-    "yahoo_id": 29841
+    "pfr_id": "AdamAn00",
+    "espn_id_new": 2576599
   },
   {
     "mfl_id": 13001,
-    "sleeper_id": 3416,
-    "pfr_id": "LeBlCr01",
     "gsis_id": "00-0032581",
     "pff_id": 11218,
-    "espn_id": 2982870,
-    "yahoo_id": 29876
+    "sleeper_id": 3416,
+    "yahoo_id": 29876,
+    "pfr_id": "LeBlCr01"
   },
   {
     "mfl_id": 13011,
-    "sleeper_id": 3766,
-    "pfr_id": "HuntMi00",
     "gsis_id": "00-0032643",
     "pff_id": 11243,
-    "espn_id": 2578305,
-    "yahoo_id": 29848
+    "sleeper_id": 3766,
+    "yahoo_id": 29848,
+    "pfr_id": "HuntMi00"
   },
   {
     "mfl_id": 13013,
-    "sleeper_id": 3763,
-    "pfr_id": "HamiWo00",
     "gsis_id": "00-0032578",
     "pff_id": 11215,
-    "espn_id": 2577392,
-    "yahoo_id": 29873
+    "sleeper_id": 3763,
+    "yahoo_id": 29873,
+    "pfr_id": "HamiWo00"
   },
   {
     "mfl_id": 13015,
-    "sleeper_id": 3563,
-    "pfr_id": "LongSt00",
     "gsis_id": "00-0032470",
     "pff_id": 11285,
-    "espn_id": 2982803,
-    "yahoo_id": 29818
+    "sleeper_id": 3563,
+    "yahoo_id": 29818,
+    "pfr_id": "LongSt00"
   },
   {
     "mfl_id": 13019,
-    "sleeper_id": 3461,
-    "pfr_id": "HansRu00",
     "gsis_id": "00-0032747",
     "pff_id": 10933,
-    "espn_id": 2971435,
-    "yahoo_id": 29575
+    "sleeper_id": 3461,
+    "yahoo_id": 29575,
+    "pfr_id": "HansRu00"
   },
   {
     "mfl_id": 13021,
-    "pfr_id": "JackDo01",
-    "gsis_id": "00-0032636"
+    "gsis_id": "00-0032636",
+    "pfr_id": "JackDo01"
   },
   {
     "mfl_id": 13022,
-    "sleeper_id": 3438,
-    "pfr_id": "WillTr05",
     "gsis_id": "00-0032916",
     "pff_id": 11004,
-    "espn_id": 2979605,
-    "yahoo_id": 29534
+    "sleeper_id": 3438,
+    "yahoo_id": 29534,
+    "pfr_id": "WillTr05"
   },
   {
     "mfl_id": 13023,
-    "pfr_id": "WillFr05",
-    "gsis_id": "00-0032829"
+    "gsis_id": "00-0032829",
+    "pfr_id": "WillFr05"
   },
   {
     "mfl_id": 13026,
-    "sleeper_id": 3680,
-    "pfr_id": "OnwuPa00",
     "gsis_id": "00-0032573",
     "pff_id": 11100,
-    "espn_id": 2576761,
-    "yahoo_id": 29758
+    "sleeper_id": 3680,
+    "yahoo_id": 29758,
+    "pfr_id": "OnwuPa00"
   },
   {
     "mfl_id": 13027,
-    "sleeper_id": 3864,
-    "pfr_id": "LampJa00",
     "gsis_id": "00-0033021",
     "pff_id": 11391,
-    "espn_id": 3057850,
-    "yahoo_id": 30002
+    "sleeper_id": 3864,
+    "yahoo_id": 30002,
+    "pfr_id": "LampJa00"
   },
   {
     "mfl_id": 13043,
-    "sleeper_id": 3537,
-    "pfr_id": "LandCh00",
     "gsis_id": "00-0032905",
     "pff_id": 10992,
-    "espn_id": 2574558,
-    "yahoo_id": 29522
+    "sleeper_id": 3537,
+    "yahoo_id": 29522,
+    "pfr_id": "LandCh00"
   },
   {
     "mfl_id": 13045,
-    "sleeper_id": 3417,
-    "pfr_id": "SmitTe04",
     "gsis_id": "00-0032820",
     "pff_id": 11181,
-    "espn_id": 2576809,
-    "yahoo_id": 29885
+    "sleeper_id": 3417,
+    "yahoo_id": 29885,
+    "pfr_id": "SmitTe04"
   },
   {
     "mfl_id": 13052,
-    "sleeper_id": 3761,
     "gsis_id": "00-0032617",
     "pff_id": 11210,
-    "espn_id": 2576665,
+    "sleeper_id": 3761,
     "yahoo_id": 29835
   },
   {
     "mfl_id": 13056,
-    "sleeper_id": 3008,
     "gsis_id": "00-0031876",
-    "espn_id": 2576240,
+    "sleeper_id": 3008,
     "yahoo_id": 28738
   },
   {
     "mfl_id": 13057,
-    "sleeper_id": 3688,
     "gsis_id": "00-0032540",
     "pff_id": 11104,
-    "espn_id": 2972283,
+    "sleeper_id": 3688,
     "yahoo_id": 29700
   },
   {
     "mfl_id": 13065,
-    "sleeper_id": 2755,
-    "pfr_id": "TomlEr01",
     "gsis_id": "00-0031690",
     "pff_id": 9786,
+    "sleeper_id": 2755,
+    "espn_id": 2511973,
+    "pfr_id": "TomlEr01",
     "ras_id": 11903,
-    "otc_id": 4150
+    "otc_id": 4150,
+    "espn_id_new": 2511973
   },
   {
     "mfl_id": 13066,
-    "sleeper_id": 3634,
-    "pfr_id": "RaymKa00",
     "gsis_id": "00-0032464",
     "pff_id": 11028,
+    "sleeper_id": 3634,
+    "espn_id": 2973405,
+    "pfr_id": "RaymKa00",
     "ras_id": 12738,
-    "otc_id": 5127
+    "otc_id": 5127,
+    "espn_id_new": 2973405
   },
   {
     "mfl_id": 13067,
-    "sleeper_id": 3824,
-    "pfr_id": "ElliAl01",
     "gsis_id": "00-0032864",
     "pff_id": 11326,
-    "espn_id": 2577731,
-    "yahoo_id": 29944
+    "sleeper_id": 3824,
+    "yahoo_id": 29944,
+    "pfr_id": "ElliAl01"
   },
   {
     "mfl_id": 13069,
-    "sleeper_id": 3487,
     "gsis_id": "00-0032676",
     "pff_id": 11189,
-    "espn_id": 3961462,
+    "sleeper_id": 3487,
     "yahoo_id": 29724
   },
   {
     "mfl_id": 13071,
-    "sleeper_id": 3642,
     "gsis_id": "00-0032729",
     "pff_id": 11164,
-    "espn_id": 3051940,
+    "sleeper_id": 3642,
     "yahoo_id": 29797
   },
   {
     "mfl_id": 13072,
-    "sleeper_id": 3867,
-    "pfr_id": "JackBr04",
     "gsis_id": "00-0033024",
     "pff_id": 11394,
-    "espn_id": 2577642,
-    "yahoo_id": 29999
+    "sleeper_id": 3867,
+    "yahoo_id": 29999,
+    "pfr_id": "JackBr04"
   },
   {
     "mfl_id": 13075,
-    "sleeper_id": 3589,
     "gsis_id": "00-0032353",
     "pff_id": 10914,
-    "espn_id": 2576895,
+    "sleeper_id": 3589,
     "yahoo_id": 29607
   },
   {
     "mfl_id": 13078,
-    "pfr_id": "ReedTr00",
-    "gsis_id": "00-0032290"
+    "gsis_id": "00-0032290",
+    "pfr_id": "ReedTr00"
   },
   {
     "mfl_id": 13082,
-    "sleeper_id": 3643,
-    "pfr_id": "MiddDo01",
     "gsis_id": "00-0032697",
     "pff_id": 11262,
-    "espn_id": 2567725,
-    "yahoo_id": 29798
+    "sleeper_id": 3643,
+    "yahoo_id": 29798,
+    "pfr_id": "MiddDo01"
   },
   {
     "mfl_id": 13083,
-    "sleeper_id": 3886,
     "gsis_id": "00-0033070",
     "pff_id": 11418,
-    "espn_id": 3116598,
+    "sleeper_id": 3886,
     "yahoo_id": 30014
   },
   {
     "mfl_id": 13085,
-    "sleeper_id": 3743,
     "gsis_id": "00-0032671",
     "pff_id": 11184,
+    "sleeper_id": 3743,
+    "yahoo_id": 29714,
     "espn_id": 3059620,
-    "yahoo_id": 29714
+    "espn_id_new": 3059620
   },
   {
     "mfl_id": 13086,
-    "pfr_id": "AbdeMe00",
-    "gsis_id": "00-0032860"
+    "gsis_id": "00-0032860",
+    "pfr_id": "AbdeMe00"
   },
   {
     "mfl_id": 13087,
-    "sleeper_id": 3667,
-    "pfr_id": "NeasSh00",
     "gsis_id": "00-0032592",
     "pff_id": 11050,
-    "espn_id": 2982866,
-    "yahoo_id": 29653
+    "sleeper_id": 3667,
+    "yahoo_id": 29653,
+    "pfr_id": "NeasSh00"
   },
   {
     "mfl_id": 13100,
-    "sleeper_id": 3479,
     "gsis_id": "00-0032871",
     "pff_id": 11332,
-    "espn_id": 2577278,
+    "sleeper_id": 3479,
     "yahoo_id": 29950
   },
   {
     "mfl_id": 13108,
-    "sleeper_id": 3664,
-    "pfr_id": "McKiJ.00",
     "gsis_id": "00-0032602",
     "pff_id": 11047,
+    "sleeper_id": 3664,
+    "espn_id": 2572861,
+    "pfr_id": "McKiJ.00",
     "ras_id": 12610,
-    "otc_id": 5150
+    "otc_id": 5150,
+    "espn_id_new": 2572861
   },
   {
     "mfl_id": 13110,
-    "sleeper_id": 3729,
     "gsis_id": "00-0032652",
     "pff_id": 11520,
-    "espn_id": 2969976,
+    "sleeper_id": 3729,
     "yahoo_id": 29749
   },
   {
     "mfl_id": 13124,
-    "sleeper_id": 4574,
-    "pfr_id": "RushCo00",
     "gsis_id": "00-0033662",
     "pff_id": 12324,
+    "sleeper_id": 4574,
+    "yahoo_id": 30788,
     "espn_id": 2972515,
-    "yahoo_id": 30788
+    "pfr_id": "RushCo00",
+    "espn_id_new": 2972515
   },
   {
     "mfl_id": 13136,
-    "sleeper_id": 4651,
-    "pfr_id": "ClemCo00",
     "gsis_id": "00-0033725",
     "pff_id": 12253,
+    "sleeper_id": 4651,
+    "espn_id": 3045260,
+    "pfr_id": "ClemCo00",
     "ras_id": 13509,
-    "otc_id": 6154
+    "otc_id": 6154,
+    "espn_id_new": 3045260
   },
   {
     "mfl_id": 13145,
-    "pfr_id": "SmitDe06",
-    "gsis_id": "00-0033413"
+    "gsis_id": "00-0033413",
+    "pfr_id": "SmitDe06"
   },
   {
     "mfl_id": 13148,
-    "sleeper_id": 4718,
-    "pfr_id": "OgunDa00",
     "gsis_id": "00-0033854",
     "pff_id": 12329,
+    "sleeper_id": 4718,
+    "espn_id": 2983509,
+    "pfr_id": "OgunDa00",
     "ras_id": 13593,
-    "otc_id": 6299
+    "otc_id": 6299,
+    "espn_id_new": 2983509
   },
   {
     "mfl_id": 13150,
-    "sleeper_id": 4635,
-    "pfr_id": "DaviJu00",
     "gsis_id": "00-0033760",
     "pff_id": 12202,
-    "espn_id": 3043216,
-    "yahoo_id": 30370
+    "sleeper_id": 4635,
+    "yahoo_id": 30370,
+    "pfr_id": "DaviJu00"
   },
   {
     "mfl_id": 13161,
-    "sleeper_id": 4670,
     "gsis_id": "00-0033706",
     "pff_id": 12044,
-    "espn_id": 3122839,
+    "sleeper_id": 4670,
     "yahoo_id": 30432
   },
   {
     "mfl_id": 13179,
-    "sleeper_id": 4489,
     "gsis_id": "00-0033474",
     "pff_id": 12163,
-    "espn_id": 2980460,
+    "sleeper_id": 4489,
     "yahoo_id": 30679
   },
   {
     "mfl_id": 13180,
-    "sleeper_id": 4324,
     "gsis_id": "00-0033259",
     "pff_id": 12123,
-    "espn_id": 2971233,
+    "sleeper_id": 4324,
     "yahoo_id": 30524
   },
   {
     "mfl_id": 13181,
-    "sleeper_id": 4644,
-    "pfr_id": "RudoTr00",
     "gsis_id": "00-0033717",
     "pff_id": 47997,
-    "espn_id": 3122935,
-    "yahoo_id": 30737
+    "sleeper_id": 4644,
+    "yahoo_id": 30737,
+    "pfr_id": "RudoTr00"
   },
   {
     "mfl_id": 13184,
-    "sleeper_id": 4520,
     "gsis_id": "00-0033517",
     "pff_id": 12219,
-    "espn_id": 2976557,
+    "sleeper_id": 4520,
     "yahoo_id": 30410
   },
   {
     "mfl_id": 13239,
-    "sleeper_id": 3803,
-    "pfr_id": "PennEl00",
     "gsis_id": "00-0032813",
     "pff_id": 11300,
+    "sleeper_id": 3803,
+    "pfr_id": "PennEl00",
     "ras_id": 12565,
     "otc_id": 5530
   },
   {
     "mfl_id": 13241,
-    "sleeper_id": 3827,
     "gsis_id": "00-0032870",
     "pff_id": 11331,
-    "espn_id": 3068939,
+    "sleeper_id": 3827,
     "yahoo_id": 29949
   },
   {
     "mfl_id": 13246,
-    "sleeper_id": 4054,
-    "pfr_id": "AlieMo00",
     "gsis_id": "00-0033217",
     "pff_id": 12078,
+    "sleeper_id": 4054,
+    "espn_id": 2998565,
+    "pfr_id": "AlieMo00",
     "ras_id": 14606,
-    "otc_id": 5618
+    "otc_id": 5618,
+    "espn_id_new": 2998565
   },
   {
     "mfl_id": 13247,
-    "sleeper_id": 1774,
     "gsis_id": "00-0030197",
     "pff_id": 8512,
-    "espn_id": 16475,
+    "sleeper_id": 1774,
     "yahoo_id": 27348
   },
   {
     "mfl_id": 13278,
-    "sleeper_id": 4141,
     "gsis_id": "00-0033931",
     "pff_id": 11849,
-    "espn_id": 3045214,
+    "sleeper_id": 4141,
     "yahoo_id": 30208
   },
   {
     "mfl_id": 13318,
-    "pfr_id": "DonaDy00",
-    "gsis_id": "00-0033961"
+    "gsis_id": "00-0033961",
+    "pfr_id": "DonaDy00"
   },
   {
     "mfl_id": 13323,
-    "sleeper_id": 4276,
     "gsis_id": "00-0033861",
     "pff_id": 11942,
-    "espn_id": 3056913,
+    "sleeper_id": 4276,
     "yahoo_id": 30300
   },
   {
     "mfl_id": 13367,
-    "sleeper_id": 4416,
-    "pfr_id": "CarrAu00",
     "gsis_id": "00-0033382",
     "pff_id": 12215,
-    "espn_id": 2974339,
-    "yahoo_id": 30656
+    "sleeper_id": 4416,
+    "yahoo_id": 30656,
+    "pfr_id": "CarrAu00"
   },
   {
     "mfl_id": 13369,
-    "sleeper_id": 4362,
-    "pfr_id": "CartCe00",
     "gsis_id": "00-0033338",
-    "pff_id": 47149
+    "pff_id": 47149,
+    "sleeper_id": 4362,
+    "pfr_id": "CartCe00"
   },
   {
     "mfl_id": 13370,
-    "sleeper_id": 4526,
-    "pfr_id": "HogaKr00",
     "gsis_id": "00-0033604",
     "pff_id": 12014,
-    "espn_id": 4198679,
-    "yahoo_id": 30487
+    "sleeper_id": 4526,
+    "yahoo_id": 30487,
+    "pfr_id": "HogaKr00"
   },
   {
     "mfl_id": 13371,
-    "sleeper_id": 4445,
     "gsis_id": "00-0033441",
     "pff_id": 12249,
-    "espn_id": 2980061,
+    "sleeper_id": 4445,
     "yahoo_id": 30629
   },
   {
     "mfl_id": 13372,
-    "sleeper_id": 4551,
-    "pfr_id": "GentTa00",
     "gsis_id": "00-0033633",
     "pff_id": 12170,
-    "espn_id": 3043841,
-    "yahoo_id": 30720
+    "sleeper_id": 4551,
+    "yahoo_id": 30720,
+    "pfr_id": "GentTa00"
   },
   {
     "mfl_id": 13375,
-    "sleeper_id": 4453,
-    "pfr_id": "BoldVi00",
     "gsis_id": "00-0033306",
     "pff_id": 12269,
-    "espn_id": 3056476,
-    "yahoo_id": 30550
+    "sleeper_id": 4453,
+    "yahoo_id": 30550,
+    "pfr_id": "BoldVi00"
   },
   {
     "mfl_id": 13377,
-    "sleeper_id": 4351,
-    "pfr_id": "PatrTi00",
     "gsis_id": "00-0033375",
     "pff_id": 12087,
+    "sleeper_id": 4351,
+    "pfr_id": "PatrTi00",
     "ras_id": 15006,
     "otc_id": 6035
   },
   {
     "mfl_id": 13378,
-    "sleeper_id": 4455,
-    "pfr_id": "BreiMa00",
     "gsis_id": "00-0033308",
     "pff_id": 12271,
+    "sleeper_id": 4455,
+    "espn_id": 3049916,
+    "pfr_id": "BreiMa00",
     "ras_id": 14544,
-    "otc_id": 5996
+    "otc_id": 5996,
+    "espn_id_new": 3049916
   },
   {
     "mfl_id": 13382,
-    "sleeper_id": 4531,
-    "pfr_id": "SealRi00",
     "gsis_id": "00-0033611",
     "pff_id": 12020,
+    "sleeper_id": 4531,
+    "pfr_id": "SealRi00",
     "ras_id": 14780,
     "otc_id": 5938
   },
   {
     "mfl_id": 13383,
-    "sleeper_id": 4294,
     "gsis_id": "00-0033222",
     "pff_id": 47970,
-    "espn_id": 2977689,
+    "sleeper_id": 4294,
     "yahoo_id": 30450
   },
   {
     "mfl_id": 13384,
-    "sleeper_id": 4349,
-    "pfr_id": "MizzTa00",
     "gsis_id": "00-0033373",
     "pff_id": 45675,
-    "espn_id": 3048680,
-    "yahoo_id": 900125
+    "sleeper_id": 4349,
+    "yahoo_id": 900125,
+    "pfr_id": "MizzTa00"
   },
   {
     "mfl_id": 13385,
-    "sleeper_id": 4326,
     "gsis_id": "00-0033261",
     "pff_id": 12125,
-    "espn_id": 3039720,
+    "sleeper_id": 4326,
     "yahoo_id": 30526
   },
   {
     "mfl_id": 13387,
-    "sleeper_id": 3445,
-    "pfr_id": "JohnMa07",
     "gsis_id": "00-0032980",
     "pff_id": 11074,
+    "sleeper_id": 3445,
+    "pfr_id": "JohnMa07",
     "otc_id": 5178
   },
   {
     "mfl_id": 13388,
-    "sleeper_id": 4426,
-    "pfr_id": "LangHa00",
     "gsis_id": "00-0033392",
     "pff_id": 50118,
-    "espn_id": 2570996,
-    "yahoo_id": 30666
+    "sleeper_id": 4426,
+    "yahoo_id": 30666,
+    "pfr_id": "LangHa00"
   },
   {
     "mfl_id": 13389,
-    "sleeper_id": 4588,
     "gsis_id": "00-0033672",
     "pff_id": 12180,
-    "espn_id": 2972092,
+    "sleeper_id": 4588,
     "yahoo_id": 30822
   },
   {
     "mfl_id": 13390,
-    "sleeper_id": 4750,
-    "pfr_id": "LenoLa00",
     "gsis_id": "00-0033992",
     "pff_id": 31892,
-    "espn_id": 3049249,
-    "yahoo_id": 30899
+    "sleeper_id": 4750,
+    "yahoo_id": 30899,
+    "pfr_id": "LenoLa00"
   },
   {
     "mfl_id": 13391,
-    "sleeper_id": 4421,
-    "pfr_id": "HollJa03",
     "gsis_id": "00-0033387",
     "pff_id": 12051,
+    "sleeper_id": 4421,
+    "pfr_id": "HollJa03",
     "ras_id": 13986,
     "otc_id": 6126
   },
   {
     "mfl_id": 13392,
-    "sleeper_id": 2613,
-    "pfr_id": "AdamTy00",
     "gsis_id": "00-0032094",
     "pff_id": 10140,
-    "espn_id": 3895228,
-    "yahoo_id": 29111
+    "sleeper_id": 2613,
+    "yahoo_id": 29111,
+    "pfr_id": "AdamTy00"
   },
   {
     "mfl_id": 13396,
-    "sleeper_id": 4323,
-    "pfr_id": "DaniDa02",
     "gsis_id": "00-0033258",
     "pff_id": 12122,
+    "sleeper_id": 4323,
+    "pfr_id": "DaniDa02",
     "ras_id": 13610,
     "otc_id": 5978
   },
   {
     "mfl_id": 13397,
-    "sleeper_id": 4564,
-    "pfr_id": "NacuKa00",
     "gsis_id": "00-0033649",
     "pff_id": 12102,
-    "espn_id": 3053804,
-    "yahoo_id": 30548
+    "sleeper_id": 4564,
+    "yahoo_id": 30548,
+    "pfr_id": "NacuKa00"
   },
   {
     "mfl_id": 13398,
-    "sleeper_id": 4355,
     "gsis_id": "00-0033379",
     "pff_id": 12144,
-    "espn_id": 3915403,
+    "sleeper_id": 4355,
     "yahoo_id": 30510
   },
   {
     "mfl_id": 13400,
-    "pfr_id": "JeroLo00",
-    "gsis_id": "00-0033316"
+    "gsis_id": "00-0033316",
+    "pfr_id": "JeroLo00"
   },
   {
     "mfl_id": 13402,
-    "sleeper_id": 4311,
-    "pfr_id": "GracJe00",
     "gsis_id": "00-0033242",
     "pff_id": 12081,
-    "espn_id": 3051924,
-    "yahoo_id": 30499
+    "sleeper_id": 4311,
+    "yahoo_id": 30499,
+    "pfr_id": "GracJe00"
   },
   {
     "mfl_id": 13403,
-    "sleeper_id": 4666,
     "gsis_id": "00-0033702",
+    "sleeper_id": 4666,
+    "yahoo_id": 30426,
     "espn_id": 3049899,
-    "yahoo_id": 30426
+    "espn_id_new": 3049899
   },
   {
     "mfl_id": 13404,
-    "sleeper_id": 4663,
-    "pfr_id": "EkelAu00",
     "gsis_id": "00-0033699",
     "pff_id": 12164,
+    "sleeper_id": 4663,
+    "espn_id": 3068267,
+    "pfr_id": "EkelAu00",
     "ras_id": 13238,
-    "otc_id": 5865
+    "otc_id": 5865,
+    "espn_id_new": 3068267
   },
   {
     "mfl_id": 13406,
-    "sleeper_id": 4342,
-    "pfr_id": "AdebQu00",
     "gsis_id": "00-0033366",
     "pff_id": 12085,
-    "espn_id": 3051869,
-    "yahoo_id": 30512
+    "sleeper_id": 4342,
+    "yahoo_id": 30512,
+    "pfr_id": "AdebQu00"
   },
   {
     "mfl_id": 13407,
-    "sleeper_id": 4439,
     "gsis_id": "00-0033435",
     "pff_id": 39398,
-    "espn_id": 3048663,
+    "sleeper_id": 4439,
     "yahoo_id": 30623
   },
   {
     "mfl_id": 13408,
-    "pfr_id": "ClarMi00",
-    "gsis_id": "00-0033352"
+    "gsis_id": "00-0033352",
+    "pfr_id": "ClarMi00"
   },
   {
     "mfl_id": 13410,
-    "sleeper_id": 3637,
     "gsis_id": "00-0032480",
     "pff_id": 11033,
-    "espn_id": 2576040,
+    "sleeper_id": 3637,
     "yahoo_id": 29636
   },
   {
     "mfl_id": 13411,
-    "sleeper_id": 4678,
-    "pfr_id": "SwooTy00",
     "gsis_id": "00-0033742",
     "pff_id": 12267,
-    "espn_id": 3046705,
-    "yahoo_id": 30763
+    "sleeper_id": 4678,
+    "yahoo_id": 30763,
+    "pfr_id": "SwooTy00"
   },
   {
     "mfl_id": 13412,
-    "sleeper_id": 4622,
-    "pfr_id": "ColeKe00",
     "gsis_id": "00-0033681",
     "pff_id": 51593,
+    "sleeper_id": 4622,
+    "espn_id": 3071572,
+    "pfr_id": "ColeKe00",
     "ras_id": 14323,
-    "otc_id": 6139
+    "otc_id": 6139,
+    "espn_id_new": 3071572
   },
   {
     "mfl_id": 13414,
-    "sleeper_id": 3546,
     "gsis_id": "00-0032521",
     "pff_id": 10898,
+    "sleeper_id": 3546,
+    "yahoo_id": 29510,
     "espn_id": 2980383,
-    "yahoo_id": 29510
+    "espn_id_new": 2980383
   },
   {
     "mfl_id": 13416,
-    "sleeper_id": 4335,
-    "pfr_id": "WalkPh00",
     "gsis_id": "00-0033275",
     "pff_id": 12134,
+    "sleeper_id": 4335,
+    "espn_id": 3051308,
+    "pfr_id": "WalkPh00",
     "ras_id": 14720,
-    "otc_id": 5993
+    "otc_id": 5993,
+    "espn_id_new": 3051308
   },
   {
     "mfl_id": 13417,
-    "sleeper_id": 4511,
-    "pfr_id": "LewiLa01",
     "gsis_id": "00-0033477",
     "pff_id": 12250,
-    "espn_id": 2972232,
-    "yahoo_id": 30700
+    "sleeper_id": 4511,
+    "yahoo_id": 30700,
+    "pfr_id": "LewiLa01"
   },
   {
     "mfl_id": 13418,
-    "sleeper_id": 4454,
-    "pfr_id": "BourKe00",
     "gsis_id": "00-0033307",
     "pff_id": 12270,
+    "sleeper_id": 4454,
+    "espn_id": 3045523,
+    "pfr_id": "BourKe00",
     "ras_id": 14345,
-    "otc_id": 5995
+    "otc_id": 5995,
+    "espn_id_new": 3045523
   },
   {
     "mfl_id": 13419,
-    "sleeper_id": 2863,
     "gsis_id": "00-0031738",
     "pff_id": 9834,
-    "espn_id": 2574756,
+    "sleeper_id": 2863,
     "yahoo_id": 28870
   },
   {
     "mfl_id": 13420,
-    "sleeper_id": 4614,
     "gsis_id": "00-0033773",
     "pff_id": 48033,
-    "espn_id": 2988624,
+    "sleeper_id": 4614,
     "yahoo_id": 30808
   },
   {
     "mfl_id": 13421,
-    "sleeper_id": 4541,
     "gsis_id": "00-0033620",
     "pff_id": 12150,
-    "espn_id": 2974328,
+    "sleeper_id": 4541,
     "yahoo_id": 30598
   },
   {
     "mfl_id": 13422,
-    "sleeper_id": 3440,
     "gsis_id": "00-0032658",
     "pff_id": 11253,
-    "espn_id": 2575214,
+    "sleeper_id": 3440,
     "yahoo_id": 29870
   },
   {
     "mfl_id": 13423,
-    "sleeper_id": 4606,
-    "pfr_id": "ColeDy00",
     "gsis_id": "00-0033765",
     "pff_id": 24304,
+    "sleeper_id": 4606,
+    "yahoo_id": 30799,
     "espn_id": 2986109,
-    "yahoo_id": 30799
+    "pfr_id": "ColeDy00",
+    "espn_id_new": 2986109
   },
   {
     "mfl_id": 13424,
-    "sleeper_id": 4381,
-    "pfr_id": "HillTa00",
     "gsis_id": "00-0033357",
     "pff_id": 12112,
+    "sleeper_id": 4381,
+    "espn_id": 2468609,
+    "pfr_id": "HillTa00",
     "ras_id": 14969,
-    "otc_id": 6047
+    "otc_id": 6047,
+    "espn_id_new": 2468609
   },
   {
     "mfl_id": 13426,
-    "sleeper_id": 4449,
-    "pfr_id": "MorrNi00",
     "gsis_id": "00-0033445",
     "pff_id": 51674,
+    "sleeper_id": 4449,
+    "yahoo_id": 30633,
     "espn_id": 4232830,
-    "yahoo_id": 30633
+    "pfr_id": "MorrNi00",
+    "espn_id_new": 4232830
   },
   {
     "mfl_id": 13427,
-    "sleeper_id": 4602,
-    "pfr_id": "TonyRo00",
     "gsis_id": "00-0033757",
     "pff_id": 12193,
+    "sleeper_id": 4602,
+    "espn_id": 2975674,
+    "pfr_id": "TonyRo00",
     "ras_id": 14797,
-    "otc_id": 6223
+    "otc_id": 6223,
+    "espn_id_new": 2975674
   },
   {
     "mfl_id": 13430,
-    "sleeper_id": 4390,
     "gsis_id": "00-0033400",
     "pff_id": 12212,
+    "sleeper_id": 4390,
+    "yahoo_id": 30641,
     "espn_id": 3043237,
-    "yahoo_id": 30641
+    "espn_id_new": 3043237
   },
   {
     "mfl_id": 13431,
-    "sleeper_id": 4331,
     "gsis_id": "00-0033269",
+    "sleeper_id": 4331,
+    "yahoo_id": 30534,
     "espn_id": 3914922,
-    "yahoo_id": 30534
+    "espn_id_new": 3914922
   },
   {
     "mfl_id": 13434,
-    "sleeper_id": 3526,
     "gsis_id": "00-0032667",
     "pff_id": 11341,
+    "sleeper_id": 3526,
+    "yahoo_id": 29920,
     "espn_id": 2574891,
-    "yahoo_id": 29920
+    "espn_id_new": 2574891
   },
   {
     "mfl_id": 13435,
-    "sleeper_id": 3676,
     "gsis_id": "00-0032566",
     "pff_id": 11093,
-    "espn_id": 2982880,
+    "sleeper_id": 3676,
     "yahoo_id": 29751
   },
   {
     "mfl_id": 13436,
-    "sleeper_id": 4681,
     "gsis_id": "00-0033815",
     "pff_id": 48079,
-    "espn_id": 3043134,
+    "sleeper_id": 4681,
     "yahoo_id": 30827
   },
   {
     "mfl_id": 13437,
-    "sleeper_id": 4596,
-    "pfr_id": "GreeTi00",
     "gsis_id": "00-0033748",
     "pff_id": 12185,
+    "sleeper_id": 4596,
+    "pfr_id": "GreeTi00",
     "ras_id": 15010,
     "otc_id": 6214
   },
   {
     "mfl_id": 13438,
-    "sleeper_id": 4660,
-    "pfr_id": "CulkSe00",
     "gsis_id": "00-0033696",
     "pff_id": 12037,
-    "espn_id": 2971426,
-    "yahoo_id": 30420
+    "sleeper_id": 4660,
+    "yahoo_id": 30420,
+    "pfr_id": "CulkSe00"
   },
   {
     "mfl_id": 13439,
-    "sleeper_id": 4304,
     "gsis_id": "00-0033234",
     "pff_id": 12031,
-    "espn_id": 3042361,
+    "sleeper_id": 4304,
     "yahoo_id": 30462
   },
   {
     "mfl_id": 13440,
-    "sleeper_id": 4359,
     "gsis_id": "00-0033410",
     "pff_id": 50361,
-    "espn_id": 3052883,
+    "sleeper_id": 4359,
     "yahoo_id": 30381
   },
   {
     "mfl_id": 13441,
-    "sleeper_id": 4684,
-    "pfr_id": "HillJa01",
     "gsis_id": "00-0033826",
     "pff_id": 37997,
-    "espn_id": 3057517,
-    "yahoo_id": 30846
+    "sleeper_id": 4684,
+    "yahoo_id": 30846,
+    "pfr_id": "HillJa01"
   },
   {
     "mfl_id": 13442,
-    "sleeper_id": 4400,
-    "pfr_id": "SmitMa04",
     "gsis_id": "00-0033415",
     "pff_id": 51190,
-    "espn_id": 3054859,
-    "yahoo_id": 30652
+    "sleeper_id": 4400,
+    "yahoo_id": 30652,
+    "pfr_id": "SmitMa04"
   },
   {
     "mfl_id": 13443,
-    "sleeper_id": 4689,
-    "pfr_id": "CartJa02",
     "gsis_id": "00-0033819",
     "pff_id": 49282,
-    "espn_id": 3051925,
-    "yahoo_id": 30848
+    "sleeper_id": 4689,
+    "yahoo_id": 30848,
+    "pfr_id": "CartJa02"
   },
   {
     "mfl_id": 13444,
-    "sleeper_id": 4643,
-    "pfr_id": "MunsCa00",
     "gsis_id": "00-0033716",
     "pff_id": 12236,
-    "espn_id": 3047530,
-    "yahoo_id": 30736
+    "sleeper_id": 4643,
+    "yahoo_id": 30736,
+    "pfr_id": "MunsCa00"
   },
   {
     "mfl_id": 13445,
-    "sleeper_id": 4468,
-    "pfr_id": "AuclAn00",
     "gsis_id": "00-0033421",
-    "pff_id": 24606
+    "pff_id": 24606,
+    "sleeper_id": 4468,
+    "pfr_id": "AuclAn00"
   },
   {
     "mfl_id": 13446,
-    "sleeper_id": 4368,
-    "pfr_id": "NickHa02",
     "gsis_id": "00-0033344",
     "pff_id": 50712,
-    "espn_id": 2978211,
-    "yahoo_id": 30583
+    "sleeper_id": 4368,
+    "yahoo_id": 30583,
+    "pfr_id": "NickHa02"
   },
   {
     "mfl_id": 13447,
-    "sleeper_id": 4413,
-    "pfr_id": "WilsEr00",
     "gsis_id": "00-0033336",
     "pff_id": 38587,
+    "sleeper_id": 4413,
+    "yahoo_id": 30448,
     "espn_id": 3056916,
-    "yahoo_id": 30448
+    "pfr_id": "WilsEr00",
+    "espn_id_new": 3056916
   },
   {
     "mfl_id": 13448,
-    "sleeper_id": 4415,
     "gsis_id": "00-0033381",
     "pff_id": 12214,
+    "sleeper_id": 4415,
+    "yahoo_id": 30655,
     "espn_id": 2972342,
-    "yahoo_id": 30655
+    "espn_id_new": 2972342
   },
   {
     "mfl_id": 13449,
-    "sleeper_id": 4720,
-    "pfr_id": "HatfDo00",
     "gsis_id": "00-0033845",
     "pff_id": 12338,
-    "espn_id": 3052502,
-    "yahoo_id": 30865
+    "sleeper_id": 4720,
+    "yahoo_id": 30865,
+    "pfr_id": "HatfDo00"
   },
   {
     "mfl_id": 13450,
-    "sleeper_id": 3427,
     "gsis_id": "00-0033001",
     "pff_id": 11226,
-    "espn_id": 2980380,
+    "sleeper_id": 3427,
     "yahoo_id": 29845
   },
   {
     "mfl_id": 13452,
-    "sleeper_id": 4696,
-    "pfr_id": "EdmuTr00",
     "gsis_id": "00-0033838",
     "pff_id": 38329,
-    "espn_id": 2970090,
-    "yahoo_id": 30850
+    "sleeper_id": 4696,
+    "yahoo_id": 30850,
+    "pfr_id": "EdmuTr00"
   },
   {
     "mfl_id": 13453,
-    "sleeper_id": 3728,
     "gsis_id": "00-0032649",
     "pff_id": 11157,
-    "espn_id": 3040661,
+    "sleeper_id": 3728,
     "yahoo_id": 29747
   },
   {
     "mfl_id": 13454,
-    "sleeper_id": 4345,
-    "pfr_id": "BradBa00",
     "gsis_id": "00-0033368",
     "pff_id": 12083,
-    "espn_id": 2970256,
-    "yahoo_id": 30514
+    "sleeper_id": 4345,
+    "yahoo_id": 30514,
+    "pfr_id": "BradBa00"
   },
   {
     "mfl_id": 13455,
+    "gsis_id": "00-0033376",
+    "espn_id": 2975417,
     "pfr_id": "RicaPa00",
-    "gsis_id": "00-0033376"
+    "espn_id_new": 2975417
   },
   {
     "mfl_id": 13456,
-    "sleeper_id": 4476,
-    "pfr_id": "MabiGr00",
     "gsis_id": "00-0033430",
     "pff_id": 12068,
-    "espn_id": 2979515,
-    "yahoo_id": 30477
+    "sleeper_id": 4476,
+    "yahoo_id": 30477,
+    "pfr_id": "MabiGr00"
   },
   {
     "mfl_id": 13457,
-    "sleeper_id": 4363,
-    "pfr_id": "CoxxDe00",
     "gsis_id": "00-0033339",
     "pff_id": 51176,
-    "espn_id": 2979535,
-    "yahoo_id": 30578
+    "sleeper_id": 4363,
+    "yahoo_id": 30578,
+    "pfr_id": "CoxxDe00"
   },
   {
     "mfl_id": 13459,
-    "sleeper_id": 4603,
-    "pfr_id": "ValoJe00",
     "gsis_id": "00-0033758",
     "pff_id": 12194,
-    "espn_id": 2976151,
-    "yahoo_id": 30778
+    "sleeper_id": 4603,
+    "yahoo_id": 30778,
+    "pfr_id": "ValoJe00"
   },
   {
     "mfl_id": 13460,
-    "sleeper_id": 4604,
-    "pfr_id": "AnkoEl00",
     "gsis_id": "00-0033598",
     "pff_id": 48856,
-    "espn_id": 3008150,
-    "yahoo_id": 30792
+    "sleeper_id": 4604,
+    "yahoo_id": 30792,
+    "pfr_id": "AnkoEl00"
   },
   {
     "mfl_id": 13461,
-    "sleeper_id": 4352,
-    "pfr_id": "PaynDo00",
     "gsis_id": "00-0033420",
     "pff_id": 51589,
-    "espn_id": 3048402,
-    "yahoo_id": 30622
+    "sleeper_id": 4352,
+    "yahoo_id": 30622,
+    "pfr_id": "PaynDo00"
   },
   {
     "mfl_id": 13462,
-    "sleeper_id": 4668,
-    "pfr_id": "OnwuJa00",
     "gsis_id": "00-0033704",
     "pff_id": 12039,
-    "espn_id": 3052889,
-    "yahoo_id": 30428
+    "sleeper_id": 4668,
+    "yahoo_id": 30428,
+    "pfr_id": "OnwuJa00"
   },
   {
     "mfl_id": 13463,
-    "sleeper_id": 4389,
-    "pfr_id": "AlleCh02",
     "gsis_id": "00-0033399",
     "pff_id": 12211,
-    "espn_id": 2975680,
-    "yahoo_id": 30640
+    "sleeper_id": 4389,
+    "yahoo_id": 30640,
+    "pfr_id": "AlleCh02"
   },
   {
     "mfl_id": 13465,
-    "sleeper_id": 4558,
-    "pfr_id": "BellB.00",
     "gsis_id": "00-0033642",
     "pff_id": 12097,
-    "espn_id": 2970622,
-    "yahoo_id": 30539
+    "sleeper_id": 4558,
+    "yahoo_id": 30539,
+    "pfr_id": "BellB.00"
   },
   {
     "mfl_id": 13466,
-    "sleeper_id": 3444,
     "gsis_id": "00-0032627",
     "pff_id": 11202,
-    "espn_id": 2970181,
+    "sleeper_id": 3444,
     "yahoo_id": 29822
   },
   {
     "mfl_id": 13468,
-    "sleeper_id": 3714,
     "gsis_id": "00-0032560",
     "pff_id": 11137,
-    "espn_id": 2579163,
+    "sleeper_id": 3714,
     "yahoo_id": 29781
   },
   {
     "mfl_id": 13470,
-    "sleeper_id": 4427,
-    "pfr_id": "MoorKe03",
     "gsis_id": "00-0033393",
     "pff_id": 51596,
+    "sleeper_id": 4427,
+    "yahoo_id": 30669,
     "espn_id": 4218312,
-    "yahoo_id": 30669
+    "pfr_id": "MoorKe03",
+    "espn_id_new": 4218312
   },
   {
     "mfl_id": 13472,
-    "sleeper_id": 4452,
-    "pfr_id": "WoodXa01",
     "gsis_id": "00-0033450",
     "pff_id": 50835,
-    "espn_id": 3042370,
-    "yahoo_id": 30638
+    "sleeper_id": 4452,
+    "yahoo_id": 30638,
+    "pfr_id": "WoodXa01"
   },
   {
     "mfl_id": 13474,
-    "sleeper_id": 4594,
-    "pfr_id": "BarrAl00",
     "gsis_id": "00-0033746",
     "pff_id": 12183,
-    "espn_id": 2976114,
-    "yahoo_id": 30766
+    "sleeper_id": 4594,
+    "yahoo_id": 30766,
+    "pfr_id": "BarrAl00"
   },
   {
     "mfl_id": 13475,
-    "sleeper_id": 4664,
-    "pfr_id": "HarrNi00",
     "gsis_id": "00-0033700",
     "pff_id": 12038,
-    "espn_id": 3051368,
-    "yahoo_id": 30424
+    "sleeper_id": 4664,
+    "yahoo_id": 30424,
+    "pfr_id": "HarrNi00"
   },
   {
     "mfl_id": 13476,
-    "sleeper_id": 4605,
-    "pfr_id": "BaylEv00",
     "gsis_id": "00-0033763",
     "pff_id": 23652,
-    "espn_id": 2971280,
-    "yahoo_id": 30795
+    "sleeper_id": 4605,
+    "yahoo_id": 30795,
+    "pfr_id": "BaylEv00"
   },
   {
     "mfl_id": 13479,
-    "sleeper_id": 4661,
-    "pfr_id": "DaviMi03",
     "gsis_id": "00-0033697",
     "pff_id": 12040,
+    "sleeper_id": 4661,
+    "yahoo_id": 30422,
     "espn_id": 3053795,
-    "yahoo_id": 30422
+    "pfr_id": "DaviMi03",
+    "espn_id_new": 3053795
   },
   {
     "mfl_id": 13486,
-    "sleeper_id": 3616,
     "gsis_id": "00-0032883",
     "pff_id": 11232,
-    "espn_id": 2578754,
+    "sleeper_id": 3616,
     "yahoo_id": 29856
   },
   {
     "mfl_id": 13488,
-    "sleeper_id": 4319,
-    "pfr_id": "PascZa00",
     "gsis_id": "00-0033251",
     "pff_id": 12303,
+    "sleeper_id": 4319,
+    "espn_id": 2978109,
+    "pfr_id": "PascZa00",
     "ras_id": 15160,
-    "otc_id": 5961
+    "otc_id": 5961,
+    "espn_id_new": 2978109
   },
   {
     "mfl_id": 13491,
-    "sleeper_id": 4611,
     "gsis_id": "00-0033770",
     "pff_id": 18348,
-    "espn_id": 2970625,
+    "sleeper_id": 4611,
     "yahoo_id": 30811
   },
   {
     "mfl_id": 13492,
-    "sleeper_id": 4719,
-    "pfr_id": "ThomCh05",
     "gsis_id": "00-0033855",
     "pff_id": 12330,
-    "espn_id": 3054970,
-    "yahoo_id": 30861
+    "sleeper_id": 4719,
+    "yahoo_id": 30861,
+    "pfr_id": "ThomCh05"
   },
   {
     "mfl_id": 13493,
-    "sleeper_id": 3731,
     "gsis_id": "00-0032730",
     "pff_id": 11165,
-    "espn_id": 2970397,
+    "sleeper_id": 3731,
     "yahoo_id": 29799
   },
   {
     "mfl_id": 13498,
-    "sleeper_id": 3592,
-    "pfr_id": "JohnIs00",
     "gsis_id": "00-0032749",
     "pff_id": 10935,
-    "espn_id": 2570484,
-    "yahoo_id": 29577
+    "sleeper_id": 3592,
+    "yahoo_id": 29577,
+    "pfr_id": "JohnIs00"
   },
   {
     "mfl_id": 13502,
-    "sleeper_id": 2859,
     "gsis_id": "00-0031636",
     "pff_id": 9732,
-    "espn_id": 2574009,
+    "sleeper_id": 2859,
     "yahoo_id": 28771
   },
   {
     "mfl_id": 13503,
-    "sleeper_id": 4491,
-    "pfr_id": "KempMa00",
     "gsis_id": "00-0033481",
-    "pff_id": 12137
+    "pff_id": 12137,
+    "sleeper_id": 4491,
+    "pfr_id": "KempMa00"
   },
   {
     "mfl_id": 13504,
-    "sleeper_id": 3841,
     "gsis_id": "00-0032934",
     "pff_id": 11358,
-    "espn_id": 2969422,
+    "sleeper_id": 3841,
     "yahoo_id": 29962
   },
   {
     "mfl_id": 13505,
-    "sleeper_id": 3895,
-    "pfr_id": "HallMa02",
     "gsis_id": "00-0033094",
     "pff_id": 11440,
+    "sleeper_id": 3895,
+    "pfr_id": "HallMa02",
     "ras_id": 12832,
     "otc_id": 5460
   },
   {
     "mfl_id": 13506,
-    "sleeper_id": 4386,
-    "pfr_id": "PipkLe00",
     "gsis_id": "00-0033362",
     "pff_id": 12117,
-    "espn_id": 2972562,
-    "yahoo_id": 30619
+    "sleeper_id": 4386,
+    "yahoo_id": 30619,
+    "pfr_id": "PipkLe00"
   },
   {
     "mfl_id": 13509,
-    "sleeper_id": 3765,
-    "pfr_id": "DeayDo01",
     "gsis_id": "00-0032641",
     "pff_id": 11242,
-    "espn_id": 2972896,
-    "yahoo_id": 29846
+    "sleeper_id": 3765,
+    "yahoo_id": 29846,
+    "pfr_id": "DeayDo01"
   },
   {
     "mfl_id": 13510,
-    "sleeper_id": 3852,
-    "pfr_id": "MickJa01",
     "gsis_id": "00-0033006",
     "pff_id": 11371,
+    "sleeper_id": 3852,
+    "pfr_id": "MickJa01",
     "ras_id": 12662,
     "otc_id": 5524
   },
   {
     "mfl_id": 13511,
-    "sleeper_id": 4460,
-    "pfr_id": "HikuCo00",
     "gsis_id": "00-0033315",
     "pff_id": 12276,
-    "espn_id": 2968204,
-    "yahoo_id": 30559
+    "sleeper_id": 4460,
+    "yahoo_id": 30559,
+    "pfr_id": "HikuCo00"
   },
   {
     "mfl_id": 13512,
-    "sleeper_id": 4357,
-    "pfr_id": "CoxxBr01",
     "gsis_id": "00-0033408",
     "pff_id": 12092,
-    "espn_id": 2980098,
-    "yahoo_id": 30379
+    "sleeper_id": 4357,
+    "yahoo_id": 30379,
+    "pfr_id": "CoxxBr01"
   },
   {
     "mfl_id": 13529,
-    "sleeper_id": 4330,
     "gsis_id": "00-0033266",
     "pff_id": 12739,
-    "espn_id": 2971830,
+    "sleeper_id": 4330,
     "yahoo_id": 30531
   },
   {
     "mfl_id": 13530,
-    "pfr_id": "BankBr01",
-    "gsis_id": "00-0033254"
+    "gsis_id": "00-0033254",
+    "pfr_id": "BankBr01"
   },
   {
     "mfl_id": 13531,
-    "sleeper_id": 3016,
-    "pfr_id": "WhitJe02",
     "gsis_id": "00-0031512",
     "pff_id": 9698,
-    "espn_id": 2574557,
-    "yahoo_id": 28801
+    "sleeper_id": 3016,
+    "yahoo_id": 28801,
+    "pfr_id": "WhitJe02"
   },
   {
     "mfl_id": 13535,
-    "pfr_id": "PinkLa00",
-    "gsis_id": "00-0031834"
+    "gsis_id": "00-0031834",
+    "pfr_id": "PinkLa00"
   },
   {
     "mfl_id": 13536,
-    "sleeper_id": 4552,
-    "pfr_id": "IrviIs00",
     "gsis_id": "00-0033635",
     "pff_id": 12171,
-    "espn_id": 3043197,
-    "yahoo_id": 30722
+    "sleeper_id": 4552,
+    "yahoo_id": 30722,
+    "pfr_id": "IrviIs00"
   },
   {
     "mfl_id": 13537,
-    "sleeper_id": 4402,
-    "pfr_id": "BoweTa00",
     "gsis_id": "00-0033324",
     "pff_id": 50170,
-    "espn_id": 3042726,
-    "yahoo_id": 30427
+    "sleeper_id": 4402,
+    "yahoo_id": 30427,
+    "pfr_id": "BoweTa00"
   },
   {
     "mfl_id": 13538,
-    "sleeper_id": 4522,
     "gsis_id": "00-0033599",
     "pff_id": 12010,
-    "espn_id": 2982809,
+    "sleeper_id": 4522,
     "yahoo_id": 30482
   },
   {
     "mfl_id": 13539,
-    "pfr_id": "DaniLe00",
-    "gsis_id": "00-0033384"
+    "gsis_id": "00-0033384",
+    "pfr_id": "DaniLe00"
   },
   {
     "mfl_id": 13541,
-    "sleeper_id": 3818,
     "gsis_id": "00-0032851",
     "pff_id": 11317,
-    "espn_id": 2577651,
+    "sleeper_id": 3818,
     "yahoo_id": 29937
   },
   {
     "mfl_id": 13543,
-    "sleeper_id": 4572,
     "gsis_id": "00-0033659",
     "pff_id": 12321,
-    "espn_id": 2974344,
+    "sleeper_id": 4572,
     "yahoo_id": 30785
   },
   {
     "mfl_id": 13544,
-    "sleeper_id": 4480,
-    "pfr_id": "WilsJe00",
     "gsis_id": "00-0033434",
     "pff_id": 12067,
-    "espn_id": 3045380,
-    "yahoo_id": 30481
+    "sleeper_id": 4480,
+    "yahoo_id": 30481,
+    "pfr_id": "WilsJe00"
   },
   {
     "mfl_id": 13545,
-    "sleeper_id": 4451,
-    "pfr_id": "WhitIs00",
     "gsis_id": "00-0033449",
     "pff_id": 12251,
-    "espn_id": 3894883,
-    "yahoo_id": 30637
+    "sleeper_id": 4451,
+    "yahoo_id": 30637,
+    "pfr_id": "WhitIs00"
   },
   {
     "mfl_id": 13546,
-    "sleeper_id": 3894,
-    "pfr_id": "GrifGa00",
     "gsis_id": "00-0033095",
     "pff_id": 11439,
+    "sleeper_id": 3894,
+    "pfr_id": "GrifGa00",
     "ras_id": 12580,
     "otc_id": 5459
   },
   {
     "mfl_id": 13547,
-    "sleeper_id": 4503,
     "gsis_id": "00-0033503",
     "pff_id": 12224,
+    "sleeper_id": 4503,
+    "yahoo_id": 30415,
     "espn_id": 3916144,
-    "yahoo_id": 30415
+    "espn_id_new": 3916144
   },
   {
     "mfl_id": 13548,
-    "sleeper_id": 4616,
-    "pfr_id": "PresGi00",
     "gsis_id": "00-0033776",
     "pff_id": 48388,
-    "espn_id": 2971022,
-    "yahoo_id": 30803
+    "sleeper_id": 4616,
+    "yahoo_id": 30803,
+    "pfr_id": "PresGi00"
   },
   {
     "mfl_id": 13549,
-    "sleeper_id": 3774,
     "gsis_id": "00-0032689",
     "pff_id": 11266,
-    "espn_id": 3057863,
+    "sleeper_id": 3774,
     "yahoo_id": 29806
   },
   {
     "mfl_id": 13552,
-    "sleeper_id": 4632,
-    "pfr_id": "PhilCa00",
     "gsis_id": "00-0033693",
     "pff_id": 48353,
-    "espn_id": 3115911,
-    "yahoo_id": 30405
+    "sleeper_id": 4632,
+    "yahoo_id": 30405,
+    "pfr_id": "PhilCa00"
   },
   {
     "mfl_id": 13553,
-    "sleeper_id": 4395,
-    "pfr_id": "McTyTo00",
     "gsis_id": "00-0033405",
     "pff_id": 49357,
-    "espn_id": 3058965,
-    "yahoo_id": 30646
+    "sleeper_id": 4395,
+    "yahoo_id": 30646,
+    "pfr_id": "McTyTo00"
   },
   {
     "mfl_id": 13556,
-    "pfr_id": "PeteOt00",
-    "gsis_id": "00-0033738"
+    "gsis_id": "00-0033738",
+    "pfr_id": "PeteOt00"
   },
   {
     "mfl_id": 13558,
-    "sleeper_id": 4361,
-    "pfr_id": "BellBr01",
     "gsis_id": "00-0033337",
     "pff_id": 50096,
-    "espn_id": 3057972,
-    "yahoo_id": 30576
+    "sleeper_id": 4361,
+    "yahoo_id": 30576,
+    "pfr_id": "BellBr01"
   },
   {
     "mfl_id": 13559,
-    "sleeper_id": 4393,
     "gsis_id": "00-0033403",
     "pff_id": 50587,
-    "espn_id": 2981511,
+    "sleeper_id": 4393,
     "yahoo_id": 30644
   },
   {
     "mfl_id": 13562,
-    "sleeper_id": 4617,
-    "pfr_id": "RossDa02",
     "gsis_id": "00-0033535",
     "pff_id": 51592,
-    "espn_id": 4220624,
-    "yahoo_id": 30802
+    "sleeper_id": 4617,
+    "yahoo_id": 30802,
+    "pfr_id": "RossDa02"
   },
   {
     "mfl_id": 13563,
-    "sleeper_id": 4470,
-    "pfr_id": "BullRi00",
     "gsis_id": "00-0033424",
     "pff_id": 12062,
-    "espn_id": 2979532,
-    "yahoo_id": 30471
+    "sleeper_id": 4470,
+    "yahoo_id": 30471,
+    "pfr_id": "BullRi00"
   },
   {
     "mfl_id": 13565,
-    "sleeper_id": 3720,
     "gsis_id": "00-0032633",
     "pff_id": 11147,
-    "espn_id": 2576755,
+    "sleeper_id": 3720,
     "yahoo_id": 29727
   },
   {
     "mfl_id": 13567,
-    "sleeper_id": 4591,
     "gsis_id": "00-0033675",
     "pff_id": 49127,
-    "espn_id": 3045206,
+    "sleeper_id": 4591,
     "yahoo_id": 30825
   },
   {
     "mfl_id": 13573,
-    "sleeper_id": 3834,
     "gsis_id": "00-0032926",
     "pff_id": 11349,
-    "espn_id": 2577664,
+    "sleeper_id": 3834,
     "yahoo_id": 29953
   },
   {
     "mfl_id": 13574,
-    "pfr_id": "ByrdEm00",
-    "gsis_id": "00-0033514"
+    "gsis_id": "00-0033514",
+    "pfr_id": "ByrdEm00"
   },
   {
     "mfl_id": 13584,
-    "sleeper_id": 4377,
     "gsis_id": "00-0033353",
     "pff_id": 12108,
-    "espn_id": 2973973,
+    "sleeper_id": 4377,
     "yahoo_id": 30610
   },
   {
     "mfl_id": 13585,
-    "sleeper_id": 4878,
-    "pfr_id": "ZylsBr00",
     "gsis_id": "00-0034052",
     "pff_id": 66438,
+    "sleeper_id": 4878,
+    "espn_id": 4294520,
+    "pfr_id": "ZylsBr00",
     "ras_id": 12369,
-    "otc_id": 6873
+    "otc_id": 6873,
+    "espn_id_new": 4294520
   },
   {
     "mfl_id": 13596,
-    "sleeper_id": 5228,
     "gsis_id": "00-0034126",
     "pff_id": 46387,
-    "espn_id": 3040507,
+    "sleeper_id": 5228,
     "yahoo_id": 31365
   },
   {
     "mfl_id": 13600,
-    "sleeper_id": 5142,
     "gsis_id": "00-0034131",
     "pff_id": 46540,
-    "espn_id": 3040535,
+    "sleeper_id": 5142,
     "yahoo_id": 31336
   },
   {
     "mfl_id": 13603,
-    "sleeper_id": 5165,
     "gsis_id": "00-0034531",
     "pff_id": 46580,
-    "espn_id": 3139591,
+    "sleeper_id": 5165,
     "yahoo_id": 31560
   },
   {
     "mfl_id": 13611,
-    "sleeper_id": 5136,
-    "pfr_id": "AdamJo03",
     "gsis_id": "00-0034457",
     "pff_id": 45662,
-    "espn_id": 3932420,
-    "yahoo_id": 31567
+    "sleeper_id": 5136,
+    "yahoo_id": 31567,
+    "pfr_id": "AdamJo03"
   },
   {
     "mfl_id": 13614,
-    "sleeper_id": 5170,
-    "pfr_id": "LindPh00",
     "gsis_id": "00-0034109",
     "pff_id": 12660,
+    "sleeper_id": 5170,
+    "pfr_id": "LindPh00",
     "ras_id": 16846,
     "otc_id": 7144
   },
   {
     "mfl_id": 13623,
-    "sleeper_id": 5549,
-    "pfr_id": "WillDa10",
     "gsis_id": "00-0034301",
     "pff_id": 13014,
+    "sleeper_id": 5549,
+    "espn_id": 3115375,
+    "pfr_id": "WillDa10",
     "ras_id": 15692,
-    "otc_id": 7318
+    "otc_id": 7318,
+    "espn_id_new": 3115375
   },
   {
     "mfl_id": 13625,
-    "sleeper_id": 5192,
     "gsis_id": "00-0034596",
     "pff_id": 45802,
-    "espn_id": 3051762,
+    "sleeper_id": 5192,
     "yahoo_id": 31653
   },
   {
     "mfl_id": 13628,
-    "sleeper_id": 5274,
-    "pfr_id": "ThomRo05",
     "gsis_id": "00-0034221",
     "pff_id": 27875,
-    "espn_id": 3121583,
-    "yahoo_id": 31241
+    "sleeper_id": 5274,
+    "yahoo_id": 31241,
+    "pfr_id": "ThomRo05"
   },
   {
     "mfl_id": 13632,
-    "sleeper_id": 5185,
-    "pfr_id": "LazaAl00",
     "gsis_id": "00-0034521",
     "pff_id": 48135,
+    "sleeper_id": 5185,
+    "espn_id": 3128390,
+    "pfr_id": "LazaAl00",
     "ras_id": 15224,
-    "otc_id": 7167
+    "otc_id": 7167,
+    "espn_id_new": 3128390
   },
   {
     "mfl_id": 13643,
-    "sleeper_id": 5164,
     "gsis_id": "00-0034068",
     "pff_id": 28580,
-    "espn_id": 3128251,
+    "sleeper_id": 5164,
     "yahoo_id": 31397
   },
   {
     "mfl_id": 13648,
-    "sleeper_id": 5290,
-    "pfr_id": "BurnDe00",
     "gsis_id": "00-0034653",
     "pff_id": 47477,
-    "espn_id": 3932935,
-    "yahoo_id": 31624
+    "sleeper_id": 5290,
+    "yahoo_id": 31624,
+    "pfr_id": "BurnDe00"
   },
   {
     "mfl_id": 13653,
-    "sleeper_id": 5250,
-    "pfr_id": "FostRo01",
     "gsis_id": "00-0034510",
     "pff_id": 48230,
-    "espn_id": 3054845,
-    "yahoo_id": 31601
+    "sleeper_id": 5250,
+    "yahoo_id": 31601,
+    "pfr_id": "FostRo01"
   },
   {
     "mfl_id": 13655,
-    "sleeper_id": 5625,
-    "pfr_id": "PhilCa01",
     "gsis_id": "00-0034512",
     "pff_id": 47593,
-    "espn_id": 3124079,
-    "yahoo_id": 31598
+    "sleeper_id": 5625,
+    "yahoo_id": 31598,
+    "pfr_id": "PhilCa01"
   },
   {
     "mfl_id": 13656,
-    "sleeper_id": 5261,
     "gsis_id": "00-0034633",
     "pff_id": 48162,
-    "espn_id": 3045164,
+    "sleeper_id": 5261,
     "yahoo_id": 31592
   },
   {
     "mfl_id": 13659,
-    "sleeper_id": 5132,
-    "pfr_id": "MitcSt02",
     "gsis_id": "00-0034081",
     "pff_id": 47508,
-    "espn_id": 3043225,
-    "yahoo_id": 31391
+    "sleeper_id": 5132,
+    "yahoo_id": 31391,
+    "pfr_id": "MitcSt02"
   },
   {
     "mfl_id": 13661,
-    "sleeper_id": 5176,
     "gsis_id": "00-0034748",
     "pff_id": 38079,
-    "espn_id": 3059719,
+    "sleeper_id": 5176,
     "yahoo_id": 31739
   },
   {
     "mfl_id": 13666,
-    "sleeper_id": 5102
+    "sleeper_id": 5102,
+    "espn_id": 3120659,
+    "espn_id_new": 3120659
   },
   {
     "mfl_id": 13669,
-    "sleeper_id": 5781,
-    "pfr_id": "TurnMa00",
     "gsis_id": "00-0034867",
     "pff_id": 48078,
-    "espn_id": 3115928,
-    "yahoo_id": 31777
+    "sleeper_id": 5781,
+    "yahoo_id": 31777,
+    "pfr_id": "TurnMa00"
   },
   {
     "mfl_id": 13689,
-    "sleeper_id": 5212,
     "gsis_id": "00-0034215",
     "pff_id": 48931,
-    "espn_id": 3127274,
+    "sleeper_id": 5212,
     "yahoo_id": 31235
   },
   {
     "mfl_id": 13711,
-    "sleeper_id": 5153,
-    "pfr_id": "WallLe00",
     "gsis_id": "00-0034514",
     "pff_id": 25445,
+    "sleeper_id": 5153,
+    "yahoo_id": 31603,
     "espn_id": 3133440,
-    "yahoo_id": 31603
+    "pfr_id": "WallLe00",
+    "espn_id_new": 3133440
   },
   {
     "mfl_id": 13712,
-    "sleeper_id": 5435,
     "gsis_id": "00-0034095",
     "pff_id": 50450,
-    "espn_id": 3921563,
+    "sleeper_id": 5435,
     "yahoo_id": 31385
   },
   {
     "mfl_id": 13719,
-    "sleeper_id": 5189,
     "gsis_id": "00-0034173",
+    "sleeper_id": 5189,
+    "yahoo_id": 31482,
     "espn_id": 4034949,
-    "yahoo_id": 31482
+    "espn_id_new": 4034949
   },
   {
     "mfl_id": 13722,
-    "sleeper_id": 4571,
-    "pfr_id": "JarwBl00",
     "gsis_id": "00-0033658",
     "pff_id": 12320,
+    "sleeper_id": 4571,
+    "pfr_id": "JarwBl00",
     "ras_id": 13283,
     "otc_id": 6230
   },
   {
     "mfl_id": 13725,
-    "sleeper_id": 5587,
     "gsis_id": "00-0034315",
     "pff_id": 35977,
-    "espn_id": 3929855,
+    "sleeper_id": 5587,
     "yahoo_id": 31514
   },
   {
     "mfl_id": 13728,
-    "sleeper_id": 4650,
     "gsis_id": "00-0033735",
     "pff_id": 12347,
-    "espn_id": 3957543,
+    "sleeper_id": 4650,
     "yahoo_id": 30756
   },
   {
     "mfl_id": 13732,
-    "sleeper_id": 4954,
     "gsis_id": "00-0034064",
     "pff_id": 38062,
-    "espn_id": 3050015,
+    "sleeper_id": 4954,
     "yahoo_id": 30967
   },
   {
     "mfl_id": 13737,
-    "sleeper_id": 5017
+    "sleeper_id": 5017,
+    "espn_id": 3919512,
+    "espn_id_new": 3919512
   },
   {
     "mfl_id": 13848,
-    "sleeper_id": 4654,
     "gsis_id": "00-0033729",
     "pff_id": 12255,
+    "sleeper_id": 4654,
+    "yahoo_id": 30711,
     "espn_id": 3051397,
-    "yahoo_id": 30711
+    "espn_id_new": 3051397
   },
   {
     "mfl_id": 13849,
-    "sleeper_id": 5163,
     "gsis_id": "00-0034597",
     "pff_id": 45753,
-    "espn_id": 3127335,
+    "sleeper_id": 5163,
     "yahoo_id": 31662
   },
   {
     "mfl_id": 13850,
-    "sleeper_id": 5248,
-    "pfr_id": "EdwaGu00",
     "gsis_id": "00-0034184",
     "pff_id": 46027,
+    "sleeper_id": 5248,
+    "espn_id": 3051926,
+    "pfr_id": "EdwaGu00",
     "ras_id": 16010,
-    "otc_id": 7251
+    "otc_id": 7251,
+    "espn_id_new": 3051926
   },
   {
     "mfl_id": 13851,
-    "sleeper_id": 4420,
     "gsis_id": "00-0033386",
     "pff_id": 12052,
-    "espn_id": 3115443,
+    "sleeper_id": 4420,
     "yahoo_id": 30660
   },
   {
     "mfl_id": 13852,
-    "sleeper_id": 5174,
     "gsis_id": "00-0034121",
     "pff_id": 50819,
-    "espn_id": 3128268,
+    "sleeper_id": 5174,
     "yahoo_id": 31410
   },
   {
     "mfl_id": 13853,
-    "sleeper_id": 5450,
-    "pfr_id": "MoorSk00",
     "gsis_id": "00-0034090",
     "pff_id": 21605,
-    "espn_id": 3048912,
-    "yahoo_id": 31372
+    "sleeper_id": 5450,
+    "yahoo_id": 31372,
+    "pfr_id": "MoorSk00"
   },
   {
     "mfl_id": 13854,
-    "sleeper_id": 5434,
     "gsis_id": "00-0034098",
     "pff_id": 49234,
-    "espn_id": 3124020,
+    "sleeper_id": 5434,
     "yahoo_id": 31395
   },
   {
     "mfl_id": 13855,
-    "sleeper_id": 5516,
     "gsis_id": "00-0034474",
     "pff_id": 51032,
-    "espn_id": 3914861,
+    "sleeper_id": 5516,
     "yahoo_id": 31300
   },
   {
     "mfl_id": 13857,
-    "sleeper_id": 5277,
-    "pfr_id": "YeldDe00",
     "gsis_id": "00-0034319",
     "pff_id": 29556,
-    "espn_id": 3059766,
-    "yahoo_id": 31519
+    "sleeper_id": 5277,
+    "yahoo_id": 31519,
+    "pfr_id": "YeldDe00"
   },
   {
     "mfl_id": 13858,
-    "sleeper_id": 5703,
     "gsis_id": "00-0034715",
     "pff_id": 66962,
-    "espn_id": 4055563,
+    "sleeper_id": 5703,
     "yahoo_id": 31705
   },
   {
     "mfl_id": 13861,
-    "sleeper_id": 5751,
     "gsis_id": "00-0034784",
-    "espn_id": 3134314,
+    "sleeper_id": 5751,
     "yahoo_id": 31747
   },
   {
     "mfl_id": 13862,
-    "sleeper_id": 4854,
     "gsis_id": "00-0034054",
     "pff_id": 47417,
+    "sleeper_id": 4854,
+    "yahoo_id": 30955,
     "espn_id": 3052056,
-    "yahoo_id": 30955
+    "espn_id_new": 3052056
   },
   {
     "mfl_id": 13863,
-    "sleeper_id": 5199,
-    "pfr_id": "PrinBy00",
     "gsis_id": "00-0034297",
     "pff_id": 42345,
+    "sleeper_id": 5199,
+    "espn_id": 4036416,
+    "pfr_id": "PrinBy00",
     "ras_id": 15456,
-    "otc_id": 7313
+    "otc_id": 7313,
+    "espn_id_new": 4036416
   },
   {
     "mfl_id": 13864,
-    "sleeper_id": 6744,
-    "pfr_id": "WardGr02",
     "gsis_id": "00-0033733",
     "pff_id": 12258,
+    "sleeper_id": 6744,
+    "espn_id": 3040035,
+    "pfr_id": "WardGr02",
     "ras_id": 13923,
-    "otc_id": 6162
+    "otc_id": 6162,
+    "espn_id_new": 3040035
   },
   {
     "mfl_id": 13865,
-    "sleeper_id": 5138,
     "gsis_id": "00-0034099",
     "pff_id": 24942,
-    "espn_id": 3140525,
+    "sleeper_id": 5138,
     "yahoo_id": 31396
   },
   {
     "mfl_id": 13866,
-    "sleeper_id": 5766,
     "gsis_id": "00-0034839",
     "pff_id": 13822,
-    "espn_id": 3916720,
+    "sleeper_id": 5766,
     "yahoo_id": 31764
   },
   {
     "mfl_id": 13867,
-    "sleeper_id": 5767,
-    "pfr_id": "AlexAd00",
     "gsis_id": "00-0034840",
     "pff_id": 13612,
-    "espn_id": 3871875,
-    "yahoo_id": 31762
+    "sleeper_id": 5767,
+    "yahoo_id": 31762,
+    "pfr_id": "AlexAd00"
   },
   {
     "mfl_id": 13868,
-    "sleeper_id": 5209,
-    "pfr_id": "BoonMi00",
     "gsis_id": "00-0034208",
     "pff_id": 31615,
-    "espn_id": 3139033,
-    "yahoo_id": 31228
+    "sleeper_id": 5209,
+    "yahoo_id": 31228,
+    "pfr_id": "BoonMi00"
   },
   {
     "mfl_id": 13869,
-    "sleeper_id": 5721,
     "gsis_id": "00-0034721",
     "pff_id": 27626,
+    "sleeper_id": 5721,
+    "yahoo_id": 31727,
     "espn_id": 4039396,
-    "yahoo_id": 31727
+    "espn_id_new": 4039396
   },
   {
     "mfl_id": 13870,
-    "sleeper_id": 4859,
-    "pfr_id": "ThomAh00",
     "gsis_id": "00-0033447",
     "pff_id": 49204,
-    "espn_id": 3042403,
-    "yahoo_id": 30635
+    "sleeper_id": 4859,
+    "yahoo_id": 30635,
+    "pfr_id": "ThomAh00"
   },
   {
     "mfl_id": 13871,
-    "sleeper_id": 5536,
-    "pfr_id": "HillDo00",
     "gsis_id": "00-0034253",
     "pff_id": 45691,
+    "sleeper_id": 5536,
+    "yahoo_id": 31457,
     "espn_id": 3126246,
-    "yahoo_id": 31457
+    "pfr_id": "HillDo00",
+    "espn_id_new": 3126246
   },
   {
     "mfl_id": 13872,
-    "sleeper_id": 5231,
     "gsis_id": "00-0034549",
     "pff_id": 25172,
-    "espn_id": 3047912,
+    "sleeper_id": 5231,
     "yahoo_id": 31680
   },
   {
     "mfl_id": 13873,
-    "sleeper_id": 5257,
     "gsis_id": "00-0034177",
     "pff_id": 21956,
+    "sleeper_id": 5257,
+    "yahoo_id": 31431,
     "espn_id": 3045169,
-    "yahoo_id": 31431
+    "espn_id_new": 3045169
   },
   {
     "mfl_id": 13874,
-    "sleeper_id": 5395,
-    "pfr_id": "WilsSh01",
     "gsis_id": "00-0034621",
     "pff_id": 45993,
-    "espn_id": 3116563,
-    "yahoo_id": 31278
+    "sleeper_id": 5395,
+    "yahoo_id": 31278,
+    "pfr_id": "WilsSh01"
   },
   {
     "mfl_id": 13875,
-    "sleeper_id": 5463,
     "gsis_id": "00-0034200",
     "pff_id": 26401,
-    "espn_id": 4057659,
+    "sleeper_id": 5463,
     "yahoo_id": 31423
   },
   {
     "mfl_id": 13876,
-    "sleeper_id": 5255,
     "gsis_id": "00-0034647",
     "pff_id": 47790,
-    "espn_id": 3045763,
+    "sleeper_id": 5255,
     "yahoo_id": 31642
   },
   {
     "mfl_id": 13877,
-    "sleeper_id": 5460,
     "gsis_id": "00-0034202",
-    "espn_id": 3068715,
+    "sleeper_id": 5460,
     "yahoo_id": 31421
   },
   {
     "mfl_id": 13878,
-    "sleeper_id": 4344,
-    "pfr_id": "BoarC.00",
     "gsis_id": "00-0033367",
     "pff_id": 12088,
+    "sleeper_id": 4344,
+    "pfr_id": "BoarC.00",
     "ras_id": 13358,
     "otc_id": 6027
   },
   {
     "mfl_id": 13879,
-    "sleeper_id": 5127,
-    "pfr_id": "AlleKy00",
     "gsis_id": "00-0034577",
     "pff_id": 26152,
+    "sleeper_id": 5127,
+    "yahoo_id": 31301,
     "espn_id": 3115293,
-    "yahoo_id": 31301
+    "pfr_id": "AlleKy00",
+    "espn_id_new": 3115293
   },
   {
     "mfl_id": 13880,
-    "sleeper_id": 4741,
-    "pfr_id": "ArnoDa00",
     "gsis_id": "00-0034011",
     "pff_id": 51842,
+    "sleeper_id": 4741,
+    "espn_id": 4212989,
+    "pfr_id": "ArnoDa00",
     "ras_id": 7676,
-    "otc_id": 6350
+    "otc_id": 6350,
+    "espn_id_new": 4212989
   },
   {
     "mfl_id": 13881,
-    "sleeper_id": 5293,
     "gsis_id": "00-0034669",
     "pff_id": 38435,
-    "espn_id": 4035853,
+    "sleeper_id": 5293,
     "yahoo_id": 31626
   },
   {
     "mfl_id": 13882,
-    "sleeper_id": 5134,
-    "pfr_id": "KirkKe00",
     "gsis_id": "00-0034317",
     "pff_id": 48017,
+    "sleeper_id": 5134,
+    "yahoo_id": 31517,
     "espn_id": 3046401,
-    "yahoo_id": 31517
+    "pfr_id": "KirkKe00",
+    "espn_id_new": 3046401
   },
   {
     "mfl_id": 13883,
-    "sleeper_id": 5125,
     "gsis_id": "00-0034698",
     "pff_id": 30366,
-    "espn_id": 3125383,
+    "sleeper_id": 5125,
     "yahoo_id": 31701
   },
   {
     "mfl_id": 13884,
-    "sleeper_id": 5260,
-    "pfr_id": "SmitVy00",
     "gsis_id": "00-0034631",
     "pff_id": 66957,
-    "espn_id": 3155188,
-    "yahoo_id": 31588
+    "sleeper_id": 5260,
+    "yahoo_id": 31588,
+    "pfr_id": "SmitVy00"
   },
   {
     "mfl_id": 13885,
-    "sleeper_id": 5506,
     "gsis_id": "00-0034157",
     "pff_id": 48552,
-    "espn_id": 3042693,
+    "sleeper_id": 5506,
     "yahoo_id": 31355
   },
   {
     "mfl_id": 13886,
-    "sleeper_id": 4656,
     "gsis_id": "00-0033731",
     "pff_id": 12165,
-    "espn_id": 3957450,
+    "sleeper_id": 4656,
     "yahoo_id": 30713
   },
   {
     "mfl_id": 13888,
-    "sleeper_id": 5158,
     "gsis_id": "00-0034473",
     "pff_id": 66928,
+    "sleeper_id": 5158,
+    "yahoo_id": 31299,
     "espn_id": 4334300,
-    "yahoo_id": 31299
+    "espn_id_new": 4334300
   },
   {
     "mfl_id": 13890,
-    "sleeper_id": 4536,
     "gsis_id": "00-0033627",
     "pff_id": 12145,
-    "espn_id": 2972240,
+    "sleeper_id": 4536,
     "yahoo_id": 30594
   },
   {
     "mfl_id": 13891,
-    "sleeper_id": 5266,
-    "pfr_id": "NewsDe00",
     "gsis_id": "00-0034565",
     "pff_id": 45695,
-    "espn_id": 3117131,
-    "yahoo_id": 31685
+    "sleeper_id": 5266,
+    "yahoo_id": 31685,
+    "pfr_id": "NewsDe00"
   },
   {
     "mfl_id": 13892,
-    "sleeper_id": 5263,
     "gsis_id": "00-0034291",
     "pff_id": 34874,
-    "espn_id": 3931782,
+    "sleeper_id": 5263,
     "yahoo_id": 31490
   },
   {
     "mfl_id": 13893,
-    "sleeper_id": 5154,
-    "pfr_id": "SherTr00",
     "gsis_id": "00-0034487",
     "pff_id": 48021,
+    "sleeper_id": 5154,
+    "espn_id": 3122168,
+    "pfr_id": "SherTr00",
     "ras_id": 17185,
-    "otc_id": 7544
+    "otc_id": 7544,
+    "espn_id_new": 3122168
   },
   {
     "mfl_id": 13894,
-    "sleeper_id": 4819,
     "gsis_id": "00-0034030",
     "pff_id": 23592,
-    "espn_id": 2973627,
+    "sleeper_id": 4819,
     "yahoo_id": 30934
   },
   {
     "mfl_id": 13895,
-    "sleeper_id": 5432,
-    "pfr_id": "SimsCa00",
     "gsis_id": "00-0034104",
     "pff_id": 47908,
+    "sleeper_id": 5432,
+    "espn_id": 3115314,
+    "pfr_id": "SimsCa00",
     "ras_id": 15471,
-    "otc_id": 7403
+    "otc_id": 7403,
+    "espn_id_new": 3115314
   },
   {
     "mfl_id": 13896,
-    "sleeper_id": 5700,
     "gsis_id": "00-0034708",
     "pff_id": 26957,
-    "espn_id": 3127374,
+    "sleeper_id": 5700,
     "yahoo_id": 31704
   },
   {
     "mfl_id": 13897,
-    "sleeper_id": 5443,
-    "pfr_id": "HollJe01",
     "gsis_id": "00-0034107",
     "pff_id": 50287,
-    "espn_id": 3916928,
-    "yahoo_id": 31377
+    "sleeper_id": 5443,
+    "yahoo_id": 31377,
+    "pfr_id": "HollJe01"
   },
   {
     "mfl_id": 13898,
-    "sleeper_id": 5272,
     "gsis_id": "00-0034450",
+    "sleeper_id": 5272,
+    "yahoo_id": 31538,
     "espn_id": 3975763,
-    "yahoo_id": 31538
+    "espn_id_new": 3975763
   },
   {
     "mfl_id": 13899,
-    "sleeper_id": 5262,
     "gsis_id": "00-0034087",
     "pff_id": 47731,
-    "espn_id": 3123992,
+    "sleeper_id": 5262,
     "yahoo_id": 31369
   },
   {
     "mfl_id": 13900,
-    "sleeper_id": 3467,
     "gsis_id": "00-0032669",
-    "espn_id": 2578718,
+    "sleeper_id": 3467,
     "yahoo_id": 29712
   },
   {
     "mfl_id": 13901,
-    "sleeper_id": 5386,
     "gsis_id": "00-0034479",
-    "espn_id": 3052413,
+    "sleeper_id": 5386,
     "yahoo_id": 31310
   },
   {
     "mfl_id": 13902,
-    "sleeper_id": 5500,
-    "pfr_id": "JarvRi00",
     "gsis_id": "00-0034143",
     "pff_id": 66932,
-    "yahoo_id": 31357
+    "sleeper_id": 5500,
+    "yahoo_id": 31357,
+    "pfr_id": "JarvRi00"
   },
   {
     "mfl_id": 13903,
-    "sleeper_id": 5605,
-    "pfr_id": "ThomMa00",
     "gsis_id": "00-0034341",
     "pff_id": 50942,
-    "espn_id": 3045376,
-    "yahoo_id": 31532
+    "sleeper_id": 5605,
+    "yahoo_id": 31532,
+    "pfr_id": "ThomMa00"
   },
   {
     "mfl_id": 13904,
-    "sleeper_id": 5567,
-    "pfr_id": "GranJa01",
     "gsis_id": "00-0034307",
     "pff_id": 47561,
-    "espn_id": 3047490,
-    "yahoo_id": 31506
+    "sleeper_id": 5567,
+    "yahoo_id": 31506,
+    "pfr_id": "GranJa01"
   },
   {
     "mfl_id": 13905,
-    "pfr_id": "JoneJJ00",
     "gsis_id": "00-0034560",
-    "yahoo_id": 31683
+    "yahoo_id": 31683,
+    "pfr_id": "JoneJJ00"
   },
   {
     "mfl_id": 13906,
-    "sleeper_id": 5565,
-    "pfr_id": "CabiJa00",
     "gsis_id": "00-0034171",
     "pff_id": 50714,
+    "sleeper_id": 5565,
+    "yahoo_id": 31480,
     "espn_id": 3116158,
-    "yahoo_id": 31480
+    "pfr_id": "CabiJa00",
+    "espn_id_new": 3116158
   },
   {
     "mfl_id": 13907,
-    "sleeper_id": 5784,
     "gsis_id": "00-0034872",
     "pff_id": 50667,
-    "espn_id": 3116052,
+    "sleeper_id": 5784,
     "yahoo_id": 31780
   },
   {
     "mfl_id": 13908,
-    "sleeper_id": 5206,
     "gsis_id": "00-0034626",
     "pff_id": 38843,
-    "espn_id": 3044725,
+    "sleeper_id": 5206,
     "yahoo_id": 31579
   },
   {
     "mfl_id": 13909,
-    "sleeper_id": 4958,
     "gsis_id": "00-0030332",
+    "sleeper_id": 4958,
+    "yahoo_id": 27369,
     "espn_id": 16486,
-    "yahoo_id": 27369
+    "espn_id_new": 16486
   },
   {
     "mfl_id": 13910,
-    "sleeper_id": 5695,
-    "pfr_id": "PoweBr00",
     "gsis_id": "00-0034646",
     "pff_id": 48036,
+    "sleeper_id": 5695,
+    "yahoo_id": 31641,
     "espn_id": 3115255,
-    "yahoo_id": 31641
+    "pfr_id": "PoweBr00",
+    "espn_id_new": 3115255
   },
   {
     "mfl_id": 13911,
-    "sleeper_id": 5539,
-    "pfr_id": "WillDe06",
     "gsis_id": "00-0034258",
     "pff_id": 48345,
-    "espn_id": 3040137,
-    "yahoo_id": 31462
+    "sleeper_id": 5539,
+    "yahoo_id": 31462,
+    "pfr_id": "WillDe06"
   },
   {
     "mfl_id": 13912,
-    "sleeper_id": 5289,
-    "pfr_id": "BatsCa00",
     "gsis_id": "00-0034652",
     "pff_id": 47669,
-    "espn_id": 3139456,
-    "yahoo_id": 31623
+    "sleeper_id": 5289,
+    "yahoo_id": 31623,
+    "pfr_id": "BatsCa00"
   },
   {
     "mfl_id": 13913,
-    "sleeper_id": 5576,
-    "pfr_id": "NiemBe00",
     "gsis_id": "00-0034296",
     "pff_id": 51099,
+    "sleeper_id": 5576,
+    "yahoo_id": 31495,
     "espn_id": 3140643,
-    "yahoo_id": 31495
+    "pfr_id": "NiemBe00",
+    "espn_id_new": 3140643
   },
   {
     "mfl_id": 13914,
-    "sleeper_id": 5479,
-    "pfr_id": "HernTr00",
     "gsis_id": "00-0034516",
     "pff_id": 50380,
+    "sleeper_id": 5479,
+    "yahoo_id": 31262,
     "espn_id": 3122160,
-    "yahoo_id": 31262
+    "pfr_id": "HernTr00",
+    "espn_id_new": 3122160
   },
   {
     "mfl_id": 13915,
-    "sleeper_id": 4811,
     "gsis_id": "00-0033452",
     "pff_id": 50640,
-    "espn_id": 2982304,
+    "sleeper_id": 4811,
     "yahoo_id": 30568
   },
   {
     "mfl_id": 13916,
-    "sleeper_id": 5271,
-    "pfr_id": "HoweGr00",
     "gsis_id": "00-0034449",
     "pff_id": 12888,
-    "espn_id": 3122716,
-    "yahoo_id": 31537
+    "sleeper_id": 5271,
+    "yahoo_id": 31537,
+    "pfr_id": "HoweGr00"
   },
   {
     "mfl_id": 13917,
-    "sleeper_id": 5193,
     "gsis_id": "00-0034591",
     "pff_id": 42781,
+    "sleeper_id": 5193,
+    "yahoo_id": 31650,
     "espn_id": 3121649,
-    "yahoo_id": 31650
+    "espn_id_new": 3121649
   },
   {
     "mfl_id": 13918,
-    "sleeper_id": 5388,
     "gsis_id": "00-0034071",
     "pff_id": 49379,
+    "sleeper_id": 5388,
+    "yahoo_id": 31402,
     "espn_id": 3141066,
-    "yahoo_id": 31402
+    "espn_id_new": 3141066
   },
   {
     "mfl_id": 13919,
-    "sleeper_id": 4435,
-    "pfr_id": "FirkAn00",
     "gsis_id": "00-0033455",
     "pff_id": 51837,
+    "sleeper_id": 4435,
+    "espn_id": 3049698,
+    "pfr_id": "FirkAn00",
     "ras_id": 13195,
-    "otc_id": 6071
+    "otc_id": 6071,
+    "espn_id_new": 3049698
   },
   {
     "mfl_id": 13920,
-    "sleeper_id": 5493,
     "gsis_id": "00-0034573",
     "pff_id": 43034,
+    "sleeper_id": 5493,
+    "yahoo_id": 31293,
     "espn_id": 4037361,
-    "yahoo_id": 31293
+    "espn_id_new": 4037361
   },
   {
     "mfl_id": 13921,
-    "sleeper_id": 4442,
     "gsis_id": "00-0033438",
     "pff_id": 12246,
-    "espn_id": 2981846,
+    "sleeper_id": 4442,
     "yahoo_id": 30626
   },
   {
     "mfl_id": 13922,
-    "sleeper_id": 5613,
-    "pfr_id": "HectBr00",
     "gsis_id": "00-0034461",
     "pff_id": 48759,
-    "espn_id": 3051369,
-    "yahoo_id": 31572
+    "sleeper_id": 5613,
+    "yahoo_id": 31572,
+    "pfr_id": "HectBr00"
   },
   {
     "mfl_id": 13923,
-    "sleeper_id": 5183,
-    "pfr_id": "AdenOl00",
     "gsis_id": "00-0034204",
     "pff_id": 50154,
-    "espn_id": 3126081,
-    "yahoo_id": 31484
+    "sleeper_id": 5183,
+    "yahoo_id": 31484,
+    "pfr_id": "AdenOl00"
   },
   {
     "mfl_id": 13924,
-    "sleeper_id": 4350,
     "gsis_id": "00-0033374",
     "pff_id": 47053,
-    "espn_id": 2978244,
+    "sleeper_id": 4350,
     "yahoo_id": 30517
   },
   {
     "mfl_id": 13926,
-    "sleeper_id": 5753,
-    "pfr_id": "BoarCh00",
     "gsis_id": "00-0034787",
     "pff_id": 29456,
+    "sleeper_id": 5753,
+    "yahoo_id": 31750,
     "espn_id": 3060403,
-    "yahoo_id": 31750
+    "pfr_id": "BoarCh00",
+    "espn_id_new": 3060403
   },
   {
     "mfl_id": 13927,
-    "sleeper_id": 5615,
     "gsis_id": "00-0034657",
     "pff_id": 49601,
+    "sleeper_id": 5615,
+    "yahoo_id": 31612,
     "espn_id": 3134316,
-    "yahoo_id": 31612
+    "espn_id_new": 3134316
   },
   {
     "mfl_id": 13928,
-    "sleeper_id": 5159,
-    "pfr_id": "NichDe00",
     "gsis_id": "00-0034481",
     "pff_id": 50381,
-    "espn_id": 3126311,
-    "yahoo_id": 31314
+    "sleeper_id": 5159,
+    "yahoo_id": 31314,
+    "pfr_id": "NichDe00"
   },
   {
     "mfl_id": 13929,
-    "sleeper_id": 2796,
     "gsis_id": "00-0031500",
     "pff_id": 10235,
+    "sleeper_id": 2796,
+    "yahoo_id": 28386,
     "espn_id": 3734467,
-    "yahoo_id": 28386
+    "espn_id_new": 3734467
   },
   {
     "mfl_id": 13930,
-    "sleeper_id": 5161,
-    "pfr_id": "TurnZe00",
     "gsis_id": "00-0034490",
     "pff_id": 49167,
+    "sleeper_id": 5161,
+    "yahoo_id": 31324,
     "espn_id": 3894901,
-    "yahoo_id": 31324
+    "pfr_id": "TurnZe00",
+    "espn_id_new": 3894901
   },
   {
     "mfl_id": 13931,
-    "sleeper_id": 5494,
     "gsis_id": "00-0034569",
     "pff_id": 51402,
-    "espn_id": 3052080,
+    "sleeper_id": 5494,
     "yahoo_id": 31296
   },
   {
     "mfl_id": 13932,
-    "sleeper_id": 5147,
-    "pfr_id": "ElleEm00",
     "gsis_id": "00-0034139",
     "pff_id": 50893,
-    "espn_id": 3123863,
-    "yahoo_id": 31356
+    "sleeper_id": 5147,
+    "yahoo_id": 31356,
+    "pfr_id": "ElleEm00"
   },
   {
     "mfl_id": 13933,
-    "sleeper_id": 5226,
-    "pfr_id": "FordPo00",
     "gsis_id": "00-0034234",
     "pff_id": 48875,
+    "sleeper_id": 5226,
+    "yahoo_id": 31477,
     "espn_id": 3125114,
-    "yahoo_id": 31477
+    "pfr_id": "FordPo00",
+    "espn_id_new": 3125114
   },
   {
     "mfl_id": 13934,
-    "sleeper_id": 5416,
-    "pfr_id": "FacyBr00",
     "gsis_id": "00-0034545",
     "pff_id": 50564,
+    "sleeper_id": 5416,
+    "yahoo_id": 31676,
     "espn_id": 3045458,
-    "yahoo_id": 31676
+    "pfr_id": "FacyBr00",
+    "espn_id_new": 3045458
   },
   {
     "mfl_id": 13935,
-    "sleeper_id": 4501,
     "gsis_id": "00-0033501",
     "pff_id": 12222,
-    "espn_id": 3121581,
+    "sleeper_id": 4501,
     "yahoo_id": 30412
   },
   {
     "mfl_id": 13936,
-    "sleeper_id": 4619,
     "gsis_id": "00-0033779",
     "pff_id": 21515,
-    "espn_id": 2973647,
+    "sleeper_id": 4619,
     "yahoo_id": 30794
   },
   {
     "mfl_id": 13937,
-    "sleeper_id": 5141,
-    "pfr_id": "CrawJa01",
     "gsis_id": "00-0034881",
     "pff_id": 49836,
-    "espn_id": 3042445,
-    "yahoo_id": 31785
+    "sleeper_id": 5141,
+    "yahoo_id": 31785,
+    "pfr_id": "CrawJa01"
   },
   {
     "mfl_id": 13938,
-    "sleeper_id": 5545,
-    "pfr_id": "GreeRa02",
     "gsis_id": "00-0034179",
     "pff_id": 24750,
-    "espn_id": 3049331,
-    "yahoo_id": 31433
+    "sleeper_id": 5545,
+    "yahoo_id": 31433,
+    "pfr_id": "GreeRa02"
   },
   {
     "mfl_id": 13939,
-    "sleeper_id": 5445,
-    "pfr_id": "OdumGe00",
     "gsis_id": "00-0034091",
     "pff_id": 31342,
+    "sleeper_id": 5445,
+    "yahoo_id": 31373,
     "espn_id": 3050199,
-    "yahoo_id": 31373
+    "pfr_id": "OdumGe00",
+    "espn_id_new": 3050199
   },
   {
     "mfl_id": 13940,
-    "sleeper_id": 4314,
-    "pfr_id": "MundJo00",
     "gsis_id": "00-0033246",
-    "pff_id": 12206
+    "pff_id": 12206,
+    "sleeper_id": 4314,
+    "espn_id": 3052096,
+    "pfr_id": "MundJo00",
+    "espn_id_new": 3052096
   },
   {
     "mfl_id": 13941,
-    "sleeper_id": 5191,
     "gsis_id": "00-0034325",
     "pff_id": 48935,
-    "espn_id": 3126489,
+    "sleeper_id": 5191,
     "yahoo_id": 31526
   },
   {
     "mfl_id": 13942,
-    "sleeper_id": 5452,
-    "pfr_id": "GrayJ.00",
     "gsis_id": "00-0034116",
     "pff_id": 51495,
+    "sleeper_id": 5452,
+    "yahoo_id": 31411,
     "espn_id": 3115481,
-    "yahoo_id": 31411
+    "pfr_id": "GrayJ.00",
+    "espn_id_new": 3115481
   },
   {
     "mfl_id": 13943,
-    "sleeper_id": 5646,
-    "pfr_id": "DaviTa00",
     "gsis_id": "00-0034500",
     "pff_id": 26296,
+    "sleeper_id": 5646,
+    "yahoo_id": 31552,
     "espn_id": 3131775,
-    "yahoo_id": 31552
+    "pfr_id": "DaviTa00",
+    "espn_id_new": 3131775
   },
   {
     "mfl_id": 13944,
-    "sleeper_id": 3837,
     "gsis_id": "00-0032931",
     "pff_id": 11352,
-    "espn_id": 3140596,
+    "sleeper_id": 3837,
     "yahoo_id": 29956
   },
   {
     "mfl_id": 13945,
-    "sleeper_id": 5214,
-    "pfr_id": "HillHo00",
     "gsis_id": "00-0034213",
     "pff_id": 50414,
-    "espn_id": 3929847,
-    "yahoo_id": 31233
+    "sleeper_id": 5214,
+    "yahoo_id": 31233,
+    "pfr_id": "HillHo00"
   },
   {
     "mfl_id": 13946,
-    "sleeper_id": 5629,
     "gsis_id": "00-0034603",
     "pff_id": 49348,
-    "espn_id": 3843234,
+    "sleeper_id": 5629,
     "yahoo_id": 31667
   },
   {
     "mfl_id": 13952,
-    "sleeper_id": 5580,
-    "pfr_id": "LuvuFr00",
     "gsis_id": "00-0034302",
     "pff_id": 51028,
+    "sleeper_id": 5580,
+    "yahoo_id": 31503,
     "espn_id": 3127273,
-    "yahoo_id": 31503
+    "pfr_id": "LuvuFr00",
+    "espn_id_new": 3127273
   },
   {
     "mfl_id": 13953,
-    "sleeper_id": 5519,
-    "pfr_id": "ThomTa01",
     "gsis_id": "00-0034488",
     "pff_id": 66931,
+    "sleeper_id": 5519,
+    "yahoo_id": 31321,
     "espn_id": 4334405,
-    "yahoo_id": 31321
+    "pfr_id": "ThomTa01",
+    "espn_id_new": 4334405
   },
   {
     "mfl_id": 13954,
-    "sleeper_id": 5669,
-    "pfr_id": "FincSh00",
     "gsis_id": "00-0034659",
     "pff_id": 50221,
-    "espn_id": 3051333,
-    "yahoo_id": 31615
+    "sleeper_id": 5669,
+    "yahoo_id": 31615,
+    "pfr_id": "FincSh00"
   },
   {
     "mfl_id": 13955,
-    "sleeper_id": 5662,
-    "pfr_id": "MoorA.00",
     "gsis_id": "00-0034594",
     "pff_id": 51146,
-    "espn_id": 3128746,
-    "yahoo_id": 31652
+    "sleeper_id": 5662,
+    "yahoo_id": 31652,
+    "pfr_id": "MoorA.00"
   },
   {
     "mfl_id": 13956,
-    "sleeper_id": 5178,
-    "pfr_id": "ChanSe00",
     "gsis_id": "00-0034496",
     "pff_id": 51315,
-    "espn_id": 3138733,
-    "yahoo_id": 31548
+    "sleeper_id": 5178,
+    "yahoo_id": 31548,
+    "pfr_id": "ChanSe00"
   },
   {
     "mfl_id": 13958,
-    "sleeper_id": 5464,
-    "pfr_id": "TurnDe01",
     "gsis_id": "00-0034201",
     "pff_id": 25681,
-    "espn_id": 3928461,
-    "yahoo_id": 31425
+    "sleeper_id": 5464,
+    "yahoo_id": 31425,
+    "pfr_id": "TurnDe01"
   },
   {
     "mfl_id": 13959,
-    "sleeper_id": 5526,
-    "pfr_id": "WillDa09",
     "gsis_id": "00-0034203",
     "pff_id": 55724,
+    "sleeper_id": 5526,
+    "yahoo_id": 31422,
     "espn_id": 4239833,
-    "yahoo_id": 31422
+    "pfr_id": "WillDa09",
+    "espn_id_new": 4239833
   },
   {
     "mfl_id": 13961,
-    "sleeper_id": 5619,
-    "pfr_id": "DawkDa01",
     "gsis_id": "00-0034654",
     "pff_id": 39541,
-    "espn_id": 3052449,
-    "yahoo_id": 31620
+    "sleeper_id": 5619,
+    "yahoo_id": 31620,
+    "pfr_id": "DawkDa01"
   },
   {
     "mfl_id": 13963,
-    "sleeper_id": 5773,
-    "pfr_id": "HodgKh00",
     "gsis_id": "00-0034854",
     "pff_id": 26104,
+    "sleeper_id": 5773,
+    "yahoo_id": 31769,
     "espn_id": 3047876,
-    "yahoo_id": 31769
+    "pfr_id": "HodgKh00",
+    "espn_id_new": 3047876
   },
   {
     "mfl_id": 13964,
-    "sleeper_id": 4529,
     "gsis_id": "00-0033608",
     "pff_id": 12017,
-    "espn_id": 2970264,
+    "sleeper_id": 4529,
     "yahoo_id": 30491
   },
   {
     "mfl_id": 13965,
-    "sleeper_id": 4371,
-    "pfr_id": "TupoJo00",
     "gsis_id": "00-0033347",
     "pff_id": 12093,
+    "sleeper_id": 4371,
+    "yahoo_id": 30586,
     "espn_id": 2979632,
-    "yahoo_id": 30586
+    "pfr_id": "TupoJo00",
+    "espn_id_new": 2979632
   },
   {
     "mfl_id": 13966,
-    "sleeper_id": 2885,
-    "pfr_id": "DaniRo01",
     "gsis_id": "00-0031878",
     "pff_id": 9974,
-    "espn_id": 3053794,
-    "yahoo_id": 28959
+    "sleeper_id": 2885,
+    "yahoo_id": 28959,
+    "pfr_id": "DaniRo01"
   },
   {
     "mfl_id": 13968,
-    "sleeper_id": 4464,
-    "pfr_id": "MullNi00",
     "gsis_id": "00-0033319",
     "pff_id": 12282,
+    "sleeper_id": 4464,
+    "espn_id": 3059989,
+    "pfr_id": "MullNi00",
     "ras_id": 14656,
-    "otc_id": 6007
+    "otc_id": 6007,
+    "espn_id_new": 3059989
   },
   {
     "mfl_id": 13969,
-    "sleeper_id": 5175,
-    "pfr_id": "DaviJa07",
     "gsis_id": "00-0034499",
     "pff_id": 22489,
-    "espn_id": 3066147,
-    "yahoo_id": 31551
+    "sleeper_id": 5175,
+    "yahoo_id": 31551,
+    "pfr_id": "DaviJa07"
   },
   {
     "mfl_id": 13970,
-    "sleeper_id": 5424,
     "gsis_id": "00-0034540",
     "pff_id": 49255,
+    "sleeper_id": 5424,
+    "yahoo_id": 31671,
     "espn_id": 3115308,
-    "yahoo_id": 31671
+    "espn_id_new": 3115308
   },
   {
     "mfl_id": 13971,
-    "sleeper_id": 5418,
-    "pfr_id": "HineDJ00",
     "gsis_id": "00-0034548",
     "pff_id": 27390,
-    "espn_id": 3040024,
-    "yahoo_id": 31679
+    "sleeper_id": 5418,
+    "yahoo_id": 31679,
+    "pfr_id": "HineDJ00"
   },
   {
     "mfl_id": 13973,
-    "sleeper_id": 5188,
-    "pfr_id": "MeekQu00",
     "gsis_id": "00-0034523",
     "pff_id": 38566,
-    "espn_id": 3931400,
-    "yahoo_id": 31270
+    "sleeper_id": 5188,
+    "yahoo_id": 31270,
+    "pfr_id": "MeekQu00"
   },
   {
     "mfl_id": 13978,
-    "sleeper_id": 5756,
-    "pfr_id": "DickGa00",
     "gsis_id": "00-0034795",
     "pff_id": 47268,
-    "espn_id": 3116132,
-    "yahoo_id": 31751
+    "sleeper_id": 5756,
+    "yahoo_id": 31751,
+    "pfr_id": "DickGa00"
   },
   {
     "mfl_id": 13980,
-    "sleeper_id": 5230,
     "gsis_id": "00-0034084",
+    "sleeper_id": 5230,
+    "yahoo_id": 31366,
     "espn_id": 3123052,
-    "yahoo_id": 31366
+    "espn_id_new": 3123052
   },
   {
     "mfl_id": 13982,
-    "sleeper_id": 5601,
-    "pfr_id": "PittJa00",
     "gsis_id": "00-0034454",
     "pff_id": 50036,
-    "espn_id": 3128455,
-    "yahoo_id": 31542
+    "sleeper_id": 5601,
+    "yahoo_id": 31542,
+    "pfr_id": "PittJa00"
   },
   {
     "mfl_id": 13987,
-    "sleeper_id": 5726,
-    "pfr_id": "SpilRo00",
     "gsis_id": "00-0034720",
     "pff_id": 50918,
+    "sleeper_id": 5726,
+    "yahoo_id": 31708,
     "espn_id": 3129446,
-    "yahoo_id": 31708
+    "pfr_id": "SpilRo00",
+    "espn_id_new": 3129446
   },
   {
     "mfl_id": 13988,
-    "sleeper_id": 5285,
-    "pfr_id": "DwelRo00",
     "gsis_id": "00-0034073",
     "pff_id": 20994,
+    "sleeper_id": 5285,
+    "espn_id": 3120303,
+    "pfr_id": "DwelRo00",
     "ras_id": 16947,
-    "otc_id": 7561
+    "otc_id": 7561,
+    "espn_id_new": 3120303
   },
   {
     "mfl_id": 13989,
-    "sleeper_id": 5483,
-    "pfr_id": "LancTy00",
     "gsis_id": "00-0034185",
     "pff_id": 48604,
-    "espn_id": 3045242,
-    "yahoo_id": 31436
+    "sleeper_id": 5483,
+    "yahoo_id": 31436,
+    "pfr_id": "LancTy00"
   },
   {
     "mfl_id": 13990,
-    "sleeper_id": 5166,
-    "pfr_id": "ScotDa02",
     "gsis_id": "00-0034256",
     "pff_id": 39588,
-    "espn_id": 3056577,
-    "yahoo_id": 31460
+    "sleeper_id": 5166,
+    "yahoo_id": 31460,
+    "pfr_id": "ScotDa02"
   },
   {
     "mfl_id": 13991,
-    "sleeper_id": 5279,
-    "pfr_id": "HendQu00",
     "gsis_id": "00-0034206",
     "pff_id": 48008,
-    "espn_id": 3895789,
-    "yahoo_id": 31486
+    "sleeper_id": 5279,
+    "yahoo_id": 31486,
+    "pfr_id": "HendQu00"
   },
   {
     "mfl_id": 13993,
-    "sleeper_id": 5670,
     "gsis_id": "00-0034655",
     "pff_id": 23189,
-    "espn_id": 3060410,
+    "sleeper_id": 5670,
     "yahoo_id": 31614
   },
   {
     "mfl_id": 13994,
-    "sleeper_id": 4443,
-    "pfr_id": "BrowPh01",
     "gsis_id": "00-0033439",
     "pff_id": 12247,
+    "sleeper_id": 4443,
+    "espn_id": 2971281,
+    "pfr_id": "BrowPh01",
     "ras_id": 14715,
-    "otc_id": 6080
+    "otc_id": 6080,
+    "espn_id_new": 2971281
   },
   {
     "mfl_id": 13995,
-    "sleeper_id": 5253,
     "gsis_id": "00-0034532",
     "pff_id": 47206,
-    "espn_id": 3128439,
+    "sleeper_id": 5253,
     "yahoo_id": 31561
   },
   {
     "mfl_id": 13996,
-    "sleeper_id": 5647,
-    "pfr_id": "HaleGr00",
     "gsis_id": "00-0034502",
     "pff_id": 50473,
-    "espn_id": 3116166,
-    "yahoo_id": 31555
+    "sleeper_id": 5647,
+    "yahoo_id": 31555,
+    "pfr_id": "HaleGr00"
   },
   {
     "mfl_id": 13998,
-    "sleeper_id": 5436,
     "gsis_id": "00-0034096",
     "pff_id": 50430,
+    "sleeper_id": 5436,
+    "yahoo_id": 31386,
     "espn_id": 3115337,
-    "yahoo_id": 31386
+    "espn_id_new": 3115337
   },
   {
     "mfl_id": 13999,
-    "sleeper_id": 5570,
-    "pfr_id": "BeebCh00",
     "gsis_id": "00-0034309",
     "pff_id": 21528,
+    "sleeper_id": 5570,
+    "pfr_id": "BeebCh00",
     "ras_id": 15494,
     "otc_id": 7453
   },
   {
     "mfl_id": 14002,
-    "sleeper_id": 3469,
     "gsis_id": "00-0032751",
     "pff_id": 10938,
-    "espn_id": 2971032,
+    "sleeper_id": 3469,
     "yahoo_id": 29584
   },
   {
     "mfl_id": 14009,
-    "sleeper_id": 5135,
-    "pfr_id": "BlacSa00",
     "gsis_id": "00-0034170",
     "pff_id": 48088,
-    "espn_id": 3116155,
-    "yahoo_id": 31479
+    "sleeper_id": 5135,
+    "yahoo_id": 31479,
+    "pfr_id": "BlacSa00"
   },
   {
     "mfl_id": 14010,
-    "sleeper_id": 4527,
     "gsis_id": "00-0033606",
     "pff_id": 12016,
-    "espn_id": 3045851,
+    "sleeper_id": 4527,
     "yahoo_id": 30489
   },
   {
     "mfl_id": 14011,
-    "sleeper_id": 5220,
-    "pfr_id": "IgweGo00",
     "gsis_id": "00-0034614",
-    "pff_id": 49166
+    "pff_id": 49166,
+    "sleeper_id": 5220,
+    "espn_id": 3045238,
+    "pfr_id": "IgweGo00",
+    "espn_id_new": 3045238
   },
   {
     "mfl_id": 14012,
-    "sleeper_id": 5691,
-    "pfr_id": "FordMi01",
     "gsis_id": "00-0034639",
     "pff_id": 50535,
+    "sleeper_id": 5691,
+    "yahoo_id": 31634,
     "espn_id": 3050916,
-    "yahoo_id": 31634
+    "pfr_id": "FordMi01",
+    "espn_id_new": 3050916
   },
   {
     "mfl_id": 14013,
-    "sleeper_id": 5181,
-    "pfr_id": "SullCh00",
     "gsis_id": "00-0034468",
     "pff_id": 49349,
-    "espn_id": 3124849,
-    "yahoo_id": 31589
+    "sleeper_id": 5181,
+    "yahoo_id": 31589,
+    "pfr_id": "SullCh00"
   },
   {
     "mfl_id": 14015,
-    "sleeper_id": 5383,
-    "pfr_id": "TollJa00",
     "gsis_id": "00-0034489",
     "pff_id": 66933,
-    "espn_id": 4329491,
-    "yahoo_id": 31322
+    "sleeper_id": 5383,
+    "yahoo_id": 31322,
+    "pfr_id": "TollJa00"
   },
   {
     "mfl_id": 14016,
-    "sleeper_id": 5680,
-    "pfr_id": "ThomCo02",
     "gsis_id": "00-0034539",
     "pff_id": 18551,
-    "espn_id": 2976524,
-    "yahoo_id": 31597
+    "sleeper_id": 5680,
+    "yahoo_id": 31597,
+    "pfr_id": "ThomCo02"
   },
   {
     "mfl_id": 14017,
-    "sleeper_id": 5284,
-    "pfr_id": "WilsJe01",
     "gsis_id": "00-0034115",
     "pff_id": 29413,
+    "sleeper_id": 5284,
+    "espn_id": 3122976,
+    "pfr_id": "WilsJe01",
     "ras_id": 16207,
-    "otc_id": 7633
+    "otc_id": 7633,
+    "espn_id_new": 3122976
   },
   {
     "mfl_id": 14024,
-    "sleeper_id": 5658,
     "gsis_id": "00-0034515",
     "pff_id": 31078,
+    "sleeper_id": 5658,
+    "yahoo_id": 31261,
     "espn_id": 3049726,
-    "yahoo_id": 31261
+    "espn_id_new": 3049726
   },
   {
     "mfl_id": 14026,
-    "sleeper_id": 5671,
     "gsis_id": "00-0034662",
     "pff_id": 51203,
-    "espn_id": 3116105,
+    "sleeper_id": 5671,
     "yahoo_id": 31609
   },
   {
     "mfl_id": 14027,
-    "sleeper_id": 5583,
     "gsis_id": "00-0034310",
     "pff_id": 26360,
-    "espn_id": 3116058,
+    "sleeper_id": 5583,
     "yahoo_id": 31509
   },
   {
     "mfl_id": 14028,
-    "sleeper_id": 5655,
     "gsis_id": "00-0034527",
     "pff_id": 49132,
-    "espn_id": 3121344,
+    "sleeper_id": 5655,
     "yahoo_id": 31576
   },
   {
     "mfl_id": 14029,
-    "sleeper_id": 5624,
-    "pfr_id": "FordKe00",
     "gsis_id": "00-0034509",
     "pff_id": 23614,
-    "espn_id": 3052662,
-    "yahoo_id": 31595
+    "sleeper_id": 5624,
+    "yahoo_id": 31595,
+    "pfr_id": "FordKe00"
   },
   {
     "mfl_id": 14032,
-    "sleeper_id": 5623,
-    "pfr_id": "LoveMi00",
     "gsis_id": "00-0034511",
     "pff_id": 48376,
-    "espn_id": 3051371,
-    "yahoo_id": 31605
+    "sleeper_id": 5623,
+    "yahoo_id": 31605,
+    "pfr_id": "LoveMi00"
   },
   {
     "mfl_id": 14034,
-    "sleeper_id": 5641,
-    "pfr_id": "WorlCh00",
     "gsis_id": "00-0034537",
     "pff_id": 51161,
-    "espn_id": 3051412,
-    "yahoo_id": 31566
+    "sleeper_id": 5641,
+    "yahoo_id": 31566,
+    "pfr_id": "WorlCh00"
   },
   {
     "mfl_id": 14035,
-    "sleeper_id": 5259,
-    "pfr_id": "ColeLa02",
     "gsis_id": "00-0034624",
     "pff_id": 45861,
-    "espn_id": 3052163,
-    "yahoo_id": 31575
+    "sleeper_id": 5259,
+    "yahoo_id": 31575,
+    "pfr_id": "ColeLa02"
   },
   {
     "mfl_id": 14037,
-    "sleeper_id": 5222,
-    "pfr_id": "DaviJa06",
     "gsis_id": "00-0034446",
     "pff_id": 50431,
-    "espn_id": 3125356,
-    "yahoo_id": 31534
+    "sleeper_id": 5222,
+    "yahoo_id": 31534,
+    "pfr_id": "DaviJa06"
   },
   {
     "mfl_id": 14038,
-    "sleeper_id": 5659,
     "gsis_id": "00-0034586",
     "pff_id": 49918,
-    "espn_id": 3043127,
+    "sleeper_id": 5659,
     "yahoo_id": 31647
   },
   {
     "mfl_id": 14039,
-    "sleeper_id": 5581,
-    "pfr_id": "WintAn00",
     "gsis_id": "00-0034303",
     "pff_id": 51015,
-    "espn_id": 3128853,
-    "yahoo_id": 31504
+    "sleeper_id": 5581,
+    "yahoo_id": 31504,
+    "pfr_id": "WintAn00"
   },
   {
     "mfl_id": 14043,
-    "sleeper_id": 5736,
-    "pfr_id": "LeavDa00",
     "gsis_id": "00-0034726",
     "pff_id": 49120,
+    "sleeper_id": 5736,
+    "yahoo_id": 31723,
     "espn_id": 3053801,
-    "yahoo_id": 31723
+    "pfr_id": "LeavDa00",
+    "espn_id_new": 3053801
   },
   {
     "mfl_id": 14045,
-    "sleeper_id": 5661,
-    "pfr_id": "LacyCh00",
     "gsis_id": "00-0034593",
     "pff_id": 29726,
-    "espn_id": 3122430,
-    "yahoo_id": 31651
+    "sleeper_id": 5661,
+    "yahoo_id": 31651,
+    "pfr_id": "LacyCh00"
   },
   {
     "mfl_id": 14046,
-    "sleeper_id": 5722,
-    "pfr_id": "KidsDa00",
     "gsis_id": "00-0034710",
     "pff_id": 23254,
-    "espn_id": 3051650,
-    "yahoo_id": 31722
+    "sleeper_id": 5722,
+    "yahoo_id": 31722,
+    "pfr_id": "KidsDa00"
   },
   {
     "mfl_id": 14060,
-    "sleeper_id": 6040,
     "gsis_id": "00-0035356",
     "pff_id": 46481,
+    "sleeper_id": 6040,
+    "yahoo_id": 32415,
     "espn_id": 3916564,
-    "yahoo_id": 32415
+    "espn_id_new": 3916564
   },
   {
     "mfl_id": 14065,
-    "sleeper_id": 6037,
     "gsis_id": "00-0034955",
     "pff_id": 46487,
-    "espn_id": 3722362,
+    "sleeper_id": 6037,
     "yahoo_id": 32221
   },
   {
     "mfl_id": 14066,
-    "sleeper_id": 6269,
     "gsis_id": "00-0035163",
     "pff_id": 29110,
-    "espn_id": 3915776,
+    "sleeper_id": 6269,
     "yahoo_id": 32366
   },
   {
     "mfl_id": 14070,
-    "sleeper_id": 6450,
-    "pfr_id": "BlouDa00",
     "gsis_id": "00-0035040",
     "pff_id": 46508,
-    "espn_id": 3116188,
-    "yahoo_id": 32272
+    "sleeper_id": 6450,
+    "yahoo_id": 32272,
+    "pfr_id": "BlouDa00"
   },
   {
     "mfl_id": 14072,
-    "sleeper_id": 6156
+    "sleeper_id": 6156,
+    "espn_id": 4035072,
+    "espn_id_new": 4035072
   },
   {
     "mfl_id": 14078,
-    "sleeper_id": 5976,
     "gsis_id": "00-0035454",
     "pff_id": 38565,
-    "espn_id": 3929927,
+    "sleeper_id": 5976,
     "yahoo_id": 32508
   },
   {
     "mfl_id": 14084,
-    "sleeper_id": 5919,
     "gsis_id": "00-0035442",
     "pff_id": 40065,
-    "espn_id": 4035006,
+    "sleeper_id": 5919,
     "yahoo_id": 32148
   },
   {
     "mfl_id": 14089,
-    "sleeper_id": 6021,
     "gsis_id": "00-0034961",
     "pff_id": 35314,
-    "espn_id": 3843406,
+    "sleeper_id": 6021,
     "yahoo_id": 32226
   },
   {
     "mfl_id": 14092,
-    "sleeper_id": 5961,
     "gsis_id": "00-0035505",
-    "espn_id": 3123675,
+    "sleeper_id": 5961,
     "yahoo_id": 32528
   },
   {
     "mfl_id": 14096,
-    "sleeper_id": 6068,
-    "pfr_id": "OzigDe01",
     "gsis_id": "00-0035184",
     "pff_id": 45903,
+    "sleeper_id": 6068,
+    "yahoo_id": 32390,
     "espn_id": 3699935,
-    "yahoo_id": 32390
+    "pfr_id": "OzigDe01",
+    "espn_id_new": 3699935
   },
   {
     "mfl_id": 14098,
-    "sleeper_id": 6334,
-    "pfr_id": "CrocDa01",
     "gsis_id": "00-0035448",
-    "pff_id": 27436
+    "pff_id": 27436,
+    "sleeper_id": 6334,
+    "pfr_id": "CrocDa01"
   },
   {
     "mfl_id": 14099,
-    "sleeper_id": 6448,
     "gsis_id": "00-0035043",
     "pff_id": 45989,
-    "espn_id": 3895788,
+    "sleeper_id": 6448,
     "yahoo_id": 32279
   },
   {
     "mfl_id": 14108,
-    "sleeper_id": 5970,
-    "pfr_id": "DortGr01",
     "gsis_id": "00-0035500",
     "pff_id": 42237,
+    "sleeper_id": 5970,
+    "yahoo_id": 32523,
     "espn_id": 4037235,
-    "yahoo_id": 32523
+    "pfr_id": "DortGr01",
+    "espn_id_new": 4037235
   },
   {
     "mfl_id": 14110,
-    "sleeper_id": 6154,
     "gsis_id": "00-0035359",
     "pff_id": 34579,
-    "espn_id": 3871102,
+    "sleeper_id": 6154,
     "yahoo_id": 32418
   },
   {
     "mfl_id": 14111,
-    "sleeper_id": 6017,
     "gsis_id": "00-0035475",
     "pff_id": 47858,
-    "espn_id": 3930064,
+    "sleeper_id": 6017,
     "yahoo_id": 32483
   },
   {
     "mfl_id": 14115,
-    "sleeper_id": 5924,
     "gsis_id": "00-0035070",
     "pff_id": 39533,
-    "espn_id": 3924318,
+    "sleeper_id": 5924,
     "yahoo_id": 32253
   },
   {
     "mfl_id": 14117,
-    "sleeper_id": 6063,
-    "pfr_id": "JohnTy03",
     "gsis_id": "00-0035457",
     "pff_id": 34427,
+    "sleeper_id": 6063,
+    "pfr_id": "JohnTy03",
     "ras_id": 19874,
     "otc_id": 8331
   },
   {
     "mfl_id": 14118,
-    "sleeper_id": 5938,
-    "pfr_id": "HumpLi01",
     "gsis_id": "00-0035406",
     "pff_id": 42247,
+    "sleeper_id": 5938,
+    "pfr_id": "HumpLi01",
     "ras_id": 19870,
     "otc_id": 8357
   },
   {
     "mfl_id": 14119,
-    "sleeper_id": 5929,
     "gsis_id": "00-0035474",
     "pff_id": 41706,
-    "espn_id": 4049301,
+    "sleeper_id": 5929,
     "yahoo_id": 32482
   },
   {
     "mfl_id": 14126,
-    "sleeper_id": 6148,
-    "pfr_id": "WillPr01",
     "gsis_id": "00-0035350",
     "pff_id": 38855,
+    "sleeper_id": 6148,
+    "espn_id": 3915399,
+    "pfr_id": "WillPr01",
     "ras_id": 17696,
-    "otc_id": 8257
+    "otc_id": 8257,
+    "espn_id_new": 3915399
   },
   {
     "mfl_id": 14127,
-    "sleeper_id": 5947,
-    "pfr_id": "MeyeJa01",
     "gsis_id": "00-0034960",
     "pff_id": 47468,
+    "sleeper_id": 5947,
+    "espn_id": 3916433,
+    "pfr_id": "MeyeJa01",
     "ras_id": 19857,
-    "otc_id": 8083
+    "otc_id": 8083,
+    "espn_id_new": 3916433
   },
   {
     "mfl_id": 14128,
-    "sleeper_id": 6049,
     "gsis_id": "00-0035361",
     "pff_id": 41818,
-    "espn_id": 3123074,
+    "sleeper_id": 6049,
     "yahoo_id": 32088
   },
   {
     "mfl_id": 14130,
-    "sleeper_id": 6165,
     "gsis_id": "00-0035126",
     "pff_id": 39967,
-    "espn_id": 4043161,
+    "sleeper_id": 6165,
     "yahoo_id": 32317
   },
   {
     "mfl_id": 14131,
-    "sleeper_id": 6069,
-    "pfr_id": "MorgSt02",
     "gsis_id": "00-0035399",
     "pff_id": 48110,
+    "sleeper_id": 6069,
+    "espn_id": 3699902,
+    "pfr_id": "MorgSt02",
     "ras_id": 17683,
-    "otc_id": 8316
+    "otc_id": 8316,
+    "espn_id_new": 3699902
   },
   {
     "mfl_id": 14132,
@@ -4685,26 +4533,23 @@
   },
   {
     "mfl_id": 14134,
-    "sleeper_id": 6019,
     "gsis_id": "00-0035450",
     "pff_id": 47912,
-    "espn_id": 3121413,
+    "sleeper_id": 6019,
     "yahoo_id": 32504
   },
   {
     "mfl_id": 14165,
-    "sleeper_id": 6134,
     "gsis_id": "00-0035128",
     "pff_id": 27584,
-    "espn_id": 3115258,
+    "sleeper_id": 6134,
     "yahoo_id": 32308
   },
   {
     "mfl_id": 14172,
-    "sleeper_id": 6020,
     "gsis_id": "00-0035115",
     "pff_id": 49887,
-    "espn_id": 3862861,
+    "sleeper_id": 6020,
     "yahoo_id": 32340
   },
   {
@@ -4713,26 +4558,23 @@
   },
   {
     "mfl_id": 14188,
-    "sleeper_id": 5760,
     "gsis_id": "00-0034819",
     "pff_id": 68149,
-    "espn_id": 4350798,
+    "sleeper_id": 5760,
     "yahoo_id": 31758
   },
   {
     "mfl_id": 14189,
-    "sleeper_id": 3568,
     "gsis_id": "00-0032609",
     "pff_id": 10980,
-    "espn_id": 2591718,
+    "sleeper_id": 3568,
     "yahoo_id": 29540
   },
   {
     "mfl_id": 14190,
-    "sleeper_id": 2650,
     "gsis_id": "00-0031543",
     "pff_id": 9728,
-    "espn_id": 2582324,
+    "sleeper_id": 2650,
     "yahoo_id": 28861
   },
   {
@@ -4741,1784 +4583,1732 @@
   },
   {
     "mfl_id": 14193,
-    "sleeper_id": 3420,
     "gsis_id": "00-0032550",
     "pff_id": 11114,
-    "espn_id": 2980238,
+    "sleeper_id": 3420,
     "yahoo_id": 29710
   },
   {
     "mfl_id": 14194,
-    "sleeper_id": 6196,
     "gsis_id": "00-0035728",
     "pff_id": 92925,
-    "espn_id": 4420894,
+    "sleeper_id": 6196,
     "yahoo_id": 31822
   },
   {
     "mfl_id": 14196,
-    "sleeper_id": 5709,
     "gsis_id": "00-0034737",
     "pff_id": 66453,
+    "sleeper_id": 5709,
+    "yahoo_id": 31734,
     "espn_id": 4290778,
-    "yahoo_id": 31734
+    "espn_id_new": 4290778
   },
   {
     "mfl_id": 14222,
-    "sleeper_id": 5959
+    "sleeper_id": 5959,
+    "espn_id": 3155647,
+    "espn_id_new": 3155647
   },
   {
     "mfl_id": 14305,
-    "sleeper_id": 6088,
-    "pfr_id": "JohnOl00",
     "gsis_id": "00-0035006",
     "pff_id": 47882,
+    "sleeper_id": 6088,
+    "pfr_id": "JohnOl00",
     "ras_id": 17863,
     "otc_id": 8038
   },
   {
     "mfl_id": 14313,
-    "sleeper_id": 6107,
     "gsis_id": "00-0034943",
     "pff_id": 48115,
-    "espn_id": 3119471,
+    "sleeper_id": 6107,
     "yahoo_id": 32211
   },
   {
     "mfl_id": 14315,
-    "sleeper_id": 6427,
-    "pfr_id": "DuliAs00",
     "gsis_id": "00-0035021",
     "pff_id": 91479,
+    "sleeper_id": 6427,
+    "espn_id": 4061956,
+    "pfr_id": "DuliAs00",
     "ras_id": 19854,
-    "otc_id": 8178
+    "otc_id": 8178,
+    "espn_id_new": 4061956
   },
   {
     "mfl_id": 14316,
-    "sleeper_id": 5902,
-    "pfr_id": "HartPe01",
     "gsis_id": "00-0035022",
     "pff_id": 13534,
+    "sleeper_id": 5902,
+    "espn_id": 3917546,
+    "pfr_id": "HartPe01",
     "ras_id": 19856,
-    "otc_id": 8179
+    "otc_id": 8179,
+    "espn_id_new": 3917546
   },
   {
     "mfl_id": 14317,
-    "sleeper_id": 6032,
-    "pfr_id": "DossKe00",
     "gsis_id": "00-0035120",
     "pff_id": 48143,
+    "sleeper_id": 6032,
+    "yahoo_id": 32342,
     "espn_id": 3120980,
-    "yahoo_id": 32342
+    "pfr_id": "DossKe00",
+    "espn_id_new": 3120980
   },
   {
     "mfl_id": 14318,
-    "sleeper_id": 5997,
     "gsis_id": "00-0035090",
     "pff_id": 47725,
-    "espn_id": 3843603,
+    "sleeper_id": 5997,
     "yahoo_id": 32338
   },
   {
     "mfl_id": 14319,
-    "sleeper_id": 6323,
     "gsis_id": "00-0034959",
     "pff_id": 47121,
+    "sleeper_id": 6323,
+    "yahoo_id": 32225,
     "espn_id": 3125107,
-    "yahoo_id": 32225
+    "espn_id_new": 3125107
   },
   {
     "mfl_id": 14320,
-    "sleeper_id": 5275,
     "gsis_id": "00-0034207",
     "pff_id": 48309,
-    "espn_id": 3053760,
+    "sleeper_id": 5275,
     "yahoo_id": 31227
   },
   {
     "mfl_id": 14321,
-    "sleeper_id": 6171,
     "gsis_id": "00-0035164",
     "pff_id": 48152,
+    "sleeper_id": 6171,
+    "yahoo_id": 32367,
     "espn_id": 3126115,
-    "yahoo_id": 32367
+    "espn_id_new": 3126115
   },
   {
     "mfl_id": 14322,
-    "sleeper_id": 5960,
-    "pfr_id": "EdwaTJ02",
     "gsis_id": "00-0035386",
     "pff_id": 30737,
+    "sleeper_id": 5960,
+    "yahoo_id": 32403,
     "espn_id": 3121544,
-    "yahoo_id": 32403
+    "pfr_id": "EdwaTJ02",
+    "espn_id_new": 3121544
   },
   {
     "mfl_id": 14323,
-    "sleeper_id": 3893,
     "gsis_id": "00-0033092",
     "pff_id": 11450,
-    "espn_id": 2989641,
+    "sleeper_id": 3893,
     "yahoo_id": 30063
   },
   {
     "mfl_id": 14324,
-    "sleeper_id": 6016,
     "gsis_id": "00-0035058",
     "pff_id": 35985,
-    "espn_id": 3932963,
+    "sleeper_id": 6016,
     "yahoo_id": 32261
   },
   {
     "mfl_id": 14325,
-    "sleeper_id": 6046,
     "gsis_id": "00-0034931",
     "pff_id": 49816,
-    "espn_id": 3133361,
+    "sleeper_id": 6046,
     "yahoo_id": 32190
   },
   {
     "mfl_id": 14326,
-    "sleeper_id": 5939,
     "gsis_id": "00-0035338",
     "pff_id": 39605,
-    "espn_id": 3922125,
+    "sleeper_id": 5939,
     "yahoo_id": 32434
   },
   {
     "mfl_id": 14327,
-    "sleeper_id": 6155,
     "gsis_id": "00-0035121",
     "pff_id": 47846,
-    "espn_id": 3916418,
+    "sleeper_id": 6155,
     "yahoo_id": 32302
   },
   {
     "mfl_id": 14328,
-    "sleeper_id": 6416,
-    "pfr_id": "WingAn01",
     "gsis_id": "00-0035378",
     "pff_id": 49268,
+    "sleeper_id": 6416,
+    "yahoo_id": 32105,
     "espn_id": 3918331,
-    "yahoo_id": 32105
+    "pfr_id": "WingAn01",
+    "espn_id_new": 3918331
   },
   {
     "mfl_id": 14329,
-    "sleeper_id": 6261,
     "gsis_id": "00-0035019",
     "pff_id": 34698,
-    "espn_id": 3121225,
+    "sleeper_id": 6261,
     "yahoo_id": 32244
   },
   {
     "mfl_id": 14330,
-    "sleeper_id": 6519,
-    "pfr_id": "ShepDa00",
     "gsis_id": "00-0035181",
     "pff_id": 29347,
-    "espn_id": 3120588,
-    "yahoo_id": 32378
+    "sleeper_id": 6519,
+    "yahoo_id": 32378,
+    "pfr_id": "ShepDa00"
   },
   {
     "mfl_id": 14331,
-    "sleeper_id": 6694,
-    "pfr_id": "JohnDE04",
     "gsis_id": "00-0035628",
     "pff_id": 45734,
+    "sleeper_id": 6694,
+    "espn_id": 3139602,
+    "pfr_id": "JohnDE04",
     "ras_id": 15775,
-    "otc_id": 8556
+    "otc_id": 8556,
+    "espn_id_new": 3139602
   },
   {
     "mfl_id": 14332,
-    "sleeper_id": 6501,
     "gsis_id": "00-0035009",
     "pff_id": 47344,
-    "espn_id": 3915230,
+    "sleeper_id": 6501,
     "yahoo_id": 32352
   },
   {
     "mfl_id": 14333,
-    "sleeper_id": 6115,
-    "pfr_id": "HillWe00",
     "gsis_id": "00-0035489",
     "pff_id": 30228,
-    "espn_id": 3060919,
-    "yahoo_id": 32473
+    "sleeper_id": 6115,
+    "yahoo_id": 32473,
+    "pfr_id": "HillWe00"
   },
   {
     "mfl_id": 14334,
-    "sleeper_id": 5244,
     "gsis_id": "00-0034141",
     "pff_id": 48301,
-    "espn_id": 4037481,
+    "sleeper_id": 5244,
     "yahoo_id": 31349
   },
   {
     "mfl_id": 14335,
-    "sleeper_id": 6208,
     "gsis_id": "00-0034921",
-    "espn_id": 3048898,
+    "sleeper_id": 6208,
     "yahoo_id": 31831
   },
   {
     "mfl_id": 14336,
-    "sleeper_id": 6420,
     "gsis_id": "00-0035417",
     "pff_id": 48082,
-    "espn_id": 3126095,
+    "sleeper_id": 6420,
     "yahoo_id": 32200
   },
   {
     "mfl_id": 14337,
-    "sleeper_id": 6421,
-    "pfr_id": "GuytJa01",
     "gsis_id": "00-0035414",
     "pff_id": 34164,
+    "sleeper_id": 6421,
+    "espn_id": 3932430,
+    "pfr_id": "GuytJa01",
     "ras_id": 19873,
-    "otc_id": 8452
+    "otc_id": 8452,
+    "espn_id_new": 3932430
   },
   {
     "mfl_id": 14338,
-    "sleeper_id": 6446,
-    "pfr_id": "HillJo03",
     "gsis_id": "00-0035013",
     "pff_id": 45826,
-    "espn_id": 3122799,
-    "yahoo_id": 32238
+    "sleeper_id": 6446,
+    "yahoo_id": 32238,
+    "pfr_id": "HillJo03"
   },
   {
     "mfl_id": 14339,
-    "sleeper_id": 4050,
     "gsis_id": "00-0033215",
     "pff_id": 12077,
-    "espn_id": 4217370,
+    "sleeper_id": 4050,
     "yahoo_id": 30111
   },
   {
     "mfl_id": 14340,
-    "sleeper_id": 6373,
     "gsis_id": "00-0035491",
     "pff_id": 47896,
-    "espn_id": 3124369,
+    "sleeper_id": 6373,
     "yahoo_id": 32159
   },
   {
     "mfl_id": 14341,
-    "sleeper_id": 6074,
-    "pfr_id": "ParhDo00",
     "gsis_id": "00-0035329",
     "pff_id": 91014,
+    "sleeper_id": 6074,
+    "espn_id": 3912092,
+    "pfr_id": "ParhDo00",
     "ras_id": 19858,
-    "otc_id": 8287
+    "otc_id": 8287,
+    "espn_id_new": 3912092
   },
   {
     "mfl_id": 14342,
-    "sleeper_id": 5241,
-    "pfr_id": "BlakCh00",
     "gsis_id": "00-0034132",
     "pff_id": 47900,
+    "sleeper_id": 5241,
+    "pfr_id": "BlakCh00",
     "ras_id": 15548,
     "otc_id": 7472
   },
   {
     "mfl_id": 14344,
-    "sleeper_id": 6317,
     "gsis_id": "00-0035394",
     "pff_id": 61944,
-    "espn_id": 3921586,
+    "sleeper_id": 6317,
     "yahoo_id": 32464
   },
   {
     "mfl_id": 14348,
-    "sleeper_id": 6209,
-    "pfr_id": "HymaIs00",
     "gsis_id": "00-0034922",
     "pff_id": 28621,
-    "espn_id": 3039968,
-    "yahoo_id": 31832
+    "sleeper_id": 6209,
+    "yahoo_id": 31832,
+    "pfr_id": "HymaIs00"
   },
   {
     "mfl_id": 14349,
-    "sleeper_id": 6195,
     "gsis_id": "00-0034915",
     "pff_id": 92136,
-    "espn_id": 4420843,
+    "sleeper_id": 6195,
     "yahoo_id": 31821
   },
   {
     "mfl_id": 14350,
-    "sleeper_id": 5168,
     "gsis_id": "00-0034551",
     "pff_id": 45727,
-    "espn_id": 3053732,
+    "sleeper_id": 5168,
     "yahoo_id": 31280
   },
   {
     "mfl_id": 14351,
-    "sleeper_id": 5269,
     "gsis_id": "00-0034735",
     "pff_id": 66966,
-    "espn_id": 3951441,
+    "sleeper_id": 5269,
     "yahoo_id": 31732
   },
   {
     "mfl_id": 14352,
-    "sleeper_id": 4752,
     "gsis_id": "00-0033994",
     "pff_id": 23172,
-    "espn_id": 2971397,
+    "sleeper_id": 4752,
     "yahoo_id": 30901
   },
   {
     "mfl_id": 14354,
-    "sleeper_id": 5984,
     "gsis_id": "00-0035520",
     "pff_id": 34629,
-    "espn_id": 3895828,
+    "sleeper_id": 5984,
     "yahoo_id": 32426
   },
   {
     "mfl_id": 14355,
-    "sleeper_id": 5235,
     "gsis_id": "00-0034575",
     "pff_id": 34985,
+    "sleeper_id": 5235,
+    "yahoo_id": 31283,
     "espn_id": 3047536,
-    "yahoo_id": 31283
+    "espn_id_new": 3047536
   },
   {
     "mfl_id": 14356,
-    "pfr_id": "KeizNi00",
     "gsis_id": "00-0034192",
-    "pff_id": 66940
+    "pff_id": 66940,
+    "pfr_id": "KeizNi00"
   },
   {
     "mfl_id": 14357,
-    "sleeper_id": 6081,
-    "pfr_id": "BlanKe01",
     "gsis_id": "00-0035603",
     "pff_id": 47311,
-    "espn_id": 3122103,
-    "yahoo_id": 32125
+    "sleeper_id": 6081,
+    "yahoo_id": 32125,
+    "pfr_id": "BlanKe01"
   },
   {
     "mfl_id": 14358,
-    "sleeper_id": 6111,
     "gsis_id": "00-0035100",
     "pff_id": 46401,
+    "sleeper_id": 6111,
+    "yahoo_id": 32138,
     "espn_id": 3886812,
-    "yahoo_id": 32138
+    "espn_id_new": 3886812
   },
   {
     "mfl_id": 14359,
+    "gsis_id": "00-0035726",
+    "espn_id": 3115349,
     "pfr_id": "JohnJa12",
-    "gsis_id": "00-0035726"
+    "espn_id_new": 3115349
   },
   {
     "mfl_id": 14363,
-    "sleeper_id": 5171,
     "gsis_id": "00-0034193",
     "pff_id": 30887,
+    "sleeper_id": 5171,
+    "yahoo_id": 31441,
     "espn_id": 3049290,
-    "yahoo_id": 31441
+    "espn_id_new": 3049290
   },
   {
     "mfl_id": 14365,
-    "sleeper_id": 4669,
     "gsis_id": "00-0033705",
     "pff_id": 12043,
-    "espn_id": 3047504,
+    "sleeper_id": 4669,
     "yahoo_id": 30430
   },
   {
     "mfl_id": 14367,
-    "sleeper_id": 6089,
     "gsis_id": "00-0035428",
     "pff_id": 47307,
-    "espn_id": 3115359,
+    "sleeper_id": 6089,
     "yahoo_id": 32543
   },
   {
     "mfl_id": 14368,
-    "sleeper_id": 6553,
-    "pfr_id": "WaltAu00",
     "gsis_id": "00-0035187",
     "pff_id": 45038,
+    "sleeper_id": 6553,
+    "yahoo_id": 32383,
     "espn_id": 3123857,
-    "yahoo_id": 32383
+    "pfr_id": "WaltAu00",
+    "espn_id_new": 3123857
   },
   {
     "mfl_id": 14370,
-    "sleeper_id": 5409,
     "gsis_id": "00-0034613",
     "pff_id": 66924,
+    "sleeper_id": 5409,
+    "yahoo_id": 31257,
     "espn_id": 3050481,
-    "yahoo_id": 31257
+    "espn_id_new": 3050481
   },
   {
     "mfl_id": 14372,
-    "sleeper_id": 3695,
-    "pfr_id": "HoltJ.01",
     "gsis_id": "00-0032986",
-    "pff_id": 11062
+    "pff_id": 11062,
+    "sleeper_id": 3695,
+    "pfr_id": "HoltJ.01"
   },
   {
     "mfl_id": 14373,
-    "sleeper_id": 6549,
-    "pfr_id": "WillDa11",
     "gsis_id": "00-0035401",
     "pff_id": 61737,
-    "espn_id": 4241723,
-    "yahoo_id": 32471
+    "sleeper_id": 6549,
+    "yahoo_id": 32471,
+    "pfr_id": "WillDa11"
   },
   {
     "mfl_id": 14377,
-    "sleeper_id": 5636,
     "gsis_id": "00-0034587",
     "pff_id": 32708,
+    "sleeper_id": 5636,
+    "yahoo_id": 31657,
     "espn_id": 3119119,
-    "yahoo_id": 31657
+    "espn_id_new": 3119119
   },
   {
     "mfl_id": 14378,
-    "sleeper_id": 6510,
     "gsis_id": "00-0035179",
     "pff_id": 27753,
-    "espn_id": 3895834,
+    "sleeper_id": 6510,
     "yahoo_id": 32374
   },
   {
     "mfl_id": 14379,
-    "sleeper_id": 5757,
     "gsis_id": "00-0034801",
     "pff_id": 49023,
+    "sleeper_id": 5757,
+    "yahoo_id": 31753,
     "espn_id": 3128303,
-    "yahoo_id": 31753
+    "espn_id_new": 3128303
   },
   {
     "mfl_id": 14380,
-    "sleeper_id": 5642,
     "gsis_id": "00-0034533",
     "pff_id": 51394,
-    "espn_id": 3046382,
+    "sleeper_id": 5642,
     "yahoo_id": 31562
   },
   {
     "mfl_id": 14381,
-    "sleeper_id": 6498,
-    "pfr_id": "HarvWi00",
     "gsis_id": "00-0035177",
     "pff_id": 50780,
-    "espn_id": 3128396,
-    "yahoo_id": 32377
+    "sleeper_id": 6498,
+    "yahoo_id": 32377,
+    "pfr_id": "HarvWi00"
   },
   {
     "mfl_id": 14384,
-    "sleeper_id": 6436,
     "gsis_id": "00-0034954",
     "pff_id": 48567,
+    "sleeper_id": 6436,
+    "yahoo_id": 32220,
     "espn_id": 3124634,
-    "yahoo_id": 32220
+    "espn_id_new": 3124634
   },
   {
     "mfl_id": 14385,
-    "sleeper_id": 5402,
     "gsis_id": "00-0034223",
     "pff_id": 48459,
-    "espn_id": 3051766,
+    "sleeper_id": 5402,
     "yahoo_id": 31243
   },
   {
     "mfl_id": 14387,
-    "sleeper_id": 5692,
     "gsis_id": "00-0034648",
-    "espn_id": 3040204,
+    "sleeper_id": 5692,
     "yahoo_id": 31643
   },
   {
     "mfl_id": 14388,
-    "sleeper_id": 4761,
-    "pfr_id": "ShelBr01",
     "gsis_id": "00-0033997",
     "pff_id": 51599,
-    "espn_id": 3057876,
-    "yahoo_id": 30904
+    "sleeper_id": 4761,
+    "yahoo_id": 30904,
+    "pfr_id": "ShelBr01"
   },
   {
     "mfl_id": 14393,
-    "sleeper_id": 6496,
     "gsis_id": "00-0035171",
-    "espn_id": 3128692,
+    "sleeper_id": 6496,
     "yahoo_id": 32369
   },
   {
     "mfl_id": 14394,
-    "sleeper_id": 3808,
     "gsis_id": "00-0032830",
     "pff_id": 11303,
-    "espn_id": 3916678,
+    "sleeper_id": 3808,
     "yahoo_id": 29933
   },
   {
     "mfl_id": 14398,
-    "sleeper_id": 5741,
     "gsis_id": "00-0034736",
     "pff_id": 51220,
-    "espn_id": 3116387,
+    "sleeper_id": 5741,
     "yahoo_id": 31733
   },
   {
     "mfl_id": 14400,
-    "sleeper_id": 5945,
-    "pfr_id": "LedbJo01",
     "gsis_id": "00-0035343",
     "pff_id": 18645,
+    "sleeper_id": 5945,
+    "yahoo_id": 32440,
     "espn_id": 3728308,
-    "yahoo_id": 32440
+    "pfr_id": "LedbJo01",
+    "espn_id_new": 3728308
   },
   {
     "mfl_id": 14401,
-    "sleeper_id": 5830,
     "gsis_id": "00-0034902",
     "pff_id": 15301,
+    "sleeper_id": 5830,
+    "yahoo_id": 31815,
     "espn_id": 2577637,
-    "yahoo_id": 31815
+    "espn_id_new": 2577637
   },
   {
     "mfl_id": 14405,
-    "sleeper_id": 5912,
-    "pfr_id": "GranCa01",
     "gsis_id": "00-0035402",
     "pff_id": 48500,
+    "sleeper_id": 5912,
+    "yahoo_id": 32490,
     "espn_id": 3918310,
-    "yahoo_id": 32490
+    "pfr_id": "GranCa01",
+    "espn_id_new": 3918310
   },
   {
     "mfl_id": 14411,
-    "sleeper_id": 5827,
     "gsis_id": "00-0034903",
     "pff_id": 91247,
-    "espn_id": 4410136,
+    "sleeper_id": 5827,
     "yahoo_id": 31810
   },
   {
     "mfl_id": 14414,
-    "sleeper_id": 5520,
     "gsis_id": "00-0034485",
     "pff_id": 66930,
+    "sleeper_id": 5520,
+    "yahoo_id": 31318,
     "espn_id": 4331768,
-    "yahoo_id": 31318
+    "espn_id_new": 4331768
   },
   {
     "mfl_id": 14419,
-    "sleeper_id": 3805,
     "gsis_id": "00-0032835",
-    "espn_id": 3135726,
+    "sleeper_id": 3805,
     "yahoo_id": 29915
   },
   {
     "mfl_id": 14420,
-    "sleeper_id": 6109,
     "gsis_id": "00-0035125",
     "pff_id": 34934,
+    "sleeper_id": 6109,
+    "yahoo_id": 32344,
     "espn_id": 3917668,
-    "yahoo_id": 32344
+    "espn_id_new": 3917668
   },
   {
     "mfl_id": 14421,
-    "sleeper_id": 5664,
     "gsis_id": "00-0034588",
     "pff_id": 48575,
-    "espn_id": 3123054,
+    "sleeper_id": 5664,
     "yahoo_id": 31648
   },
   {
     "mfl_id": 14426,
-    "sleeper_id": 6268,
     "gsis_id": "00-0035189",
+    "sleeper_id": 6268,
+    "yahoo_id": 32174,
     "espn_id": 3128444,
-    "yahoo_id": 32174
+    "espn_id_new": 3128444
   },
   {
     "mfl_id": 14432,
-    "sleeper_id": 5684,
     "gsis_id": "00-0034650",
     "pff_id": 48510,
-    "espn_id": 3676003,
+    "sleeper_id": 5684,
     "yahoo_id": 31645
   },
   {
     "mfl_id": 14434,
-    "sleeper_id": 5792,
-    "pfr_id": "ReavJe00",
     "gsis_id": "00-0034465",
     "pff_id": 50406,
+    "sleeper_id": 5792,
+    "yahoo_id": 31582,
     "espn_id": 3125248,
-    "yahoo_id": 31582
+    "pfr_id": "ReavJe00",
+    "espn_id_new": 3125248
   },
   {
     "mfl_id": 14435,
-    "sleeper_id": 5162,
     "gsis_id": "00-0034578",
     "pff_id": 47542,
-    "espn_id": 3116642,
+    "sleeper_id": 5162,
     "yahoo_id": 31302
   },
   {
     "mfl_id": 14440,
-    "sleeper_id": 6363,
-    "pfr_id": "WalkMi00",
     "gsis_id": "00-0035374",
     "pff_id": 48213,
-    "espn_id": 3915296,
-    "yahoo_id": 32101
+    "sleeper_id": 6363,
+    "yahoo_id": 32101,
+    "pfr_id": "WalkMi00"
   },
   {
     "mfl_id": 14441,
-    "sleeper_id": 6656,
     "gsis_id": "00-0035373",
     "pff_id": 44987,
-    "espn_id": 3122794,
+    "sleeper_id": 6656,
     "yahoo_id": 32100
   },
   {
     "mfl_id": 14442,
-    "sleeper_id": 4848,
     "gsis_id": "00-0034051",
     "pff_id": 20035,
-    "espn_id": 2978524,
+    "sleeper_id": 4848,
     "yahoo_id": 30954
   },
   {
     "mfl_id": 14445,
-    "sleeper_id": 6710,
     "gsis_id": "00-0035691",
     "pff_id": 95845,
-    "espn_id": 4426310,
+    "sleeper_id": 6710,
     "yahoo_id": 32621
   },
   {
     "mfl_id": 14447,
-    "sleeper_id": 5449,
     "gsis_id": "00-0034085",
     "pff_id": 28870,
-    "espn_id": 3912343,
+    "sleeper_id": 5449,
     "yahoo_id": 31367
   },
   {
     "mfl_id": 14450,
-    "sleeper_id": 5941,
     "gsis_id": "00-0035154",
     "pff_id": 48087,
-    "espn_id": 3929817,
+    "sleeper_id": 5941,
     "yahoo_id": 32356
   },
   {
     "mfl_id": 14452,
-    "sleeper_id": 5508,
     "gsis_id": "00-0034145",
     "pff_id": 49368,
-    "espn_id": 3128630,
+    "sleeper_id": 5508,
     "yahoo_id": 31359
   },
   {
     "mfl_id": 14456,
-    "sleeper_id": 6244,
-    "pfr_id": "WatsBr01",
     "gsis_id": "00-0035375",
     "pff_id": 51088,
-    "espn_id": 3115968,
-    "yahoo_id": 32102
+    "sleeper_id": 6244,
+    "yahoo_id": 32102,
+    "pfr_id": "WatsBr01"
   },
   {
     "mfl_id": 14458,
-    "sleeper_id": 6246,
     "gsis_id": "00-0035427",
     "pff_id": 46004,
-    "espn_id": 3914534,
+    "sleeper_id": 6246,
     "yahoo_id": 32541
   },
   {
     "mfl_id": 14461,
-    "sleeper_id": 6357,
     "gsis_id": "00-0035194",
     "pff_id": 94354,
-    "espn_id": 3957156,
+    "sleeper_id": 6357,
     "yahoo_id": 32109
   },
   {
     "mfl_id": 14463,
-    "sleeper_id": 6358,
     "gsis_id": "00-0035200",
     "pff_id": 47788,
-    "espn_id": 3914158,
+    "sleeper_id": 6358,
     "yahoo_id": 32115
   },
   {
     "mfl_id": 14464,
-    "sleeper_id": 5754,
     "gsis_id": "00-0034788",
     "pff_id": 31849,
-    "espn_id": 3118954,
+    "sleeper_id": 5754,
     "yahoo_id": 31749
   },
   {
     "mfl_id": 14465,
-    "sleeper_id": 6585,
-    "pfr_id": "BrooTo01",
     "gsis_id": "00-0035551",
     "pff_id": 45764,
-    "espn_id": 3886841,
-    "yahoo_id": 32559
+    "sleeper_id": 6585,
+    "yahoo_id": 32559,
+    "pfr_id": "BrooTo01"
   },
   {
     "mfl_id": 14466,
-    "sleeper_id": 6347,
     "gsis_id": "00-0035198",
     "pff_id": 58208,
-    "espn_id": 4262186,
+    "sleeper_id": 6347,
     "yahoo_id": 32113
   },
   {
     "mfl_id": 14467,
-    "sleeper_id": 6348,
     "gsis_id": "00-0035202",
     "pff_id": 57868,
+    "sleeper_id": 6348,
+    "yahoo_id": 32118,
     "espn_id": 4240528,
-    "yahoo_id": 32118
+    "espn_id_new": 4240528
   },
   {
     "mfl_id": 14471,
-    "sleeper_id": 6227,
     "gsis_id": "00-0035353",
     "pff_id": 61326,
-    "espn_id": 4240591,
+    "sleeper_id": 6227,
     "yahoo_id": 32412
   },
   {
     "mfl_id": 14472,
-    "sleeper_id": 6315,
     "gsis_id": "00-0035352",
     "pff_id": 51045,
+    "sleeper_id": 6315,
+    "yahoo_id": 32411,
     "espn_id": 4035232,
-    "yahoo_id": 32411
+    "espn_id_new": 4035232
   },
   {
     "mfl_id": 14480,
-    "sleeper_id": 6318,
     "gsis_id": "00-0035396",
     "pff_id": 30806,
-    "espn_id": 3124022,
+    "sleeper_id": 6318,
     "yahoo_id": 32466
   },
   {
     "mfl_id": 14481,
-    "sleeper_id": 6628,
-    "pfr_id": "BryaVe00",
     "gsis_id": "00-0035548",
     "pff_id": 47959,
-    "espn_id": 3138760,
-    "yahoo_id": 32556
+    "sleeper_id": 6628,
+    "yahoo_id": 32556,
+    "pfr_id": "BryaVe00"
   },
   {
     "mfl_id": 14482,
-    "sleeper_id": 6666,
-    "pfr_id": "DawkNo00",
     "gsis_id": "00-0035549",
     "pff_id": 35771,
-    "espn_id": 3911689,
-    "yahoo_id": 32557
+    "sleeper_id": 6666,
+    "yahoo_id": 32557,
+    "pfr_id": "DawkNo00"
   },
   {
     "mfl_id": 14486,
-    "sleeper_id": 6453,
     "gsis_id": "00-0035045",
     "pff_id": 55003,
+    "sleeper_id": 6453,
+    "yahoo_id": 32283,
     "espn_id": 4249030,
-    "yahoo_id": 32283
+    "espn_id_new": 4249030
   },
   {
     "mfl_id": 14488,
-    "sleeper_id": 6451,
-    "pfr_id": "CarlSt00",
     "gsis_id": "00-0035039",
     "pff_id": 94365,
-    "espn_id": 3948283,
-    "yahoo_id": 32273
+    "sleeper_id": 6451,
+    "yahoo_id": 32273,
+    "pfr_id": "CarlSt00"
   },
   {
     "mfl_id": 14489,
-    "sleeper_id": 6452,
     "gsis_id": "00-0035042",
     "pff_id": 63303,
+    "sleeper_id": 6452,
+    "yahoo_id": 32277,
     "espn_id": 3936185,
-    "yahoo_id": 32277
+    "espn_id_new": 3936185
   },
   {
     "mfl_id": 14493,
-    "sleeper_id": 6027,
     "gsis_id": "00-0035415",
     "pff_id": 51497,
-    "espn_id": 3116134,
+    "sleeper_id": 6027,
     "yahoo_id": 32206
   },
   {
     "mfl_id": 14494,
-    "sleeper_id": 6611,
     "gsis_id": "00-0035412",
     "pff_id": 38956,
-    "espn_id": 3929818,
+    "sleeper_id": 6611,
     "yahoo_id": 32208
   },
   {
     "mfl_id": 14495,
-    "sleeper_id": 6612,
-    "pfr_id": "GiffLu00",
     "gsis_id": "00-0035413",
     "pff_id": 50675,
+    "sleeper_id": 6612,
+    "yahoo_id": 32205,
     "espn_id": 3116097,
-    "yahoo_id": 32205
+    "pfr_id": "GiffLu00",
+    "espn_id_new": 3116097
   },
   {
     "mfl_id": 14496,
-    "sleeper_id": 6539,
     "gsis_id": "00-0034935",
     "pff_id": 94358,
-    "espn_id": 4422215,
+    "sleeper_id": 6539,
     "yahoo_id": 32400
   },
   {
     "mfl_id": 14498,
-    "sleeper_id": 6438,
     "gsis_id": "00-0034949",
     "pff_id": 34050,
-    "espn_id": 3915575,
+    "sleeper_id": 6438,
     "yahoo_id": 32219
   },
   {
     "mfl_id": 14499,
-    "sleeper_id": 6395,
-    "pfr_id": "BensTr00",
     "gsis_id": "00-0034930",
-    "pff_id": 94356
+    "pff_id": 94356,
+    "sleeper_id": 6395,
+    "pfr_id": "BensTr00"
   },
   {
     "mfl_id": 14501,
-    "sleeper_id": 6396,
     "gsis_id": "00-0034932",
     "pff_id": 30778,
-    "espn_id": 3125402,
+    "sleeper_id": 6396,
     "yahoo_id": 32191
   },
   {
     "mfl_id": 14502,
-    "sleeper_id": 5442,
-    "pfr_id": "MarsTr00",
     "gsis_id": "00-0034111",
     "pff_id": 49154,
-    "espn_id": 3116602,
-    "yahoo_id": 31381
+    "sleeper_id": 5442,
+    "yahoo_id": 31381,
+    "pfr_id": "MarsTr00"
   },
   {
     "mfl_id": 14503,
-    "sleeper_id": 6588,
-    "pfr_id": "KennTo01",
     "gsis_id": "00-0035544",
     "pff_id": 94379,
-    "espn_id": 3126997,
-    "yahoo_id": 32561
+    "sleeper_id": 6588,
+    "yahoo_id": 32561,
+    "pfr_id": "KennTo01"
   },
   {
     "mfl_id": 14506,
-    "sleeper_id": 6651,
-    "pfr_id": "PittAn01",
     "gsis_id": "00-0035330",
     "pff_id": 94372,
+    "sleeper_id": 6651,
+    "yahoo_id": 32457,
     "espn_id": 4423367,
-    "yahoo_id": 32457
+    "pfr_id": "PittAn01",
+    "espn_id_new": 4423367
   },
   {
     "mfl_id": 14509,
-    "sleeper_id": 6430,
     "gsis_id": "00-0035076",
     "pff_id": 39043,
+    "sleeper_id": 6430,
+    "yahoo_id": 32266,
     "espn_id": 3116367,
-    "yahoo_id": 32266
+    "espn_id_new": 3116367
   },
   {
     "mfl_id": 14510,
-    "sleeper_id": 6371,
     "gsis_id": "00-0035483",
     "pff_id": 27308,
-    "espn_id": 4040826,
+    "sleeper_id": 6371,
     "yahoo_id": 32152
   },
   {
     "mfl_id": 14512,
-    "sleeper_id": 6372,
     "gsis_id": "00-0035494",
     "pff_id": 94355,
-    "espn_id": 3119996,
+    "sleeper_id": 6372,
     "yahoo_id": 32162
   },
   {
     "mfl_id": 14513,
-    "sleeper_id": 5639,
     "gsis_id": "00-0034606",
-    "espn_id": 3045166,
+    "sleeper_id": 5639,
     "yahoo_id": 31670
   },
   {
     "mfl_id": 14517,
-    "sleeper_id": 5233,
     "gsis_id": "00-0034169",
     "pff_id": 47131,
-    "espn_id": 3051387,
+    "sleeper_id": 5233,
     "yahoo_id": 31478
   },
   {
     "mfl_id": 14518,
-    "sleeper_id": 6711,
-    "pfr_id": "ThomJa04",
     "gsis_id": "00-0035705",
     "pff_id": 49116,
+    "sleeper_id": 6711,
+    "yahoo_id": 32623,
     "espn_id": 4043089,
-    "yahoo_id": 32623
+    "pfr_id": "ThomJa04",
+    "espn_id_new": 4043089
   },
   {
     "mfl_id": 14519,
-    "sleeper_id": 6307,
-    "pfr_id": "KunaJo00",
     "gsis_id": "00-0035444",
     "pff_id": 38548,
+    "sleeper_id": 6307,
+    "yahoo_id": 32151,
     "espn_id": 4035866,
-    "yahoo_id": 32151
+    "pfr_id": "KunaJo00",
+    "espn_id_new": 4035866
   },
   {
     "mfl_id": 14525,
-    "sleeper_id": 6461,
     "gsis_id": "00-0035118",
     "pff_id": 94369,
-    "espn_id": 4422336,
+    "sleeper_id": 6461,
     "yahoo_id": 32306
   },
   {
     "mfl_id": 14531,
-    "sleeper_id": 6026,
-    "pfr_id": "HuggAl01",
     "gsis_id": "00-0035455",
     "pff_id": 36862,
-    "espn_id": 3728248,
-    "yahoo_id": 32509
+    "sleeper_id": 6026,
+    "yahoo_id": 32509,
+    "pfr_id": "HuggAl01"
   },
   {
     "mfl_id": 14532,
-    "sleeper_id": 5968,
     "gsis_id": "00-0035155",
     "pff_id": 49394,
-    "espn_id": 3728261,
+    "sleeper_id": 5968,
     "yahoo_id": 32357
   },
   {
     "mfl_id": 14533,
-    "sleeper_id": 6239,
-    "pfr_id": "TaylMa01",
     "gsis_id": "00-0035480",
-    "pff_id": 94375
+    "pff_id": 94375,
+    "sleeper_id": 6239,
+    "espn_id": 4408988,
+    "pfr_id": "TaylMa01",
+    "espn_id_new": 4408988
   },
   {
     "mfl_id": 14535,
-    "sleeper_id": 6043,
     "gsis_id": "00-0035513",
     "pff_id": 42782,
-    "espn_id": 4037633,
+    "sleeper_id": 6043,
     "yahoo_id": 32420
   },
   {
     "mfl_id": 14536,
-    "sleeper_id": 5660,
     "gsis_id": "00-0034590",
     "pff_id": 39383,
-    "espn_id": 3042746,
+    "sleeper_id": 5660,
     "yahoo_id": 31649
   },
   {
     "mfl_id": 14538,
-    "sleeper_id": 4828,
     "gsis_id": "00-0034034",
     "pff_id": 38044,
-    "espn_id": 3049329,
+    "sleeper_id": 4828,
     "yahoo_id": 30940
   },
   {
     "mfl_id": 14540,
-    "sleeper_id": 5591,
     "gsis_id": "00-0034326",
     "pff_id": 28474,
-    "espn_id": 3128264,
+    "sleeper_id": 5591,
     "yahoo_id": 31523
   },
   {
     "mfl_id": 14543,
-    "sleeper_id": 6551,
     "gsis_id": "00-0035157",
     "pff_id": 29188,
+    "sleeper_id": 6551,
+    "yahoo_id": 32359,
     "espn_id": 3122906,
-    "yahoo_id": 32359
+    "espn_id_new": 3122906
   },
   {
     "mfl_id": 14544,
-    "sleeper_id": 6712,
     "gsis_id": "00-0035701",
-    "espn_id": 4039244,
+    "sleeper_id": 6712,
     "yahoo_id": 32624
   },
   {
     "mfl_id": 14545,
-    "sleeper_id": 6247,
-    "pfr_id": "MoorJa02",
     "gsis_id": "00-0035432",
     "pff_id": 91472,
-    "espn_id": 4069806,
-    "yahoo_id": 32547
+    "sleeper_id": 6247,
+    "yahoo_id": 32547,
+    "pfr_id": "MoorJa02"
   },
   {
     "mfl_id": 14548,
-    "sleeper_id": 6386,
     "gsis_id": "00-0035602",
     "pff_id": 47996,
-    "espn_id": 3919510,
+    "sleeper_id": 6386,
     "yahoo_id": 32124
   },
   {
     "mfl_id": 14549,
-    "sleeper_id": 6387,
-    "pfr_id": "WebsNs00",
     "gsis_id": "00-0035621",
-    "pff_id": 48107
+    "pff_id": 48107,
+    "sleeper_id": 6387,
+    "espn_id": 3119317,
+    "pfr_id": "WebsNs00",
+    "espn_id_new": 3119317
   },
   {
     "mfl_id": 14551,
-    "sleeper_id": 6598,
-    "pfr_id": "IrwiTr00",
     "gsis_id": "00-0035341",
     "pff_id": 48080,
+    "sleeper_id": 6598,
+    "yahoo_id": 32438,
     "espn_id": 3931391,
-    "yahoo_id": 32438
+    "pfr_id": "IrwiTr00",
+    "espn_id_new": 3931391
   },
   {
     "mfl_id": 14552,
-    "sleeper_id": 6379,
     "gsis_id": "00-0035099",
     "pff_id": 44889,
+    "sleeper_id": 6379,
+    "yahoo_id": 32140,
     "espn_id": 3122154,
-    "yahoo_id": 32140
+    "espn_id_new": 3122154
   },
   {
     "mfl_id": 14553,
-    "sleeper_id": 6380,
-    "pfr_id": "DaviDa03",
     "gsis_id": "00-0035101",
     "pff_id": 33158,
-    "espn_id": 3933568,
-    "yahoo_id": 32141
+    "sleeper_id": 6380,
+    "yahoo_id": 32141,
+    "pfr_id": "DaviDa03"
   },
   {
     "mfl_id": 14554,
-    "sleeper_id": 6381,
-    "pfr_id": "HollAl00",
     "gsis_id": "00-0035104",
     "pff_id": 63664,
-    "espn_id": 4249496,
-    "yahoo_id": 32143
+    "sleeper_id": 6381,
+    "yahoo_id": 32143,
+    "pfr_id": "HollAl00"
   },
   {
     "mfl_id": 14555,
-    "sleeper_id": 6699,
-    "pfr_id": "OlszGu00",
     "gsis_id": "00-0035645",
     "pff_id": 95015,
-    "otc_id": 8577
+    "sleeper_id": 6699,
+    "espn_id": 4424106,
+    "pfr_id": "OlszGu00",
+    "otc_id": 8577,
+    "espn_id_new": 4424106
   },
   {
     "mfl_id": 14557,
-    "sleeper_id": 5990,
     "gsis_id": "00-0034962",
     "pff_id": 51107,
-    "espn_id": 3924319,
+    "sleeper_id": 5990,
     "yahoo_id": 32230
   },
   {
     "mfl_id": 14558,
-    "sleeper_id": 6234,
-    "pfr_id": "HarrDe07",
     "gsis_id": "00-0035215",
     "pff_id": 91470,
+    "sleeper_id": 6234,
+    "espn_id": 4411193,
+    "pfr_id": "HarrDe07",
     "ras_id": 20091,
-    "otc_id": 8512
+    "otc_id": 8512,
+    "espn_id_new": 4411193
   },
   {
     "mfl_id": 14559,
-    "sleeper_id": 5996,
-    "pfr_id": "GustPo01",
     "gsis_id": "00-0035404",
     "pff_id": 50290,
-    "espn_id": 3912553,
-    "yahoo_id": 32492
+    "sleeper_id": 5996,
+    "yahoo_id": 32492,
+    "pfr_id": "GustPo01"
   },
   {
     "mfl_id": 14560,
-    "sleeper_id": 6163,
     "gsis_id": "00-0035018",
     "pff_id": 31572,
-    "espn_id": 3121110,
+    "sleeper_id": 6163,
     "yahoo_id": 32243
   },
   {
     "mfl_id": 14561,
-    "sleeper_id": 6557,
-    "pfr_id": "SmitJe03",
     "gsis_id": "00-0035510",
     "pff_id": 48055,
+    "sleeper_id": 6557,
+    "espn_id": 3929118,
+    "pfr_id": "SmitJe03",
     "ras_id": 17754,
-    "otc_id": 8307
+    "otc_id": 8307,
+    "espn_id_new": 3929118
   },
   {
     "mfl_id": 14563,
-    "sleeper_id": 6540,
     "gsis_id": "00-0035385",
     "pff_id": 48211,
-    "espn_id": 3116182,
+    "sleeper_id": 6540,
     "yahoo_id": 32409
   },
   {
     "mfl_id": 14565,
-    "sleeper_id": 5828,
-    "pfr_id": "SpenDi00",
     "gsis_id": "00-0031319",
-    "pff_id": 91248
+    "pff_id": 91248,
+    "sleeper_id": 5828,
+    "pfr_id": "SpenDi00"
   },
   {
     "mfl_id": 14568,
-    "sleeper_id": 6563,
     "gsis_id": "00-0035433",
-    "espn_id": 3129309,
+    "sleeper_id": 6563,
     "yahoo_id": 32548
   },
   {
     "mfl_id": 14576,
-    "sleeper_id": 4829,
     "gsis_id": "00-0034035",
     "pff_id": 48081,
-    "espn_id": 3060347,
+    "sleeper_id": 4829,
     "yahoo_id": 30938
   },
   {
     "mfl_id": 14579,
-    "sleeper_id": 6682,
     "gsis_id": "00-0035573",
     "pff_id": 50513,
-    "espn_id": 3675805,
+    "sleeper_id": 6682,
     "yahoo_id": 32589
   },
   {
     "mfl_id": 14584,
-    "sleeper_id": 2894,
-    "pfr_id": "WatsJo00",
     "gsis_id": "00-0034956",
     "pff_id": 49722,
-    "espn_id": 2512419,
-    "yahoo_id": 32222
+    "sleeper_id": 2894,
+    "yahoo_id": 32222,
+    "pfr_id": "WatsJo00"
   },
   {
     "mfl_id": 14589,
-    "sleeper_id": 6593,
-    "pfr_id": "SchnSp00",
     "gsis_id": "00-0035587",
     "pff_id": 39145,
-    "espn_id": 3126075,
-    "yahoo_id": 32560
+    "sleeper_id": 6593,
+    "yahoo_id": 32560,
+    "pfr_id": "SchnSp00"
   },
   {
     "mfl_id": 14590,
-    "sleeper_id": 6485,
-    "pfr_id": "AlShAz00",
     "gsis_id": "00-0035166",
     "pff_id": 49792,
+    "sleeper_id": 6485,
+    "yahoo_id": 32318,
     "espn_id": 3919117,
-    "yahoo_id": 32318
+    "pfr_id": "AlShAz00",
+    "espn_id_new": 3919117
   },
   {
     "mfl_id": 14591,
-    "sleeper_id": 6231,
     "gsis_id": "00-0035161",
     "pff_id": 94371,
-    "espn_id": 3118906,
+    "sleeper_id": 6231,
     "yahoo_id": 32364
   },
   {
     "mfl_id": 14592,
-    "sleeper_id": 6271,
-    "pfr_id": "ZaccOl01",
     "gsis_id": "00-0035208",
     "pff_id": 44920,
+    "sleeper_id": 6271,
+    "espn_id": 3917914,
+    "pfr_id": "ZaccOl01",
     "ras_id": 17699,
-    "otc_id": 8393
+    "otc_id": 8393,
+    "espn_id_new": 3917914
   },
   {
     "mfl_id": 14595,
-    "sleeper_id": 6536,
-    "pfr_id": "StroKe00",
     "gsis_id": "00-0035334",
     "pff_id": 48981,
+    "sleeper_id": 6536,
+    "yahoo_id": 32461,
     "espn_id": 3124052,
-    "yahoo_id": 32461
+    "pfr_id": "StroKe00",
+    "espn_id_new": 3124052
   },
   {
     "mfl_id": 14600,
-    "sleeper_id": 6528,
     "gsis_id": "00-0035192",
+    "sleeper_id": 6528,
+    "yahoo_id": 32384,
     "espn_id": 3124084,
-    "yahoo_id": 32384
+    "espn_id_new": 3124084
   },
   {
     "mfl_id": 14602,
-    "sleeper_id": 6472,
-    "pfr_id": "PhilJu00",
     "gsis_id": "00-0035419",
     "pff_id": 49677,
-    "espn_id": 3122441,
-    "yahoo_id": 32204
+    "sleeper_id": 6472,
+    "yahoo_id": 32204,
+    "pfr_id": "PhilJu00"
   },
   {
     "mfl_id": 14603,
-    "sleeper_id": 6695,
     "gsis_id": "00-0035634",
     "pff_id": 28605,
-    "espn_id": 3140141,
+    "sleeper_id": 6695,
     "yahoo_id": 32609
   },
   {
     "mfl_id": 14610,
-    "sleeper_id": 6584,
-    "pfr_id": "SizeDe00",
     "gsis_id": "00-0035557",
     "pff_id": 94382,
-    "espn_id": 3145343,
-    "yahoo_id": 32578
+    "sleeper_id": 6584,
+    "yahoo_id": 32578,
+    "pfr_id": "SizeDe00"
   },
   {
     "mfl_id": 14612,
-    "sleeper_id": 6311,
-    "pfr_id": "LairPa00",
     "gsis_id": "00-0035342",
     "pff_id": 28219,
+    "sleeper_id": 6311,
+    "yahoo_id": 32439,
     "espn_id": 3127211,
-    "yahoo_id": 32439
+    "pfr_id": "LairPa00",
+    "espn_id_new": 3127211
   },
   {
     "mfl_id": 14613,
-    "sleeper_id": 6402,
-    "pfr_id": "SimsSt00",
     "gsis_id": "00-0034928",
     "pff_id": 48341,
+    "sleeper_id": 6402,
+    "espn_id": 3917960,
+    "pfr_id": "SimsSt00",
     "ras_id": 17750,
-    "otc_id": 8075
+    "otc_id": 8075,
+    "espn_id_new": 3917960
   },
   {
     "mfl_id": 14618,
-    "sleeper_id": 6595,
-    "pfr_id": "HodgDe00",
     "gsis_id": "00-0035577",
     "pff_id": 29838,
-    "espn_id": 3127051,
-    "yahoo_id": 32581
+    "sleeper_id": 6595,
+    "yahoo_id": 32581,
+    "pfr_id": "HodgDe00"
   },
   {
     "mfl_id": 14622,
-    "sleeper_id": 6730,
     "gsis_id": "00-0035735",
     "pff_id": 60453,
-    "espn_id": 4242418,
+    "sleeper_id": 6730,
     "yahoo_id": 32642
   },
   {
     "mfl_id": 14624,
-    "sleeper_id": 6355,
     "gsis_id": "00-0035098",
     "pff_id": 51344,
-    "espn_id": 3915373
+    "sleeper_id": 6355,
+    "espn_id": 3915373,
+    "espn_id_new": 3915373
   },
   {
     "mfl_id": 14627,
-    "sleeper_id": 3785,
     "gsis_id": "00-0032660",
     "pff_id": 11280,
-    "espn_id": 2982857,
+    "sleeper_id": 3785,
     "yahoo_id": 29813
   },
   {
     "mfl_id": 14630,
-    "sleeper_id": 6555,
     "gsis_id": "00-0035190",
     "pff_id": 36038,
+    "sleeper_id": 6555,
+    "yahoo_id": 32386,
     "espn_id": 3686689,
-    "yahoo_id": 32386
+    "espn_id_new": 3686689
   },
   {
     "mfl_id": 14640,
-    "sleeper_id": 5196,
     "gsis_id": "00-0034672",
     "pff_id": 47173,
-    "espn_id": 3115360,
+    "sleeper_id": 5196,
     "yahoo_id": 31627
   },
   {
     "mfl_id": 14650,
-    "sleeper_id": 5823,
     "gsis_id": "00-0034909",
+    "sleeper_id": 5823,
+    "yahoo_id": 31808,
     "espn_id": 3127313,
-    "yahoo_id": 31808
+    "espn_id_new": 3127313
   },
   {
     "mfl_id": 14651,
-    "sleeper_id": 6099,
     "gsis_id": "00-0034923",
     "pff_id": 89295,
-    "espn_id": 4250485,
+    "sleeper_id": 6099,
     "yahoo_id": 32181
   },
   {
     "mfl_id": 14652,
-    "sleeper_id": 6005,
-    "pfr_id": "GiveKe01",
     "gsis_id": "00-0035026",
     "pff_id": 28308,
+    "sleeper_id": 6005,
+    "yahoo_id": 32321,
     "espn_id": 3929641,
-    "yahoo_id": 32321
+    "pfr_id": "GiveKe01",
+    "espn_id_new": 3929641
   },
   {
     "mfl_id": 14653,
-    "sleeper_id": 6601,
-    "pfr_id": "MackIs00",
     "gsis_id": "00-0035519",
     "pff_id": 26229,
-    "espn_id": 3131784,
-    "yahoo_id": 32425
+    "sleeper_id": 6601,
+    "yahoo_id": 32425,
+    "pfr_id": "MackIs00"
   },
   {
     "mfl_id": 14654,
-    "sleeper_id": 6439,
-    "pfr_id": "HentHa00",
     "gsis_id": "00-0035025",
     "pff_id": 47150,
-    "espn_id": 3925348,
-    "yahoo_id": 32295
+    "sleeper_id": 6439,
+    "yahoo_id": 32295,
+    "pfr_id": "HentHa00"
   },
   {
     "mfl_id": 14657,
-    "sleeper_id": 5528,
     "gsis_id": "00-0034255",
     "pff_id": 34845,
-    "espn_id": 3046700,
+    "sleeper_id": 5528,
     "yahoo_id": 31459
   },
   {
     "mfl_id": 14658,
-    "sleeper_id": 6739,
     "gsis_id": "00-0035742",
-    "espn_id": 3072765,
+    "sleeper_id": 6739,
     "yahoo_id": 32650
   },
   {
     "mfl_id": 14660,
-    "sleeper_id": 6160,
-    "pfr_id": "TauaJo00",
     "gsis_id": "00-0035016",
     "pff_id": 49714,
-    "espn_id": 3914595,
-    "yahoo_id": 32241
+    "sleeper_id": 6160,
+    "yahoo_id": 32241,
+    "pfr_id": "TauaJo00"
   },
   {
     "mfl_id": 14665,
-    "sleeper_id": 6279,
-    "pfr_id": "DillBr00",
     "gsis_id": "00-0035102",
-    "pff_id": 91468
+    "pff_id": 91468,
+    "sleeper_id": 6279,
+    "pfr_id": "DillBr00"
   },
   {
     "mfl_id": 14666,
-    "sleeper_id": 5489,
     "gsis_id": "00-0034556",
     "pff_id": 35978,
-    "espn_id": 3139926,
+    "sleeper_id": 5489,
     "yahoo_id": 31294
   },
   {
     "mfl_id": 14669,
-    "sleeper_id": 6333,
-    "pfr_id": "NixoKe00",
     "gsis_id": "00-0035133",
     "pff_id": 56167,
+    "sleeper_id": 6333,
+    "yahoo_id": 32348,
     "espn_id": 4259493,
-    "yahoo_id": 32348
+    "pfr_id": "NixoKe00",
+    "espn_id_new": 4259493
   },
   {
     "mfl_id": 14670,
-    "sleeper_id": 5532,
     "gsis_id": "00-0034251",
     "pff_id": 48874,
+    "sleeper_id": 5532,
+    "yahoo_id": 31454,
     "espn_id": 3052059,
-    "yahoo_id": 31454
+    "espn_id_new": 3052059
   },
   {
     "mfl_id": 14671,
-    "sleeper_id": 6724,
     "gsis_id": "00-0035327",
     "pff_id": 26617,
-    "espn_id": 3128745,
+    "sleeper_id": 6724,
     "yahoo_id": 32454
   },
   {
     "mfl_id": 14672,
-    "sleeper_id": 6353,
-    "pfr_id": "ReedTr01",
     "gsis_id": "00-0035617",
     "pff_id": 38268,
+    "sleeper_id": 6353,
+    "yahoo_id": 32135,
     "espn_id": 3116177,
-    "yahoo_id": 32135
+    "pfr_id": "ReedTr01",
+    "espn_id_new": 3116177
   },
   {
     "mfl_id": 14673,
-    "sleeper_id": 6055,
-    "pfr_id": "PatrNa00",
     "gsis_id": "00-0035615",
     "pff_id": 49805,
-    "espn_id": 3728310,
-    "yahoo_id": 32134
+    "sleeper_id": 6055,
+    "yahoo_id": 32134,
+    "pfr_id": "PatrNa00"
   },
   {
     "mfl_id": 14674,
-    "sleeper_id": 4658,
     "gsis_id": "00-0033734",
     "pff_id": 12259,
-    "espn_id": 3892777,
+    "sleeper_id": 4658,
     "yahoo_id": 30716
   },
   {
     "mfl_id": 14675,
-    "sleeper_id": 6627,
-    "pfr_id": "TuttSh00",
     "gsis_id": "00-0035409",
     "pff_id": 37279,
+    "sleeper_id": 6627,
+    "yahoo_id": 32497,
     "espn_id": 3886601,
-    "yahoo_id": 32497
+    "pfr_id": "TuttSh00",
+    "espn_id_new": 3886601
   },
   {
     "mfl_id": 14676,
-    "sleeper_id": 6235,
-    "pfr_id": "PhilKy00",
     "gsis_id": "00-0035507",
     "pff_id": 36340,
+    "sleeper_id": 6235,
+    "yahoo_id": 32530,
     "espn_id": 3886528,
-    "yahoo_id": 32530
+    "pfr_id": "PhilKy00",
+    "espn_id_new": 3886528
   },
   {
     "mfl_id": 14677,
-    "sleeper_id": 6378,
     "gsis_id": "00-0035486",
     "pff_id": 37161,
-    "espn_id": 3913020,
+    "sleeper_id": 6378,
     "yahoo_id": 32155
   },
   {
     "mfl_id": 14678,
-    "sleeper_id": 6679,
-    "pfr_id": "SkipTu00",
     "gsis_id": "00-0035579",
     "pff_id": 44583,
-    "espn_id": 4039521,
-    "yahoo_id": 32582
+    "sleeper_id": 6679,
+    "yahoo_id": 32582,
+    "pfr_id": "SkipTu00"
   },
   {
     "mfl_id": 14679,
-    "sleeper_id": 6252,
     "gsis_id": "00-0035434",
     "pff_id": 50232,
-    "espn_id": 3124030,
+    "sleeper_id": 6252,
     "yahoo_id": 32549
   },
   {
     "mfl_id": 14680,
-    "sleeper_id": 6494,
     "gsis_id": "00-0035094",
     "pff_id": 38461,
-    "espn_id": 3115979,
+    "sleeper_id": 6494,
     "yahoo_id": 32336
   },
   {
     "mfl_id": 14681,
-    "sleeper_id": 5218,
     "gsis_id": "00-0034612",
     "pff_id": 48452,
-    "espn_id": 3052926,
+    "sleeper_id": 5218,
     "yahoo_id": 31256
   },
   {
     "mfl_id": 14682,
-    "sleeper_id": 6432,
     "gsis_id": "00-0035103",
     "pff_id": 49757,
-    "espn_id": 3122141,
+    "sleeper_id": 6432,
     "yahoo_id": 32304
   },
   {
     "mfl_id": 14683,
-    "sleeper_id": 2682,
-    "pfr_id": "JoneCh06",
     "gsis_id": "00-0034641",
     "pff_id": 49339,
-    "espn_id": 3116104,
-    "yahoo_id": 31636
+    "sleeper_id": 2682,
+    "yahoo_id": 31636,
+    "pfr_id": "JoneCh06"
   },
   {
     "mfl_id": 14696,
-    "sleeper_id": 6354,
     "gsis_id": "00-0035108",
     "pff_id": 50353,
-    "espn_id": 3886327,
+    "sleeper_id": 6354,
     "yahoo_id": 32145
   },
   {
     "mfl_id": 14702,
-    "sleeper_id": 6257,
     "gsis_id": "00-0035437",
     "pff_id": 51405,
+    "sleeper_id": 6257,
+    "yahoo_id": 32552,
     "espn_id": 3917058,
-    "yahoo_id": 32552
+    "espn_id_new": 3917058
   },
   {
     "mfl_id": 14713,
-    "sleeper_id": 5448,
     "gsis_id": "00-0034088",
     "pff_id": 28990,
-    "espn_id": 4036898,
+    "sleeper_id": 5448,
     "yahoo_id": 31370
   },
   {
     "mfl_id": 14716,
-    "sleeper_id": 6467,
     "gsis_id": "00-0035073",
     "pff_id": 94361,
+    "sleeper_id": 6467,
+    "yahoo_id": 32254,
     "espn_id": 4422407,
-    "yahoo_id": 32254
+    "espn_id_new": 4422407
   },
   {
     "mfl_id": 14717,
-    "sleeper_id": 6650,
     "gsis_id": "00-0035358",
+    "sleeper_id": 6650,
+    "yahoo_id": 32417,
     "espn_id": 3150744,
-    "yahoo_id": 32417
+    "espn_id_new": 3150744
   },
   {
     "mfl_id": 14720,
-    "sleeper_id": 6579,
     "gsis_id": "00-0035172",
     "pff_id": 33464,
-    "espn_id": 3935064,
+    "sleeper_id": 6579,
     "yahoo_id": 32371
   },
   {
     "mfl_id": 14722,
-    "sleeper_id": 6258,
     "gsis_id": "00-0035346",
     "pff_id": 50356,
+    "sleeper_id": 6258,
+    "yahoo_id": 32443,
     "espn_id": 3124702,
-    "yahoo_id": 32443
+    "espn_id_new": 3124702
   },
   {
     "mfl_id": 14727,
-    "sleeper_id": 6659,
-    "pfr_id": "ReynCr00",
     "gsis_id": "00-0035567",
     "pff_id": 94383,
+    "sleeper_id": 6659,
+    "yahoo_id": 32596,
     "espn_id": 4421446,
-    "yahoo_id": 32596
+    "pfr_id": "ReynCr00",
+    "espn_id_new": 4421446
   },
   {
     "mfl_id": 14728,
-    "sleeper_id": 6581,
-    "pfr_id": "RobeDe01",
     "gsis_id": "00-0035521",
     "pff_id": 30462,
-    "espn_id": 3125126,
-    "yahoo_id": 32427
+    "sleeper_id": 6581,
+    "yahoo_id": 32427,
+    "pfr_id": "RobeDe01"
   },
   {
     "mfl_id": 14737,
-    "sleeper_id": 6105,
-    "pfr_id": "GileJo01",
     "gsis_id": "00-0035363",
     "pff_id": 39382,
-    "espn_id": 3917797,
-    "yahoo_id": 32091
+    "sleeper_id": 6105,
+    "yahoo_id": 32091,
+    "pfr_id": "GileJo01"
   },
   {
     "mfl_id": 14738,
-    "sleeper_id": 6542,
     "gsis_id": "00-0035390",
     "pff_id": 56895,
-    "espn_id": 4239817,
+    "sleeper_id": 6542,
     "yahoo_id": 32408
   },
   {
     "mfl_id": 14741,
-    "sleeper_id": 6310,
     "gsis_id": "00-0035365",
     "pff_id": 35173,
-    "espn_id": 3917147,
+    "sleeper_id": 6310,
     "yahoo_id": 32092
   },
   {
     "mfl_id": 14746,
-    "sleeper_id": 5505,
     "gsis_id": "00-0034154",
     "pff_id": 50141,
-    "espn_id": 3134315,
+    "sleeper_id": 5505,
     "yahoo_id": 31352
   },
   {
     "mfl_id": 14748,
-    "sleeper_id": 6714,
     "gsis_id": "00-0035714",
     "pff_id": 27582,
-    "espn_id": 3139613,
+    "sleeper_id": 6714,
     "yahoo_id": 32628
   },
   {
     "mfl_id": 14751,
-    "sleeper_id": 6591,
-    "pfr_id": "JoneCh10",
     "gsis_id": "00-0035553",
     "pff_id": 47186,
-    "espn_id": 3126263,
-    "yahoo_id": 32565
+    "sleeper_id": 6591,
+    "yahoo_id": 32565,
+    "pfr_id": "JoneCh10"
   },
   {
     "mfl_id": 14752,
-    "sleeper_id": 6075,
     "gsis_id": "00-0035562",
     "pff_id": 91465,
+    "sleeper_id": 6075,
+    "yahoo_id": 32576,
     "espn_id": 3940587,
-    "yahoo_id": 32576
+    "espn_id_new": 3940587
   },
   {
     "mfl_id": 14753,
-    "sleeper_id": 6429,
-    "pfr_id": "HassJT00",
     "gsis_id": "00-0035044",
     "pff_id": 94366,
-    "espn_id": 4264341,
-    "yahoo_id": 32280
+    "sleeper_id": 6429,
+    "yahoo_id": 32280,
+    "pfr_id": "HassJT00"
   },
   {
     "mfl_id": 14755,
-    "sleeper_id": 6398,
-    "pfr_id": "GoodAh00",
     "gsis_id": "00-0034933",
     "pff_id": 29951,
-    "espn_id": 3127075,
-    "yahoo_id": 32192
+    "sleeper_id": 6398,
+    "yahoo_id": 32192,
+    "pfr_id": "GoodAh00"
   },
   {
     "mfl_id": 14756,
-    "sleeper_id": 5495,
     "gsis_id": "00-0034559",
     "pff_id": 38754,
-    "espn_id": 4035726,
+    "sleeper_id": 5495,
     "yahoo_id": 31286
   },
   {
     "mfl_id": 14758,
-    "sleeper_id": 6328,
     "gsis_id": "00-0035499",
     "pff_id": 49466,
-    "espn_id": 3125705,
+    "sleeper_id": 6328,
     "yahoo_id": 32522
   },
   {
     "mfl_id": 14759,
-    "sleeper_id": 6090,
-    "pfr_id": "HartMo01",
     "gsis_id": "00-0035339",
     "pff_id": 49390,
-    "espn_id": 3915970,
-    "yahoo_id": 32435
+    "sleeper_id": 6090,
+    "yahoo_id": 32435,
+    "pfr_id": "HartMo01"
   },
   {
     "mfl_id": 14760,
-    "sleeper_id": 5197,
     "gsis_id": "00-0034660",
     "pff_id": 29622,
-    "espn_id": 4048717,
+    "sleeper_id": 5197,
     "yahoo_id": 31607
   },
   {
     "mfl_id": 14761,
-    "sleeper_id": 6634,
     "gsis_id": "00-0035485",
     "pff_id": 49572,
-    "espn_id": 3914477,
+    "sleeper_id": 6634,
     "yahoo_id": 32472
   },
   {
     "mfl_id": 14762,
-    "sleeper_id": 5474,
     "gsis_id": "00-0034130",
     "pff_id": 38426,
-    "espn_id": 3125816,
+    "sleeper_id": 5474,
     "yahoo_id": 31415
   },
   {
     "mfl_id": 14777,
-    "sleeper_id": 6770,
-    "pfr_id": "BurrJo01",
     "gsis_id": "00-0036442",
     "pff_id": 28022,
+    "sleeper_id": 6770,
+    "espn_id": 3915511,
+    "pfr_id": "BurrJo01",
     "ras_id": 18958,
-    "otc_id": 8741
+    "otc_id": 8741,
+    "espn_id_new": 3915511
   },
   {
     "mfl_id": 14778,
-    "sleeper_id": 6768,
-    "pfr_id": "TagoTu00",
     "gsis_id": "00-0036212",
     "pff_id": 60326,
+    "sleeper_id": 6768,
+    "espn_id": 4241479,
+    "pfr_id": "TagoTu00",
     "ras_id": 20135,
-    "otc_id": 8745
+    "otc_id": 8745,
+    "espn_id_new": 4241479
   },
   {
     "mfl_id": 14779,
-    "sleeper_id": 6797,
-    "pfr_id": "HerbJu00",
     "gsis_id": "00-0036355",
     "pff_id": 28237,
+    "sleeper_id": 6797,
+    "espn_id": 4038941,
+    "pfr_id": "HerbJu00",
     "ras_id": 18938,
-    "otc_id": 8746
+    "otc_id": 8746,
+    "espn_id_new": 4038941
   },
   {
     "mfl_id": 14783,
-    "sleeper_id": 6904,
-    "pfr_id": "HurtJa00",
     "gsis_id": "00-0036389",
     "pff_id": 40291,
+    "sleeper_id": 6904,
+    "espn_id": 4040715,
+    "pfr_id": "HurtJa00",
     "ras_id": 18948,
-    "otc_id": 8793
+    "otc_id": 8793,
+    "espn_id_new": 4040715
   },
   {
     "mfl_id": 14784,
-    "sleeper_id": 7013,
     "gsis_id": "00-0036022",
     "pff_id": 46465,
-    "espn_id": 3915436,
+    "sleeper_id": 7013,
     "yahoo_id": 33207
   },
   {
@@ -6527,28 +6317,27 @@
   },
   {
     "mfl_id": 14787,
-    "sleeper_id": 6898,
     "gsis_id": "00-0035988",
     "pff_id": 40119,
-    "espn_id": 4055171,
+    "sleeper_id": 6898,
     "yahoo_id": 33266
   },
   {
     "mfl_id": 14788,
-    "sleeper_id": 7008,
     "gsis_id": "00-0036092",
     "pff_id": 34412,
-    "espn_id": 3929824,
+    "sleeper_id": 7008,
     "yahoo_id": 33015
   },
   {
     "mfl_id": 14789,
-    "sleeper_id": 7083,
-    "pfr_id": "HuntTy01",
     "gsis_id": "00-0035993",
     "pff_id": 46448,
+    "sleeper_id": 7083,
+    "yahoo_id": 32993,
     "espn_id": 4035671,
-    "yahoo_id": 32993
+    "pfr_id": "HuntTy01",
+    "espn_id_new": 4035671
   },
   {
     "mfl_id": 14791,
@@ -6556,18 +6345,17 @@
   },
   {
     "mfl_id": 14792,
-    "sleeper_id": 7335,
     "gsis_id": "00-0035939",
     "pff_id": 35299,
-    "espn_id": 3675812,
+    "sleeper_id": 7335,
     "yahoo_id": 33258
   },
   {
     "mfl_id": 14793,
-    "sleeper_id": 7084,
-    "pfr_id": "LutoJa00",
     "gsis_id": "00-0036312",
     "pff_id": 17287,
+    "sleeper_id": 7084,
+    "pfr_id": "LutoJa00",
     "ras_id": 17376,
     "otc_id": 8929
   },
@@ -6582,143 +6370,168 @@
   },
   {
     "mfl_id": 14797,
-    "sleeper_id": 6790,
-    "pfr_id": "SwifDA00",
     "gsis_id": "00-0036275",
     "pff_id": 57212,
+    "sleeper_id": 6790,
+    "espn_id": 4259545,
+    "pfr_id": "SwifDA00",
     "ras_id": 20140,
-    "otc_id": 8775
+    "otc_id": 8775,
+    "espn_id_new": 4259545
   },
   {
     "mfl_id": 14798,
-    "sleeper_id": 6845,
-    "pfr_id": "MossZa00",
     "gsis_id": "00-0036251",
     "pff_id": 40341,
+    "sleeper_id": 6845,
+    "espn_id": 4035676,
+    "pfr_id": "MossZa00",
     "ras_id": 14253,
-    "otc_id": 8826
+    "otc_id": 8826,
+    "espn_id_new": 4035676
   },
   {
     "mfl_id": 14799,
-    "sleeper_id": 6938,
-    "pfr_id": "AkerCa00",
     "gsis_id": "00-0036414",
     "pff_id": 57206,
+    "sleeper_id": 6938,
+    "espn_id": 4240021,
+    "pfr_id": "AkerCa00",
     "ras_id": 20143,
-    "otc_id": 8792
+    "otc_id": 8792,
+    "espn_id_new": 4240021
   },
   {
     "mfl_id": 14800,
-    "sleeper_id": 6806,
-    "pfr_id": "DobbJK00",
     "gsis_id": "00-0036158",
     "pff_id": 57366,
+    "sleeper_id": 6806,
+    "espn_id": 4241985,
+    "pfr_id": "DobbJK00",
     "ras_id": 20146,
-    "otc_id": 8795
+    "otc_id": 8795,
+    "espn_id_new": 4241985
   },
   {
     "mfl_id": 14802,
-    "sleeper_id": 6813,
-    "pfr_id": "TaylJo02",
     "gsis_id": "00-0036223",
     "pff_id": 57488,
+    "sleeper_id": 6813,
+    "espn_id": 4242335,
+    "pfr_id": "TaylJo02",
     "ras_id": 20139,
-    "otc_id": 8781
+    "otc_id": 8781,
+    "espn_id_new": 4242335
   },
   {
     "mfl_id": 14803,
-    "sleeper_id": 6820,
-    "pfr_id": "EdwaCl00",
     "gsis_id": "00-0036360",
     "pff_id": 57279,
+    "sleeper_id": 6820,
+    "espn_id": 4242214,
+    "pfr_id": "EdwaCl00",
     "ras_id": 20138,
-    "otc_id": 8772
+    "otc_id": 8772,
+    "espn_id_new": 4242214
   },
   {
     "mfl_id": 14804,
-    "sleeper_id": 6878,
-    "pfr_id": "McFaAn00",
     "gsis_id": "00-0036336",
     "pff_id": 57289,
+    "sleeper_id": 6878,
+    "espn_id": 4241941,
+    "pfr_id": "McFaAn00",
     "ras_id": 20145,
-    "otc_id": 8864
+    "otc_id": 8864,
+    "espn_id_new": 4241941
   },
   {
     "mfl_id": 14805,
-    "sleeper_id": 6828,
-    "pfr_id": "DillAJ00",
     "gsis_id": "00-0036265",
     "pff_id": 57165,
+    "sleeper_id": 6828,
+    "espn_id": 4239934,
+    "pfr_id": "DillAJ00",
     "ras_id": 20141,
-    "otc_id": 8802
+    "otc_id": 8802,
+    "espn_id_new": 4239934
   },
   {
     "mfl_id": 14806,
-    "sleeper_id": 6908,
-    "pfr_id": "PeriLa00",
     "gsis_id": "00-0036269",
     "pff_id": 26408,
+    "sleeper_id": 6908,
+    "espn_id": 4034952,
+    "pfr_id": "PeriLa00",
     "ras_id": 19031,
-    "otc_id": 8860
+    "otc_id": 8860,
+    "espn_id_new": 4034952
   },
   {
     "mfl_id": 14807,
-    "sleeper_id": 7045,
-    "pfr_id": "KellJo01",
     "gsis_id": "00-0036370",
     "pff_id": 13750,
+    "sleeper_id": 7045,
+    "espn_id": 3910544,
+    "pfr_id": "KellJo01",
     "ras_id": 13079,
-    "otc_id": 8852
+    "otc_id": 8852,
+    "espn_id_new": 3910544
   },
   {
     "mfl_id": 14808,
-    "sleeper_id": 7064,
-    "pfr_id": "EvanDa02",
     "gsis_id": "00-0036297",
     "pff_id": 40692,
+    "sleeper_id": 7064,
+    "espn_id": 4036431,
+    "pfr_id": "EvanDa02",
     "ras_id": 20185,
-    "otc_id": 8833
+    "otc_id": 8833,
+    "espn_id_new": 4036431
   },
   {
     "mfl_id": 14809,
-    "sleeper_id": 7101,
-    "pfr_id": "SmitRo08",
     "gsis_id": "00-0035957",
     "pff_id": 26306,
-    "yahoo_id": 33153
+    "sleeper_id": 7101,
+    "yahoo_id": 33153,
+    "pfr_id": "SmitRo08"
   },
   {
     "mfl_id": 14810,
-    "sleeper_id": 6885,
-    "pfr_id": "VaugKe00",
     "gsis_id": "00-0036450",
     "pff_id": 45866,
+    "sleeper_id": 6885,
+    "espn_id": 3917612,
+    "pfr_id": "VaugKe00",
     "ras_id": 17477,
-    "otc_id": 8816
+    "otc_id": 8816,
+    "espn_id_new": 3917612
   },
   {
     "mfl_id": 14811,
-    "sleeper_id": 6918,
-    "pfr_id": "AhmeSa01",
     "gsis_id": "00-0036020",
     "pff_id": 57472,
+    "sleeper_id": 6918,
+    "espn_id": 4243315,
+    "pfr_id": "AhmeSa01",
     "ras_id": 20189,
-    "otc_id": 9168
+    "otc_id": 9168,
+    "espn_id_new": 4243315
   },
   {
     "mfl_id": 14812,
-    "sleeper_id": 7038,
     "gsis_id": "00-0036027",
     "pff_id": 45958,
-    "espn_id": 4038533,
+    "sleeper_id": 7038,
     "yahoo_id": 33098
   },
   {
     "mfl_id": 14813,
-    "sleeper_id": 6955,
-    "pfr_id": "RobiJa00",
     "gsis_id": "00-0035831",
     "pff_id": 22425,
+    "sleeper_id": 6955,
+    "pfr_id": "RobiJa00",
     "ras_id": 19056,
     "otc_id": 9041
   },
@@ -6729,60 +6542,61 @@
   },
   {
     "mfl_id": 14815,
-    "sleeper_id": 6931,
-    "pfr_id": "DallDe00",
     "gsis_id": "00-0036425",
     "pff_id": 55632,
+    "sleeper_id": 6931,
+    "espn_id": 4240631,
+    "pfr_id": "DallDe00",
     "ras_id": 20186,
-    "otc_id": 8884
+    "otc_id": 8884,
+    "espn_id_new": 4240631
   },
   {
     "mfl_id": 14816,
-    "sleeper_id": 6992,
     "gsis_id": "00-0036006",
-    "espn_id": 4239083,
+    "sleeper_id": 6992,
     "yahoo_id": 32972
   },
   {
     "mfl_id": 14817,
-    "sleeper_id": 6963,
     "gsis_id": "00-0035973",
     "pff_id": 40448,
+    "sleeper_id": 6963,
+    "yahoo_id": 33235,
     "espn_id": 4039358,
-    "yahoo_id": 33235
+    "espn_id_new": 4039358
   },
   {
     "mfl_id": 14818,
-    "sleeper_id": 7088,
-    "pfr_id": "JoneXa00",
     "gsis_id": "00-0036078",
-    "espn_id": 3916209,
-    "yahoo_id": 33297
+    "sleeper_id": 7088,
+    "yahoo_id": 33297,
+    "pfr_id": "JoneXa00"
   },
   {
     "mfl_id": 14819,
-    "sleeper_id": 7103,
     "gsis_id": "00-0035825",
     "pff_id": 40616,
-    "espn_id": 4035470,
+    "sleeper_id": 7103,
     "yahoo_id": 33126
   },
   {
     "mfl_id": 14820,
-    "sleeper_id": 6966,
-    "pfr_id": "LeakJa01",
     "gsis_id": "00-0035868",
-    "espn_id": 4241940,
-    "yahoo_id": 33037
+    "sleeper_id": 6966,
+    "yahoo_id": 33037,
+    "pfr_id": "LeakJa01"
   },
   {
     "mfl_id": 14821,
-    "sleeper_id": 6996,
-    "pfr_id": "HastJa02",
     "gsis_id": "00-0035806",
     "pff_id": 25582,
+    "sleeper_id": 6996,
+    "espn_id": 3928925,
+    "pfr_id": "HastJa02",
     "ras_id": 19030,
-    "otc_id": 9172
+    "otc_id": 9172,
+    "espn_id_new": 3928925
   },
   {
     "mfl_id": 14822,
@@ -6790,479 +6604,540 @@
   },
   {
     "mfl_id": 14823,
-    "sleeper_id": 7021,
-    "pfr_id": "DowdRi01",
     "gsis_id": "00-0036139",
     "pff_id": 40693,
-    "espn_id": 4038815,
+    "sleeper_id": 7021,
     "yahoo_id": 33100,
+    "espn_id": 4038815,
+    "pfr_id": "DowdRi01",
     "ras_id": 13838,
-    "otc_id": 9346
+    "otc_id": 9346,
+    "espn_id_new": 4038815
   },
   {
     "mfl_id": 14824,
-    "sleeper_id": 7005,
-    "pfr_id": "PhilSc01",
     "gsis_id": "00-0036069",
     "pff_id": 83711,
-    "espn_id": 4362878,
+    "sleeper_id": 7005,
     "yahoo_id": 33161,
+    "pfr_id": "PhilSc01",
     "ras_id": 14218,
     "otc_id": 9030
   },
   {
     "mfl_id": 14826,
-    "sleeper_id": 7227,
-    "pfr_id": "PierAr00",
     "gsis_id": "00-0036208",
     "pff_id": 45749,
-    "espn_id": 4042808,
+    "sleeper_id": 7227,
     "yahoo_id": 33179,
+    "pfr_id": "PierAr00",
     "ras_id": 18719,
     "otc_id": 9415
   },
   {
     "mfl_id": 14827,
-    "sleeper_id": 6973,
-    "pfr_id": "TaylJJ01",
     "gsis_id": "00-0036096",
     "pff_id": 25512,
+    "sleeper_id": 6973,
+    "espn_id": 4039607,
+    "pfr_id": "TaylJJ01",
     "ras_id": 20144,
-    "otc_id": 9280
+    "otc_id": 9280,
+    "espn_id_new": 4039607
   },
   {
     "mfl_id": 14828,
-    "sleeper_id": 6984,
-    "pfr_id": "JoneTo04",
     "gsis_id": "00-0035860",
-    "pff_id": 40498
+    "pff_id": 40498,
+    "sleeper_id": 6984,
+    "espn_id": 4046676,
+    "pfr_id": "JoneTo04",
+    "espn_id_new": 4046676
   },
   {
     "mfl_id": 14829,
-    "sleeper_id": 7048,
     "gsis_id": "00-0036117",
     "pff_id": 57184,
-    "espn_id": 4045702,
+    "sleeper_id": 7048,
     "yahoo_id": 33309
   },
   {
     "mfl_id": 14830,
-    "sleeper_id": 6959,
-    "pfr_id": "BellLe02",
     "gsis_id": "00-0035912",
     "pff_id": 45854,
-    "espn_id": 3916721,
-    "yahoo_id": 32926
+    "sleeper_id": 6959,
+    "yahoo_id": 32926,
+    "pfr_id": "BellLe02"
   },
   {
     "mfl_id": 14831,
-    "sleeper_id": 7093,
-    "pfr_id": "KillAd00",
     "gsis_id": "00-0036000",
     "pff_id": 42425,
-    "espn_id": 4042112,
-    "yahoo_id": 32966
+    "sleeper_id": 7093,
+    "yahoo_id": 32966,
+    "pfr_id": "KillAd00"
   },
   {
     "mfl_id": 14832,
-    "sleeper_id": 6786,
-    "pfr_id": "LambCe00",
     "gsis_id": "00-0036358",
     "pff_id": 61570,
+    "sleeper_id": 6786,
+    "espn_id": 4241389,
+    "pfr_id": "LambCe00",
     "ras_id": 20152,
-    "otc_id": 8757
+    "otc_id": 8757,
+    "espn_id_new": 4241389
   },
   {
     "mfl_id": 14833,
-    "sleeper_id": 6783,
-    "pfr_id": "JeudJe00",
     "gsis_id": "00-0036407",
     "pff_id": 61103,
+    "sleeper_id": 6783,
+    "espn_id": 4241463,
+    "pfr_id": "JeudJe00",
     "ras_id": 20151,
-    "otc_id": 8755
+    "otc_id": 8755,
+    "espn_id_new": 4241463
   },
   {
     "mfl_id": 14834,
-    "sleeper_id": 6789,
-    "pfr_id": "RuggHe00",
     "gsis_id": "00-0036357",
     "pff_id": 61102,
+    "sleeper_id": 6789,
+    "pfr_id": "RuggHe00",
     "ras_id": 20192,
     "otc_id": 8752
   },
   {
     "mfl_id": 14835,
-    "sleeper_id": 6801,
-    "pfr_id": "HiggTe00",
     "gsis_id": "00-0036410",
     "pff_id": 61211,
+    "sleeper_id": 6801,
+    "espn_id": 4239993,
+    "pfr_id": "HiggTe00",
     "ras_id": 20153,
-    "otc_id": 8773
+    "otc_id": 8773,
+    "espn_id_new": 4239993
   },
   {
     "mfl_id": 14836,
-    "sleeper_id": 6794,
-    "pfr_id": "JeffJu00",
     "gsis_id": "00-0036322",
     "pff_id": 61398,
+    "sleeper_id": 6794,
+    "espn_id": 4262921,
+    "pfr_id": "JeffJu00",
     "ras_id": 20157,
-    "otc_id": 8762
+    "otc_id": 8762,
+    "espn_id_new": 4262921
   },
   {
     "mfl_id": 14837,
-    "sleeper_id": 6805,
-    "pfr_id": "HamlKJ00",
     "gsis_id": "00-0036412",
     "pff_id": 61590,
+    "sleeper_id": 6805,
+    "pfr_id": "HamlKJ00",
     "ras_id": 20155,
     "otc_id": 8786
   },
   {
     "mfl_id": 14838,
-    "sleeper_id": 6814,
-    "pfr_id": "ShenLa00",
     "gsis_id": "00-0036268",
     "pff_id": 61220,
+    "sleeper_id": 6814,
+    "espn_id": 4243160,
+    "pfr_id": "ShenLa00",
     "ras_id": 18213,
-    "otc_id": 8782
+    "otc_id": 8782,
+    "espn_id_new": 4243160
   },
   {
     "mfl_id": 14839,
-    "sleeper_id": 6798,
-    "pfr_id": "ReagJa00",
     "gsis_id": "00-0036387",
     "pff_id": 61697,
+    "sleeper_id": 6798,
+    "espn_id": 4241802,
+    "pfr_id": "ReagJa00",
     "ras_id": 20156,
-    "otc_id": 8761
+    "otc_id": 8761,
+    "espn_id_new": 4241802
   },
   {
     "mfl_id": 14840,
-    "sleeper_id": 6803,
-    "pfr_id": "AiyuBr00",
     "gsis_id": "00-0036261",
     "pff_id": 84109,
+    "sleeper_id": 6803,
+    "espn_id": 4360438,
+    "pfr_id": "AiyuBr00",
     "ras_id": 18212,
-    "otc_id": 8765
+    "otc_id": 8765,
+    "espn_id_new": 4360438
   },
   {
     "mfl_id": 14841,
-    "sleeper_id": 6886,
-    "pfr_id": "ClayCh01",
     "gsis_id": "00-0036326",
     "pff_id": 42312,
+    "sleeper_id": 6886,
+    "espn_id": 4046692,
+    "pfr_id": "ClayCh01",
     "ras_id": 18243,
-    "otc_id": 8789
+    "otc_id": 8789,
+    "espn_id_new": 4046692
   },
   {
     "mfl_id": 14842,
-    "sleeper_id": 6819,
-    "pfr_id": "PittMi01",
     "gsis_id": "00-0036252",
     "pff_id": 29049,
+    "sleeper_id": 6819,
+    "espn_id": 4035687,
+    "pfr_id": "PittMi01",
     "ras_id": 18211,
-    "otc_id": 8774
+    "otc_id": 8774,
+    "espn_id_new": 4035687
   },
   {
     "mfl_id": 14843,
-    "sleeper_id": 6909,
-    "pfr_id": "BowdLy00",
     "gsis_id": "00-0036364",
     "pff_id": 61361,
+    "sleeper_id": 6909,
+    "espn_id": 4259979,
+    "pfr_id": "BowdLy00",
     "ras_id": 20199,
-    "otc_id": 8820
+    "otc_id": 8820,
+    "espn_id_new": 4259979
   },
   {
     "mfl_id": 14844,
-    "sleeper_id": 6870,
-    "pfr_id": "EdwaBr01",
     "gsis_id": "00-0036365",
     "pff_id": 28486,
+    "sleeper_id": 6870,
+    "espn_id": 4038818,
+    "pfr_id": "EdwaBr01",
     "ras_id": 20148,
-    "otc_id": 8821
+    "otc_id": 8821,
+    "espn_id_new": 4038818
   },
   {
     "mfl_id": 14845,
-    "sleeper_id": 6943,
-    "pfr_id": "DaviGa01",
     "gsis_id": "00-0036196",
     "pff_id": 55410,
+    "sleeper_id": 6943,
+    "espn_id": 4243537,
+    "pfr_id": "DaviGa01",
     "ras_id": 20191,
-    "otc_id": 8868
+    "otc_id": 8868,
+    "espn_id_new": 4243537
   },
   {
     "mfl_id": 14846,
-    "sleeper_id": 6849,
-    "pfr_id": "MimsDe00",
     "gsis_id": "00-0036255",
     "pff_id": 47800,
+    "sleeper_id": 6849,
+    "espn_id": 4035403,
+    "pfr_id": "MimsDe00",
     "ras_id": 18200,
-    "otc_id": 8799
+    "otc_id": 8799,
+    "espn_id_new": 4035403
   },
   {
     "mfl_id": 14847,
-    "sleeper_id": 6847,
-    "pfr_id": "DuveDe00",
     "gsis_id": "00-0036331",
     "pff_id": 40006,
+    "sleeper_id": 6847,
+    "espn_id": 4039050,
+    "pfr_id": "DuveDe00",
     "ras_id": 18216,
-    "otc_id": 8832
+    "otc_id": 8832,
+    "espn_id_new": 4039050
   },
   {
     "mfl_id": 14848,
-    "sleeper_id": 6957,
-    "pfr_id": "ProcJa00",
     "gsis_id": "00-0036133",
     "pff_id": 48037,
+    "sleeper_id": 6957,
+    "pfr_id": "ProcJa00",
     "ras_id": 18210,
     "otc_id": 8941
   },
   {
     "mfl_id": 14850,
-    "sleeper_id": 6895,
-    "pfr_id": "CephQu00",
     "gsis_id": "00-0036277",
     "pff_id": 29614,
+    "sleeper_id": 6895,
+    "espn_id": 4035793,
+    "pfr_id": "CephQu00",
     "ras_id": 20198,
-    "otc_id": 8906
+    "otc_id": 8906,
+    "espn_id_new": 4035793
   },
   {
     "mfl_id": 14851,
-    "sleeper_id": 6866,
-    "pfr_id": "HillKJ00",
     "gsis_id": "00-0036382",
     "pff_id": 28025,
+    "sleeper_id": 6866,
+    "pfr_id": "HillKJ00",
     "ras_id": 899,
     "otc_id": 8960
   },
   {
     "mfl_id": 14852,
-    "sleeper_id": 6945,
-    "pfr_id": "GibsAn00",
     "gsis_id": "00-0036328",
     "pff_id": 78050,
+    "sleeper_id": 6945,
+    "espn_id": 4360294,
+    "pfr_id": "GibsAn00",
     "ras_id": 18260,
-    "otc_id": 8806
+    "otc_id": 8806,
+    "espn_id_new": 4360294
   },
   {
     "mfl_id": 14853,
-    "sleeper_id": 6857,
-    "pfr_id": "JohnCo01",
     "gsis_id": "00-0036254",
     "pff_id": 47808,
+    "sleeper_id": 6857,
+    "espn_id": 4039043,
+    "pfr_id": "JohnCo01",
     "ras_id": 18316,
-    "otc_id": 8905
+    "otc_id": 8905,
+    "espn_id_new": 4039043
   },
   {
     "mfl_id": 14854,
-    "sleeper_id": 6939,
     "gsis_id": "00-0035819",
     "pff_id": 42198,
-    "espn_id": 4040628,
+    "sleeper_id": 6939,
     "yahoo_id": 33040
   },
   {
     "mfl_id": 14855,
-    "sleeper_id": 6873,
-    "pfr_id": "MackAu01",
     "gsis_id": "00-0035869",
     "pff_id": 28070,
-    "espn_id": 4040623,
+    "sleeper_id": 6873,
     "yahoo_id": 33039,
+    "espn_id": 4040623,
+    "pfr_id": "MackAu01",
     "ras_id": 18264,
-    "otc_id": 9027
+    "otc_id": 9027,
+    "espn_id_new": 4040623
   },
   {
     "mfl_id": 14856,
-    "sleeper_id": 6879,
     "gsis_id": "00-0035978",
     "pff_id": 39931,
-    "espn_id": 4035221,
+    "sleeper_id": 6879,
     "yahoo_id": 33027
   },
   {
     "mfl_id": 14857,
-    "sleeper_id": 6824,
-    "pfr_id": "PeopDo00",
     "gsis_id": "00-0036233",
     "pff_id": 61439,
+    "sleeper_id": 6824,
+    "espn_id": 4258195,
+    "pfr_id": "PeopDo00",
     "ras_id": 20154,
-    "otc_id": 8927
+    "otc_id": 8927,
+    "espn_id_new": 4258195
   },
   {
     "mfl_id": 14858,
-    "sleeper_id": 6853,
-    "pfr_id": "JeffVa00",
     "gsis_id": "00-0036415",
     "pff_id": 47447,
+    "sleeper_id": 6853,
+    "espn_id": 3930066,
+    "pfr_id": "JeffVa00",
     "ras_id": 20150,
-    "otc_id": 8797
+    "otc_id": 8797,
+    "espn_id_new": 3930066
   },
   {
     "mfl_id": 14859,
-    "sleeper_id": 7009,
     "gsis_id": "00-0035934",
     "pff_id": 41247,
+    "sleeper_id": 7009,
+    "yahoo_id": 33253,
     "espn_id": 4046715,
-    "yahoo_id": 33253
+    "espn_id_new": 4046715
   },
   {
     "mfl_id": 14861,
-    "sleeper_id": 7002,
-    "pfr_id": "JohnJu02",
     "gsis_id": "00-0036040",
     "pff_id": 28305,
+    "sleeper_id": 7002,
+    "espn_id": 3929645,
+    "pfr_id": "JohnJu02",
     "ras_id": 16760,
-    "otc_id": 9380
+    "otc_id": 9380,
+    "espn_id_new": 3929645
   },
   {
     "mfl_id": 14862,
-    "sleeper_id": 6913,
-    "pfr_id": "ReedJo03",
     "gsis_id": "00-0036377",
     "pff_id": 40221,
+    "sleeper_id": 6913,
+    "espn_id": 4037591,
+    "pfr_id": "ReedJo03",
     "ras_id": 17419,
-    "otc_id": 8891
+    "otc_id": 8891,
+    "espn_id_new": 4037591
   },
   {
     "mfl_id": 14863,
-    "sleeper_id": 6906,
-    "pfr_id": "GandAn00",
     "gsis_id": "00-0036340",
     "pff_id": 39993,
+    "sleeper_id": 6906,
+    "pfr_id": "GandAn00",
     "ras_id": 18203,
     "otc_id": 8882
   },
   {
     "mfl_id": 14864,
-    "sleeper_id": 6960,
-    "pfr_id": "JohnTy00",
     "gsis_id": "00-0036427",
     "pff_id": 48054,
+    "sleeper_id": 6960,
+    "espn_id": 2310331,
+    "pfr_id": "JohnTy00",
     "ras_id": 18263,
-    "otc_id": 8901
+    "otc_id": 8901,
+    "espn_id_new": 2310331
   },
   {
     "mfl_id": 14865,
-    "sleeper_id": 7135,
-    "pfr_id": "SwaiFr00",
     "gsis_id": "00-0036247",
     "pff_id": 26448,
+    "sleeper_id": 7135,
+    "espn_id": 4034950,
+    "pfr_id": "SwaiFr00",
     "ras_id": 16393,
-    "otc_id": 8954
+    "otc_id": 8954,
+    "espn_id_new": 4034950
   },
   {
     "mfl_id": 14866,
     "sleeper_id": 7076,
-    "espn_id": 4240626,
     "yahoo_id": 33022
   },
   {
     "mfl_id": 14867,
-    "sleeper_id": 6826,
-    "pfr_id": "KmetCo00",
     "gsis_id": "00-0036290",
     "pff_id": 60995,
+    "sleeper_id": 6826,
+    "espn_id": 4258595,
+    "pfr_id": "KmetCo00",
     "ras_id": 20172,
-    "otc_id": 8783
+    "otc_id": 8783,
+    "espn_id_new": 4258595
   },
   {
     "mfl_id": 14869,
-    "sleeper_id": 6919,
     "gsis_id": "00-0036023",
     "pff_id": 47191,
-    "espn_id": 4036189,
+    "sleeper_id": 6919,
     "yahoo_id": 33208
   },
   {
     "mfl_id": 14870,
-    "sleeper_id": 6869,
-    "pfr_id": "TrauAd00",
     "gsis_id": "00-0036422",
     "pff_id": 109795,
+    "sleeper_id": 6869,
+    "espn_id": 3911853,
+    "pfr_id": "TrauAd00",
     "ras_id": 18270,
-    "otc_id": 8845
+    "otc_id": 8845,
+    "espn_id_new": 3911853
   },
   {
     "mfl_id": 14871,
-    "sleeper_id": 6865,
-    "pfr_id": "ParkCo02",
     "gsis_id": "00-0036244",
     "pff_id": 52266,
+    "sleeper_id": 6865,
+    "espn_id": 4242557,
+    "pfr_id": "ParkCo02",
     "ras_id": 20158,
-    "otc_id": 8873
+    "otc_id": 8873,
+    "espn_id_new": 4242557
   },
   {
     "mfl_id": 14872,
-    "sleeper_id": 6834,
     "gsis_id": "00-0035787",
     "pff_id": 47214,
-    "espn_id": 3915772,
+    "sleeper_id": 6834,
     "yahoo_id": 33064
   },
   {
     "mfl_id": 14873,
-    "sleeper_id": 6843,
-    "pfr_id": "OkwuAl00",
     "gsis_id": "00-0036423",
     "pff_id": 41933,
+    "sleeper_id": 6843,
+    "espn_id": 4035115,
+    "pfr_id": "OkwuAl00",
     "ras_id": 15871,
-    "otc_id": 8858
+    "otc_id": 8858,
+    "espn_id_new": 4035115
   },
   {
     "mfl_id": 14874,
-    "sleeper_id": 6846,
-    "pfr_id": "BryaHu02",
     "gsis_id": "00-0036008",
     "pff_id": 61072,
-    "espn_id": 4243318,
+    "sleeper_id": 6846,
     "yahoo_id": 33186,
+    "pfr_id": "BryaHu02",
     "ras_id": 20171,
     "otc_id": 9133
   },
   {
     "mfl_id": 14875,
-    "sleeper_id": 6850,
-    "pfr_id": "BryaHa00",
     "gsis_id": "00-0036232",
     "pff_id": 26394,
+    "sleeper_id": 6850,
+    "espn_id": 4040774,
+    "pfr_id": "BryaHa00",
     "ras_id": 19126,
-    "otc_id": 8855
+    "otc_id": 8855,
+    "espn_id_new": 4040774
   },
   {
     "mfl_id": 14876,
-    "sleeper_id": 7050,
-    "pfr_id": "DeguJo00",
     "gsis_id": "00-0036332",
     "pff_id": 47034,
+    "sleeper_id": 7050,
+    "pfr_id": "DeguJo00",
     "ras_id": 18272,
     "otc_id": 8834
   },
   {
     "mfl_id": 14877,
-    "gsis_id": "00-0036321"
+    "gsis_id": "00-0036321",
+    "espn_id": 4241986,
+    "espn_id_new": 4241986
   },
   {
     "mfl_id": 14878,
-    "gsis_id": "00-0036288"
+    "gsis_id": "00-0036288",
+    "espn_id": 4259594,
+    "espn_id_new": 4259594
   },
   {
     "mfl_id": 14879,
-    "gsis_id": "00-0036192"
+    "gsis_id": "00-0036192",
+    "espn_id": 4240585,
+    "espn_id_new": 4240585
   },
   {
     "mfl_id": 14880,
-    "gsis_id": "00-0036341"
+    "gsis_id": "00-0036341",
+    "espn_id": 4039029,
+    "espn_id_new": 4039029
   },
   {
     "mfl_id": 14881,
-    "sleeper_id": 6861,
     "gsis_id": "00-0036089",
-    "espn_id": 4047458,
+    "sleeper_id": 6861,
     "yahoo_id": 33320
   },
   {
     "mfl_id": 14882,
-    "gsis_id": "00-0036224"
+    "gsis_id": "00-0036224",
+    "espn_id": 3916409,
+    "espn_id_new": 3916409
   },
   {
     "mfl_id": 14883,
@@ -7282,15 +7157,21 @@
   },
   {
     "mfl_id": 14887,
-    "gsis_id": "00-0036356"
+    "gsis_id": "00-0036356",
+    "espn_id": 4035462,
+    "espn_id_new": 4035462
   },
   {
     "mfl_id": 14888,
-    "gsis_id": "00-0036286"
+    "gsis_id": "00-0036286",
+    "espn_id": 4242205,
+    "espn_id_new": 4242205
   },
   {
     "mfl_id": 14889,
-    "gsis_id": "00-0036441"
+    "gsis_id": "00-0036441",
+    "espn_id": 4241394,
+    "espn_id_new": 4241394
   },
   {
     "mfl_id": 14890,
@@ -7298,19 +7179,27 @@
   },
   {
     "mfl_id": 14891,
-    "gsis_id": "00-0036280"
+    "gsis_id": "00-0036280",
+    "espn_id": 4040615,
+    "espn_id_new": 4040615
   },
   {
     "mfl_id": 14892,
-    "gsis_id": "00-0036409"
+    "gsis_id": "00-0036409",
+    "espn_id": 4043130,
+    "espn_id_new": 4043130
   },
   {
     "mfl_id": 14893,
-    "gsis_id": "00-0036418"
+    "gsis_id": "00-0036418",
+    "espn_id": 3917657,
+    "espn_id_new": 3917657
   },
   {
     "mfl_id": 14894,
-    "gsis_id": "00-0036193"
+    "gsis_id": "00-0036193",
+    "espn_id": 3925350,
+    "espn_id_new": 3925350
   },
   {
     "mfl_id": 14895,
@@ -7318,43 +7207,63 @@
   },
   {
     "mfl_id": 14896,
-    "gsis_id": "00-0036323"
+    "gsis_id": "00-0036323",
+    "espn_id": 4242207,
+    "espn_id_new": 4242207
   },
   {
     "mfl_id": 14897,
-    "gsis_id": "00-0036220"
+    "gsis_id": "00-0036220",
+    "espn_id": 4035495,
+    "espn_id_new": 4035495
   },
   {
     "mfl_id": 14898,
-    "gsis_id": "00-0036213"
+    "gsis_id": "00-0036213",
+    "espn_id": 4040965,
+    "espn_id_new": 4040965
   },
   {
     "mfl_id": 14899,
-    "gsis_id": "00-0036260"
+    "gsis_id": "00-0036260",
+    "espn_id": 4259491,
+    "espn_id_new": 4259491
   },
   {
     "mfl_id": 14900,
-    "gsis_id": "00-0036130"
+    "gsis_id": "00-0036130",
+    "espn_id": 4035245,
+    "espn_id_new": 4035245
   },
   {
     "mfl_id": 14901,
-    "gsis_id": "00-0036366"
+    "gsis_id": "00-0036366",
+    "espn_id": 3892883,
+    "espn_id_new": 3892883
   },
   {
     "mfl_id": 14902,
-    "gsis_id": "00-0036274"
+    "gsis_id": "00-0036274",
+    "espn_id": 4241984,
+    "espn_id_new": 4241984
   },
   {
     "mfl_id": 14903,
-    "gsis_id": "00-0036361"
+    "gsis_id": "00-0036361",
+    "espn_id": 4040966,
+    "espn_id_new": 4040966
   },
   {
     "mfl_id": 14904,
-    "gsis_id": "00-0036416"
+    "gsis_id": "00-0036416",
+    "espn_id": 4035433,
+    "espn_id_new": 4035433
   },
   {
     "mfl_id": 14905,
-    "gsis_id": "00-0036281"
+    "gsis_id": "00-0036281",
+    "espn_id": 4240596,
+    "espn_id_new": 4240596
   },
   {
     "mfl_id": 14906,
@@ -7362,64 +7271,75 @@
   },
   {
     "mfl_id": 14908,
-    "gsis_id": "00-0036388"
+    "gsis_id": "00-0036388",
+    "espn_id": 4241470,
+    "espn_id_new": 4241470
   },
   {
     "mfl_id": 14909,
-    "gsis_id": "00-0036411"
+    "gsis_id": "00-0036411",
+    "espn_id": 4034790,
+    "espn_id_new": 4034790
   },
   {
     "mfl_id": 14910,
-    "gsis_id": "00-0036221"
+    "gsis_id": "00-0036221",
+    "espn_id": 4039059,
+    "espn_id_new": 4039059
   },
   {
     "mfl_id": 14911,
-    "gsis_id": "00-0036329"
+    "gsis_id": "00-0036329",
+    "espn_id": 3858271,
+    "espn_id_new": 3858271
   },
   {
     "mfl_id": 14912,
-    "sleeper_id": 7062,
     "gsis_id": "00-0035849",
+    "sleeper_id": 7062,
+    "yahoo_id": 33211,
     "espn_id": 3915165,
-    "yahoo_id": 33211
+    "espn_id_new": 3915165
   },
   {
     "mfl_id": 14913,
-    "sleeper_id": 5628,
     "gsis_id": "00-0034605",
     "pff_id": 50627,
-    "espn_id": 3053054,
+    "sleeper_id": 5628,
     "yahoo_id": 31669
   },
   {
     "mfl_id": 14915,
-    "sleeper_id": 7095,
     "gsis_id": "00-0035759",
-    "espn_id": 3053774,
+    "sleeper_id": 7095,
     "yahoo_id": 32667
   },
   {
     "mfl_id": 14916,
-    "sleeper_id": 6138,
     "gsis_id": "00-0035370",
     "pff_id": 44429,
-    "espn_id": 4035425,
+    "sleeper_id": 6138,
     "yahoo_id": 32097
   },
   {
     "mfl_id": 14917,
-    "sleeper_id": 6108,
     "gsis_id": "00-0035760",
+    "sleeper_id": 6108,
+    "yahoo_id": 32669,
     "espn_id": 3693033,
-    "yahoo_id": 32669
+    "espn_id_new": 3693033
   },
   {
     "mfl_id": 14918,
-    "gsis_id": "00-0036285"
+    "gsis_id": "00-0036285",
+    "espn_id": 4239995,
+    "espn_id_new": 4239995
   },
   {
     "mfl_id": 14919,
-    "gsis_id": "00-0036287"
+    "gsis_id": "00-0036287",
+    "espn_id": 4242516,
+    "espn_id_new": 4242516
   },
   {
     "mfl_id": 14920,
@@ -7427,43 +7347,63 @@
   },
   {
     "mfl_id": 14921,
-    "gsis_id": "00-0036231"
+    "gsis_id": "00-0036231",
+    "espn_id": 4401811,
+    "espn_id_new": 4401811
   },
   {
     "mfl_id": 14922,
-    "gsis_id": "00-0036289"
+    "gsis_id": "00-0036289",
+    "espn_id": 4038557,
+    "espn_id_new": 4038557
   },
   {
     "mfl_id": 14924,
-    "gsis_id": "00-0036292"
+    "gsis_id": "00-0036292",
+    "espn_id": 4243253,
+    "espn_id_new": 4243253
   },
   {
     "mfl_id": 14925,
-    "gsis_id": "00-0036159"
+    "gsis_id": "00-0036159",
+    "espn_id": 4046528,
+    "espn_id_new": 4046528
   },
   {
     "mfl_id": 14926,
-    "gsis_id": "00-0036362"
+    "gsis_id": "00-0036362",
+    "espn_id": 4259804,
+    "espn_id_new": 4259804
   },
   {
     "mfl_id": 14927,
-    "gsis_id": "00-0036293"
+    "gsis_id": "00-0036293",
+    "espn_id": 4043169,
+    "espn_id_new": 4043169
   },
   {
     "mfl_id": 14928,
-    "gsis_id": "00-0036294"
+    "gsis_id": "00-0036294",
+    "espn_id": 3918330,
+    "espn_id_new": 3918330
   },
   {
     "mfl_id": 14929,
-    "gsis_id": "00-0036249"
+    "gsis_id": "00-0036249",
+    "espn_id": 4046690,
+    "espn_id_new": 4046690
   },
   {
     "mfl_id": 14930,
-    "gsis_id": "00-0036262"
+    "gsis_id": "00-0036262",
+    "espn_id": 3915520,
+    "espn_id_new": 3915520
   },
   {
     "mfl_id": 14931,
-    "gsis_id": "00-0036390"
+    "gsis_id": "00-0036390",
+    "espn_id": 3894830,
+    "espn_id_new": 3894830
   },
   {
     "mfl_id": 14932,
@@ -7471,41 +7411,55 @@
   },
   {
     "mfl_id": 14933,
-    "gsis_id": "00-0036253"
+    "gsis_id": "00-0036253",
+    "espn_id": 4035661,
+    "espn_id_new": 4035661
   },
   {
     "mfl_id": 14934,
-    "gsis_id": "00-0036266"
+    "gsis_id": "00-0036266",
+    "espn_id": 4039052,
+    "espn_id_new": 4039052
   },
   {
     "mfl_id": 14935,
-    "gsis_id": "00-0036330"
+    "gsis_id": "00-0036330",
+    "espn_id": 4035385,
+    "espn_id_new": 4035385
   },
   {
     "mfl_id": 14936,
-    "sleeper_id": 6956,
-    "pfr_id": "AsiaDe00",
     "gsis_id": "00-0036194",
     "pff_id": 40294,
+    "sleeper_id": 6956,
+    "espn_id": 4046522,
+    "pfr_id": "AsiaDe00",
     "ras_id": 19113,
-    "otc_id": 8831
+    "otc_id": 8831,
+    "espn_id_new": 4046522
   },
   {
     "mfl_id": 14937,
-    "gsis_id": "00-0036420"
+    "gsis_id": "00-0036420",
+    "espn_id": 4035566,
+    "espn_id_new": 4035566
   },
   {
     "mfl_id": 14939,
-    "sleeper_id": 7082,
-    "pfr_id": "KeenDa00",
     "gsis_id": "00-0036225",
     "pff_id": 61068,
+    "sleeper_id": 7082,
+    "espn_id": 4240861,
+    "pfr_id": "KeenDa00",
     "ras_id": 20201,
-    "otc_id": 8841
+    "otc_id": 8841,
+    "espn_id_new": 4240861
   },
   {
     "mfl_id": 14940,
-    "gsis_id": "00-0036333"
+    "gsis_id": "00-0036333",
+    "espn_id": 4037333,
+    "espn_id_new": 4037333
   },
   {
     "mfl_id": 14941,
@@ -7513,11 +7467,15 @@
   },
   {
     "mfl_id": 14942,
-    "gsis_id": "00-0036421"
+    "gsis_id": "00-0036421",
+    "espn_id": 4035663,
+    "espn_id_new": 4035663
   },
   {
     "mfl_id": 14943,
-    "gsis_id": "00-0036298"
+    "gsis_id": "00-0036298",
+    "espn_id": 3917142,
+    "espn_id_new": 3917142
   },
   {
     "mfl_id": 14944,
@@ -7529,15 +7487,21 @@
   },
   {
     "mfl_id": 14946,
-    "gsis_id": "00-0036371"
+    "gsis_id": "00-0036371",
+    "espn_id": 4035666,
+    "espn_id_new": 4035666
   },
   {
     "mfl_id": 14947,
-    "gsis_id": "00-0036335"
+    "gsis_id": "00-0036335",
+    "espn_id": 4038849,
+    "espn_id_new": 4038849
   },
   {
     "mfl_id": 14948,
-    "gsis_id": "00-0036300"
+    "gsis_id": "00-0036300",
+    "espn_id": 4243009,
+    "espn_id_new": 4243009
   },
   {
     "mfl_id": 14949,
@@ -7545,11 +7509,15 @@
   },
   {
     "mfl_id": 14950,
-    "gsis_id": "00-0036395"
+    "gsis_id": "00-0036395",
+    "espn_id": 4035463,
+    "espn_id_new": 4035463
   },
   {
     "mfl_id": 14951,
-    "gsis_id": "00-0036337"
+    "gsis_id": "00-0036337",
+    "espn_id": 4259181,
+    "espn_id_new": 4259181
   },
   {
     "mfl_id": 14952,
@@ -7557,27 +7525,39 @@
   },
   {
     "mfl_id": 14953,
-    "gsis_id": "00-0036338"
+    "gsis_id": "00-0036338",
+    "espn_id": 4038946,
+    "espn_id_new": 4038946
   },
   {
     "mfl_id": 14954,
-    "gsis_id": "00-0036302"
+    "gsis_id": "00-0036302",
+    "espn_id": 3858276,
+    "espn_id_new": 3858276
   },
   {
     "mfl_id": 14955,
-    "gsis_id": "00-0036303"
+    "gsis_id": "00-0036303",
+    "espn_id": 4241977,
+    "espn_id_new": 4241977
   },
   {
     "mfl_id": 14956,
-    "gsis_id": "00-0036374"
+    "gsis_id": "00-0036374",
+    "espn_id": 4040432,
+    "espn_id_new": 4040432
   },
   {
     "mfl_id": 14957,
-    "gsis_id": "00-0036375"
+    "gsis_id": "00-0036375",
+    "espn_id": 4239694,
+    "espn_id_new": 4239694
   },
   {
     "mfl_id": 14958,
-    "gsis_id": "00-0036235"
+    "gsis_id": "00-0036235",
+    "espn_id": 4037468,
+    "espn_id_new": 4037468
   },
   {
     "mfl_id": 14959,
@@ -7593,31 +7573,40 @@
   },
   {
     "mfl_id": 14962,
-    "gsis_id": "00-0036305"
+    "gsis_id": "00-0036305",
+    "espn_id": 3917016,
+    "espn_id_new": 3917016
   },
   {
     "mfl_id": 14963,
-    "gsis_id": "00-0036306"
+    "gsis_id": "00-0036306",
+    "espn_id": 4035505,
+    "espn_id_new": 4035505
   },
   {
     "mfl_id": 14964,
     "gsis_id": "00-0036241",
-    "espn_id": 4037584
+    "espn_id": 4037584,
+    "espn_id_new": 4037584
   },
   {
     "mfl_id": 14966,
-    "gsis_id": "00-0036343"
+    "gsis_id": "00-0036343",
+    "espn_id": 4046525,
+    "espn_id_new": 4046525
   },
   {
     "mfl_id": 14967,
-    "gsis_id": "00-0036307"
+    "gsis_id": "00-0036307",
+    "espn_id": 4036651,
+    "espn_id_new": 4036651
   },
   {
     "mfl_id": 14969,
-    "sleeper_id": 7086,
-    "pfr_id": "HighJo00",
     "gsis_id": "00-0036398",
     "pff_id": 84142,
+    "sleeper_id": 7086,
+    "pfr_id": "HighJo00",
     "ras_id": 17407,
     "otc_id": 8908
   },
@@ -7627,29 +7616,35 @@
   },
   {
     "mfl_id": 14971,
-    "gsis_id": "00-0036081"
+    "gsis_id": "00-0036081",
+    "espn_id": 3915837,
+    "espn_id_new": 3915837
   },
   {
     "mfl_id": 14973,
-    "sleeper_id": 7107,
-    "pfr_id": "HuntJa01",
     "gsis_id": "00-0036278",
     "pff_id": 45693,
+    "sleeper_id": 7107,
+    "pfr_id": "HuntJa01",
     "ras_id": 19039,
     "otc_id": 8912
   },
   {
     "mfl_id": 14974,
-    "sleeper_id": 7090,
-    "pfr_id": "MoonDa00",
     "gsis_id": "00-0036309",
     "pff_id": 48236,
+    "sleeper_id": 7090,
+    "espn_id": 4040655,
+    "pfr_id": "MoonDa00",
     "ras_id": 17781,
-    "otc_id": 8913
+    "otc_id": 8913,
+    "espn_id_new": 4040655
   },
   {
     "mfl_id": 14975,
-    "gsis_id": "00-0036237"
+    "gsis_id": "00-0036237",
+    "espn_id": 4240123,
+    "espn_id_new": 4240123
   },
   {
     "mfl_id": 14976,
@@ -7657,20 +7652,26 @@
   },
   {
     "mfl_id": 14977,
-    "sleeper_id": 7066,
-    "pfr_id": "OsboKJ00",
     "gsis_id": "00-0036345",
     "pff_id": 23503,
+    "sleeper_id": 7066,
+    "espn_id": 3916566,
+    "pfr_id": "OsboKJ00",
     "ras_id": 20195,
-    "otc_id": 8916
+    "otc_id": 8916,
+    "espn_id_new": 3916566
   },
   {
     "mfl_id": 14978,
-    "gsis_id": "00-0036378"
+    "gsis_id": "00-0036378",
+    "espn_id": 3915487,
+    "espn_id_new": 3915487
   },
   {
     "mfl_id": 14980,
-    "gsis_id": "00-0036400"
+    "gsis_id": "00-0036400",
+    "espn_id": 4045165,
+    "espn_id_new": 4045165
   },
   {
     "mfl_id": 14981,
@@ -7678,24 +7679,32 @@
   },
   {
     "mfl_id": 14982,
-    "gsis_id": "00-0036380"
+    "gsis_id": "00-0036380",
+    "espn_id": 4039413,
+    "espn_id_new": 4039413
   },
   {
     "mfl_id": 14983,
-    "gsis_id": "00-0036162"
+    "gsis_id": "00-0036162",
+    "espn_id": 3917232,
+    "espn_id_new": 3917232
   },
   {
     "mfl_id": 14984,
-    "sleeper_id": 7075,
-    "pfr_id": "WoerCh00",
     "gsis_id": "00-0036429",
     "pff_id": 42257,
+    "sleeper_id": 7075,
+    "espn_id": 4035020,
+    "pfr_id": "WoerCh00",
     "ras_id": 19125,
-    "otc_id": 8930
+    "otc_id": 8930,
+    "espn_id_new": 4035020
   },
   {
     "mfl_id": 14985,
-    "gsis_id": "00-0036313"
+    "gsis_id": "00-0036313",
+    "espn_id": 4035239,
+    "espn_id_new": 4035239
   },
   {
     "mfl_id": 14986,
@@ -7703,11 +7712,15 @@
   },
   {
     "mfl_id": 14987,
-    "gsis_id": "00-0036430"
+    "gsis_id": "00-0036430",
+    "espn_id": 3699530,
+    "espn_id_new": 3699530
   },
   {
     "mfl_id": 14988,
-    "gsis_id": "00-0036401"
+    "gsis_id": "00-0036401",
+    "espn_id": 4038902,
+    "espn_id_new": 4038902
   },
   {
     "mfl_id": 14989,
@@ -7719,28 +7732,38 @@
   },
   {
     "mfl_id": 14991,
-    "gsis_id": "00-0036431"
+    "gsis_id": "00-0036431",
+    "espn_id": 4040613,
+    "espn_id_new": 4040613
   },
   {
     "mfl_id": 14992,
-    "sleeper_id": 6927,
-    "pfr_id": "WatkQu00",
     "gsis_id": "00-0036271",
     "pff_id": 61664,
+    "sleeper_id": 6927,
+    "espn_id": 4050373,
+    "pfr_id": "WatkQu00",
     "ras_id": 20197,
-    "otc_id": 8940
+    "otc_id": 8940,
+    "espn_id_new": 4050373
   },
   {
     "mfl_id": 14995,
-    "gsis_id": "00-0036348"
+    "gsis_id": "00-0036348",
+    "espn_id": 4046537,
+    "espn_id_new": 4046537
   },
   {
     "mfl_id": 14996,
-    "gsis_id": "00-0036250"
+    "gsis_id": "00-0036250",
+    "espn_id": 3914240,
+    "espn_id_new": 3914240
   },
   {
     "mfl_id": 14997,
-    "gsis_id": "00-0036222"
+    "gsis_id": "00-0036222",
+    "espn_id": 4044540,
+    "espn_id_new": 4044540
   },
   {
     "mfl_id": 14999,
@@ -7748,19 +7771,27 @@
   },
   {
     "mfl_id": 15000,
-    "gsis_id": "00-0036314"
+    "gsis_id": "00-0036314",
+    "espn_id": 3917992,
+    "espn_id_new": 3917992
   },
   {
     "mfl_id": 15001,
-    "gsis_id": "00-0036349"
+    "gsis_id": "00-0036349",
+    "espn_id": 4242154,
+    "espn_id_new": 4242154
   },
   {
     "mfl_id": 15002,
-    "gsis_id": "00-0036402"
+    "gsis_id": "00-0036402",
+    "espn_id": 4034766,
+    "espn_id_new": 4034766
   },
   {
     "mfl_id": 15004,
-    "gsis_id": "00-0036315"
+    "gsis_id": "00-0036315",
+    "espn_id": 4046353,
+    "espn_id_new": 4046353
   },
   {
     "mfl_id": 15006,
@@ -7768,14 +7799,16 @@
   },
   {
     "mfl_id": 15007,
-    "gsis_id": "00-0036351"
+    "gsis_id": "00-0036351",
+    "espn_id": 3686690,
+    "espn_id_new": 3686690
   },
   {
     "mfl_id": 15008,
-    "sleeper_id": 7143,
-    "pfr_id": "DiNuBe00",
     "gsis_id": "00-0036384",
     "pff_id": 34311,
+    "sleeper_id": 7143,
+    "pfr_id": "DiNuBe00",
     "ras_id": 18961,
     "otc_id": 8971
   },
@@ -7785,7 +7818,9 @@
   },
   {
     "mfl_id": 15010,
-    "gsis_id": "00-0036403"
+    "gsis_id": "00-0036403",
+    "espn_id": 3931408,
+    "espn_id_new": 3931408
   },
   {
     "mfl_id": 15011,
@@ -7805,7 +7840,9 @@
   },
   {
     "mfl_id": 15016,
-    "gsis_id": "00-0036166"
+    "gsis_id": "00-0036166",
+    "espn_id": 3895791,
+    "espn_id_new": 3895791
   },
   {
     "mfl_id": 15017,
@@ -7821,11 +7858,11 @@
   },
   {
     "mfl_id": 15021,
-    "sleeper_id": 6988,
-    "pfr_id": "CalaRa00",
     "gsis_id": "00-0036435",
     "pff_id": 45828,
-    "yahoo_id": 32915
+    "sleeper_id": 6988,
+    "yahoo_id": 32915,
+    "pfr_id": "CalaRa00"
   },
   {
     "mfl_id": 15022,
@@ -7837,18 +7874,22 @@
   },
   {
     "mfl_id": 15025,
-    "sleeper_id": 6929,
-    "pfr_id": "ColeBr01",
     "gsis_id": "00-0036353",
-    "yahoo_id": 32919
+    "sleeper_id": 6929,
+    "yahoo_id": 32919,
+    "pfr_id": "ColeBr01"
   },
   {
     "mfl_id": 15026,
-    "gsis_id": "00-0036438"
+    "gsis_id": "00-0036438",
+    "espn_id": 4035426,
+    "espn_id_new": 4035426
   },
   {
     "mfl_id": 15027,
-    "gsis_id": "00-0036439"
+    "gsis_id": "00-0036439",
+    "espn_id": 4034964,
+    "espn_id_new": 4034964
   },
   {
     "mfl_id": 15028,
@@ -7856,47 +7897,51 @@
   },
   {
     "mfl_id": 15029,
-    "gsis_id": "00-0036167"
+    "gsis_id": "00-0036167",
+    "espn_id": 3915171,
+    "espn_id_new": 3915171
   },
   {
     "mfl_id": 15030,
-    "sleeper_id": 5748,
     "gsis_id": "00-0034769",
-    "espn_id": 3128747,
+    "sleeper_id": 5748,
     "yahoo_id": 31744
   },
   {
     "mfl_id": 15032,
-    "sleeper_id": 6523,
     "gsis_id": "00-0035156",
     "pff_id": 34735,
+    "sleeper_id": 6523,
+    "yahoo_id": 32358,
     "espn_id": 3916370,
-    "yahoo_id": 32358
+    "espn_id_new": 3916370
   },
   {
     "mfl_id": 15033,
-    "sleeper_id": 6763,
     "gsis_id": "00-0035750",
     "pff_id": 20052,
-    "espn_id": 2974503,
+    "sleeper_id": 6763,
     "yahoo_id": 32664
   },
   {
     "mfl_id": 15034,
-    "sleeper_id": 6989,
-    "pfr_id": "CallMa01",
     "gsis_id": "00-0036219",
     "pff_id": 42295,
+    "sleeper_id": 6989,
+    "espn_id": 4035170,
+    "pfr_id": "CallMa01",
     "ras_id": 17739,
-    "otc_id": 9421
+    "otc_id": 9421,
+    "espn_id_new": 4035170
   },
   {
     "mfl_id": 15035,
-    "sleeper_id": 5806,
     "gsis_id": "00-0034899",
     "pff_id": 46454,
+    "sleeper_id": 5806,
+    "yahoo_id": 31803,
     "espn_id": 3124092,
-    "yahoo_id": 31803
+    "espn_id_new": 3124092
   },
   {
     "mfl_id": 15036,
@@ -7905,261 +7950,248 @@
   },
   {
     "mfl_id": 15038,
-    "sleeper_id": 7080,
     "gsis_id": "00-0035947",
-    "espn_id": 3917166,
+    "sleeper_id": 7080,
     "yahoo_id": 33132
   },
   {
     "mfl_id": 15039,
-    "sleeper_id": 7091,
     "gsis_id": "00-0036034",
     "pff_id": 48124,
-    "espn_id": 4032749,
+    "sleeper_id": 7091,
     "yahoo_id": 33095
   },
   {
     "mfl_id": 15040,
-    "sleeper_id": 7098,
-    "pfr_id": "WillTy01",
     "gsis_id": "00-0036457",
     "pff_id": 38287,
-    "espn_id": 3895827
+    "sleeper_id": 7098,
+    "espn_id": 3895827,
+    "pfr_id": "WillTy01",
+    "espn_id_new": 3895827
   },
   {
     "mfl_id": 15041,
-    "sleeper_id": 7106,
     "gsis_id": "00-0036145",
     "pff_id": 34914,
-    "espn_id": 3917849,
+    "sleeper_id": 7106,
     "yahoo_id": 33329,
     "ras_id": 20196,
     "otc_id": 9307
   },
   {
     "mfl_id": 15042,
-    "sleeper_id": 7087,
-    "pfr_id": "WardJo00",
     "gsis_id": "00-0035924",
-    "pff_id": 25859
+    "pff_id": 25859,
+    "sleeper_id": 7087,
+    "espn_id": 4039274,
+    "pfr_id": "WardJo00",
+    "espn_id_new": 4039274
   },
   {
     "mfl_id": 15045,
-    "sleeper_id": 7015,
     "gsis_id": "00-0036154",
-    "espn_id": 3915136,
+    "sleeper_id": 7015,
     "yahoo_id": 32994
   },
   {
     "mfl_id": 15046,
-    "sleeper_id": 7351,
-    "pfr_id": "MerrKi00",
     "gsis_id": "00-0035844",
     "pff_id": 35096,
+    "sleeper_id": 7351,
+    "yahoo_id": 33242,
     "espn_id": 3915145,
-    "yahoo_id": 33242
+    "pfr_id": "MerrKi00",
+    "espn_id_new": 3915145
   },
   {
     "mfl_id": 15047,
-    "sleeper_id": 3813,
     "gsis_id": "00-0032849",
     "pff_id": 11310,
-    "espn_id": 2578317,
+    "sleeper_id": 3813,
     "yahoo_id": 29925
   },
   {
     "mfl_id": 15049,
-    "sleeper_id": 7014,
-    "pfr_id": "BachJo01",
     "gsis_id": "00-0035895",
     "pff_id": 43250,
+    "sleeper_id": 7014,
+    "yahoo_id": 33108,
     "espn_id": 4036507,
-    "yahoo_id": 33108
+    "pfr_id": "BachJo01",
+    "espn_id_new": 4036507
   },
   {
     "mfl_id": 15051,
-    "sleeper_id": 7307,
     "gsis_id": "00-0035889",
     "pff_id": 33007,
+    "sleeper_id": 7307,
+    "yahoo_id": 32960,
     "espn_id": 3915398,
-    "yahoo_id": 32960
+    "espn_id_new": 3915398
   },
   {
     "mfl_id": 15053,
-    "sleeper_id": 7175,
-    "pfr_id": "RowlCh00",
     "gsis_id": "00-0035789",
-    "espn_id": 4052137,
-    "yahoo_id": 33066
+    "sleeper_id": 7175,
+    "yahoo_id": 33066,
+    "pfr_id": "RowlCh00"
   },
   {
     "mfl_id": 15054,
-    "sleeper_id": 7216,
     "gsis_id": "00-0035956",
     "pff_id": 13756,
+    "sleeper_id": 7216,
+    "yahoo_id": 33151,
     "espn_id": 3916749,
-    "yahoo_id": 33151
+    "espn_id_new": 3916749
   },
   {
     "mfl_id": 15055,
-    "sleeper_id": 6936,
     "gsis_id": "00-0036320",
     "pff_id": 33672,
-    "espn_id": 3924357,
+    "sleeper_id": 6936,
     "yahoo_id": 33360
   },
   {
     "mfl_id": 15056,
-    "sleeper_id": 7311,
-    "pfr_id": "WhitJa04",
     "gsis_id": "00-0036085",
     "pff_id": 28987,
-    "espn_id": 3921709,
-    "yahoo_id": 33318
+    "sleeper_id": 7311,
+    "yahoo_id": 33318,
+    "pfr_id": "WhitJa04"
   },
   {
     "mfl_id": 15057,
-    "sleeper_id": 7357,
-    "pfr_id": "ChisDa00",
     "gsis_id": "00-0035976",
     "pff_id": 34061,
-    "espn_id": 3929637,
-    "yahoo_id": 33023
+    "sleeper_id": 7357,
+    "yahoo_id": 33023,
+    "pfr_id": "ChisDa00"
   },
   {
     "mfl_id": 15059,
-    "sleeper_id": 7366,
     "gsis_id": "00-0035979",
     "pff_id": 49299,
-    "espn_id": 4037511,
+    "sleeper_id": 7366,
     "yahoo_id": 33029
   },
   {
     "mfl_id": 15060,
-    "sleeper_id": 6778,
     "gsis_id": "00-0035752",
     "pff_id": 46440,
-    "espn_id": 3040206,
+    "sleeper_id": 6778,
     "yahoo_id": 32662
   },
   {
     "mfl_id": 15061,
-    "sleeper_id": 7185,
     "gsis_id": "00-0035790",
     "pff_id": 77573,
-    "espn_id": 4361650,
+    "sleeper_id": 7185,
     "yahoo_id": 33067
   },
   {
     "mfl_id": 15062,
-    "sleeper_id": 5966,
     "gsis_id": "00-0035048",
     "pff_id": 50115,
-    "espn_id": 3915285,
+    "sleeper_id": 5966,
     "yahoo_id": 32287
   },
   {
     "mfl_id": 15063,
-    "sleeper_id": 7504,
-    "pfr_id": "HarrDe10",
     "gsis_id": "00-0036090",
     "pff_id": 43858,
+    "sleeper_id": 7504,
+    "yahoo_id": 33321,
     "espn_id": 4035577,
-    "yahoo_id": 33321
+    "pfr_id": "HarrDe10",
+    "espn_id_new": 4035577
   },
   {
     "mfl_id": 15064,
-    "sleeper_id": 5292,
     "gsis_id": "00-0034667",
     "pff_id": 47687,
-    "espn_id": 3052122,
+    "sleeper_id": 5292,
     "yahoo_id": 31625
   },
   {
     "mfl_id": 15066,
-    "sleeper_id": 7065,
     "gsis_id": "00-0036129",
     "pff_id": 47286,
-    "espn_id": 3915400,
+    "sleeper_id": 7065,
     "yahoo_id": 33007
   },
   {
     "mfl_id": 15067,
-    "sleeper_id": 5759,
     "gsis_id": "00-0034802",
     "pff_id": 51427,
-    "espn_id": 3052527,
+    "sleeper_id": 5759,
     "yahoo_id": 31754
   },
   {
     "mfl_id": 15068,
-    "sleeper_id": 7356,
-    "pfr_id": "RendTy00",
     "gsis_id": "00-0035845",
-    "espn_id": 3914456,
-    "yahoo_id": 33243
+    "sleeper_id": 7356,
+    "yahoo_id": 33243,
+    "pfr_id": "RendTy00"
   },
   {
     "mfl_id": 15069,
-    "sleeper_id": 6967,
     "gsis_id": "00-0035987",
     "pff_id": 47537,
-    "espn_id": 4039000,
+    "sleeper_id": 6967,
     "yahoo_id": 33267
   },
   {
     "mfl_id": 15070,
-    "sleeper_id": 6665,
-    "pfr_id": "FortJo01",
     "gsis_id": "00-0035547",
-    "pff_id": 94384
+    "pff_id": 94384,
+    "sleeper_id": 6665,
+    "pfr_id": "FortJo01"
   },
   {
     "mfl_id": 15071,
-    "sleeper_id": 7253,
     "gsis_id": "00-0036029",
     "pff_id": 36346,
-    "espn_id": 3930024,
+    "sleeper_id": 7253,
     "yahoo_id": 33103
   },
   {
     "mfl_id": 15073,
-    "sleeper_id": 7449,
-    "pfr_id": "MotlPa00",
     "gsis_id": "00-0036106",
     "pff_id": 42189,
-    "espn_id": 4037647,
-    "yahoo_id": 33293
+    "sleeper_id": 7449,
+    "yahoo_id": 33293,
+    "pfr_id": "MotlPa00"
   },
   {
     "mfl_id": 15074,
-    "sleeper_id": 7232,
-    "pfr_id": "SmitRa02",
     "gsis_id": "00-0036209",
     "pff_id": 43811,
-    "espn_id": 4040762,
-    "yahoo_id": 33180
+    "sleeper_id": 7232,
+    "yahoo_id": 33180,
+    "pfr_id": "SmitRa02"
   },
   {
     "mfl_id": 15075,
-    "sleeper_id": 7446,
     "gsis_id": "00-0036177",
-    "espn_id": 4035098,
+    "sleeper_id": 7446,
     "yahoo_id": 33343
   },
   {
     "mfl_id": 15076,
-    "sleeper_id": 7346,
     "gsis_id": "00-0035942",
+    "sleeper_id": 7346,
+    "yahoo_id": 33261,
     "espn_id": 3909013,
-    "yahoo_id": 33261
+    "espn_id_new": 3909013
   },
   {
     "mfl_id": 15077,
-    "sleeper_id": 7407,
-    "pfr_id": "WrigIs01",
     "gsis_id": "00-0036142",
     "pff_id": 40113,
+    "sleeper_id": 7407,
+    "pfr_id": "WrigIs01",
     "ras_id": 19077,
     "otc_id": 9425
   },
@@ -8169,850 +8201,830 @@
   },
   {
     "mfl_id": 15079,
-    "sleeper_id": 6925,
-    "pfr_id": "BassEs01",
     "gsis_id": "00-0035862",
     "pff_id": 45258,
+    "sleeper_id": 6925,
+    "yahoo_id": 32932,
     "espn_id": 4037216,
-    "yahoo_id": 32932
+    "pfr_id": "BassEs01",
+    "espn_id_new": 4037216
   },
   {
     "mfl_id": 15080,
-    "sleeper_id": 7404,
-    "pfr_id": "TogiNo00",
     "gsis_id": "00-0036005",
     "pff_id": 47282,
-    "espn_id": 3930298,
+    "sleeper_id": 7404,
     "yahoo_id": 32970,
+    "espn_id": 3930298,
+    "pfr_id": "TogiNo00",
     "ras_id": 17658,
-    "otc_id": 9121
+    "otc_id": 9121,
+    "espn_id_new": 3930298
   },
   {
     "mfl_id": 15081,
-    "sleeper_id": 7301,
-    "pfr_id": "WharTe00",
     "gsis_id": "00-0035890",
     "pff_id": 40292,
+    "sleeper_id": 7301,
+    "yahoo_id": 32952,
     "espn_id": 4058925,
-    "yahoo_id": 32952
+    "pfr_id": "WharTe00",
+    "espn_id_new": 4058925
   },
   {
     "mfl_id": 15082,
-    "sleeper_id": 7268,
-    "pfr_id": "BarnKr00",
     "gsis_id": "00-0035961",
     "pff_id": 42548,
+    "sleeper_id": 7268,
+    "yahoo_id": 33221,
     "espn_id": 4035817,
-    "yahoo_id": 33221
+    "pfr_id": "BarnKr00",
+    "espn_id_new": 4035817
   },
   {
     "mfl_id": 15087,
-    "sleeper_id": 7466,
-    "pfr_id": "CottNa00",
     "gsis_id": "00-0035835",
     "pff_id": 45980,
-    "espn_id": 3917812,
-    "yahoo_id": 33123
+    "sleeper_id": 7466,
+    "yahoo_id": 33123,
+    "pfr_id": "CottNa00"
   },
   {
     "mfl_id": 15088,
-    "sleeper_id": 7288,
-    "pfr_id": "ElleBe00",
     "gsis_id": "00-0035823",
-    "pff_id": 27766
+    "pff_id": 27766,
+    "sleeper_id": 7288,
+    "pfr_id": "ElleBe00"
   },
   {
     "mfl_id": 15089,
-    "sleeper_id": 7018,
-    "pfr_id": "RoacMa01",
     "gsis_id": "00-0035763",
     "pff_id": 50191,
+    "sleeper_id": 7018,
+    "yahoo_id": 33118,
     "espn_id": 4039064,
-    "yahoo_id": 33118
+    "pfr_id": "RoacMa01",
+    "espn_id_new": 4039064
   },
   {
     "mfl_id": 15093,
-    "sleeper_id": 6390,
     "gsis_id": "00-0035607",
     "pff_id": 38540,
+    "sleeper_id": 6390,
+    "yahoo_id": 32130,
     "espn_id": 3914150,
-    "yahoo_id": 32130
+    "espn_id_new": 3914150
   },
   {
     "mfl_id": 15094,
-    "sleeper_id": 6419,
     "gsis_id": "00-0035227",
     "pff_id": 51189,
+    "sleeper_id": 6419,
+    "yahoo_id": 32164,
     "espn_id": 3929850,
-    "yahoo_id": 32164
+    "espn_id_new": 3929850
   },
   {
     "mfl_id": 15095,
-    "sleeper_id": 6981,
-    "pfr_id": "GaleTi01",
     "gsis_id": "00-0035965",
     "pff_id": 50275,
-    "espn_id": 3676832,
-    "yahoo_id": 33225
+    "sleeper_id": 6981,
+    "yahoo_id": 33225,
+    "pfr_id": "GaleTi01"
   },
   {
     "mfl_id": 15096,
-    "sleeper_id": 7318,
-    "pfr_id": "NabeGa00",
     "gsis_id": "00-0035908",
     "pff_id": 40117,
-    "espn_id": 4035611,
-    "yahoo_id": 32987
+    "sleeper_id": 7318,
+    "yahoo_id": 32987,
+    "pfr_id": "NabeGa00"
   },
   {
     "mfl_id": 15097,
-    "sleeper_id": 6964,
-    "pfr_id": "McKeSe01",
     "gsis_id": "00-0036032",
     "pff_id": 42266,
-    "espn_id": 4036275,
+    "sleeper_id": 6964,
     "yahoo_id": 33101,
+    "espn_id": 4036275,
+    "pfr_id": "McKeSe01",
     "ras_id": 19119,
-    "otc_id": 9341
+    "otc_id": 9341,
+    "espn_id_new": 4036275
   },
   {
     "mfl_id": 15098,
-    "sleeper_id": 7316,
-    "pfr_id": "BradDa00",
     "gsis_id": "00-0035898",
     "pff_id": 46445,
-    "espn_id": 4040640,
-    "yahoo_id": 32975
+    "sleeper_id": 7316,
+    "yahoo_id": 32975,
+    "pfr_id": "BradDa00"
   },
   {
     "mfl_id": 15099,
-    "sleeper_id": 7328,
-    "pfr_id": "BilaAs00",
     "gsis_id": "00-0035897",
-    "espn_id": 3932422,
-    "yahoo_id": 32974
+    "sleeper_id": 7328,
+    "yahoo_id": 32974,
+    "pfr_id": "BilaAs00"
   },
   {
     "mfl_id": 15101,
-    "sleeper_id": 6657,
     "gsis_id": "00-0035600",
     "pff_id": 48374,
-    "espn_id": 3116082,
+    "sleeper_id": 6657,
     "yahoo_id": 32601
   },
   {
     "mfl_id": 15103,
-    "sleeper_id": 7204,
     "gsis_id": "00-0036187",
     "pff_id": 40951,
+    "sleeper_id": 7204,
+    "yahoo_id": 33357,
     "espn_id": 4039505,
-    "yahoo_id": 33357
+    "espn_id_new": 4039505
   },
   {
     "mfl_id": 15109,
-    "sleeper_id": 7496,
-    "pfr_id": "WestNi00",
     "gsis_id": "00-0036182",
     "pff_id": 47861,
-    "otc_id": 9304
+    "sleeper_id": 7496,
+    "espn_id": 3929785,
+    "pfr_id": "WestNi00",
+    "otc_id": 9304,
+    "espn_id_new": 3929785
   },
   {
     "mfl_id": 15110,
-    "sleeper_id": 5727,
     "gsis_id": "00-0034723",
     "pff_id": 49607,
+    "sleeper_id": 5727,
+    "yahoo_id": 31726,
     "espn_id": 3040031,
-    "yahoo_id": 31726
+    "espn_id_new": 3040031
   },
   {
     "mfl_id": 15111,
-    "sleeper_id": 7296,
     "gsis_id": "00-0035833",
+    "sleeper_id": 7296,
     "yahoo_id": 33149
   },
   {
     "mfl_id": 15114,
-    "sleeper_id": 7226,
-    "pfr_id": "HartMy00",
     "gsis_id": "00-0035950",
     "pff_id": 49159,
-    "espn_id": 4035290,
-    "yahoo_id": 33139
+    "sleeper_id": 7226,
+    "yahoo_id": 33139,
+    "pfr_id": "HartMy00"
   },
   {
     "mfl_id": 15116,
-    "sleeper_id": 7458,
-    "pfr_id": "ZubeIs00",
     "gsis_id": "00-0036100",
     "pff_id": 26884,
-    "espn_id": 3916129,
-    "yahoo_id": 33020
+    "sleeper_id": 7458,
+    "yahoo_id": 33020,
+    "pfr_id": "ZubeIs00"
   },
   {
     "mfl_id": 15117,
-    "sleeper_id": 6610,
     "gsis_id": "00-0035020",
     "pff_id": 49231,
+    "sleeper_id": 6610,
+    "yahoo_id": 32319,
     "espn_id": 3931424,
-    "yahoo_id": 32319
+    "espn_id_new": 3931424
   },
   {
     "mfl_id": 15121,
-    "sleeper_id": 7391,
     "gsis_id": "00-0036151",
     "pff_id": 27128,
+    "sleeper_id": 7391,
+    "yahoo_id": 33335,
     "espn_id": 4039375,
-    "yahoo_id": 33335
+    "espn_id_new": 4039375
   },
   {
     "mfl_id": 15123,
-    "sleeper_id": 4647,
-    "pfr_id": "ThomCo03",
     "gsis_id": "00-0033720",
-    "pff_id": 12239
+    "pff_id": 12239,
+    "sleeper_id": 4647,
+    "pfr_id": "ThomCo03"
   },
   {
     "mfl_id": 15124,
-    "sleeper_id": 7419,
-    "pfr_id": "PierJa01",
     "gsis_id": "00-0035795",
     "pff_id": 60649,
+    "sleeper_id": 7419,
+    "yahoo_id": 32939,
     "espn_id": 4259252,
-    "yahoo_id": 32939
+    "pfr_id": "PierJa01",
+    "espn_id_new": 4259252
   },
   {
     "mfl_id": 15125,
-    "sleeper_id": 6994,
-    "pfr_id": "JackLa02",
     "gsis_id": "00-0036152",
     "pff_id": 50532,
-    "espn_id": 4034849,
-    "yahoo_id": 33336
+    "sleeper_id": 6994,
+    "yahoo_id": 33336,
+    "pfr_id": "JackLa02"
   },
   {
     "mfl_id": 15126,
-    "sleeper_id": 7068,
-    "pfr_id": "BernFr01",
     "gsis_id": "00-0036028",
     "pff_id": 44722,
-    "espn_id": 3932336,
-    "yahoo_id": 33105
+    "sleeper_id": 7068,
+    "yahoo_id": 33105,
+    "pfr_id": "BernFr01"
   },
   {
     "mfl_id": 15127,
-    "sleeper_id": 7289,
-    "pfr_id": "CostDo00",
     "gsis_id": "00-0035822",
     "pff_id": 44473,
-    "espn_id": 4038987,
-    "yahoo_id": 33122
+    "sleeper_id": 7289,
+    "yahoo_id": 33122,
+    "pfr_id": "CostDo00"
   },
   {
     "mfl_id": 15129,
-    "sleeper_id": 7200,
-    "pfr_id": "DorsKh00",
     "gsis_id": "00-0036124",
     "pff_id": 27819,
+    "sleeper_id": 7200,
+    "yahoo_id": 33012,
     "espn_id": 4027919,
-    "yahoo_id": 33012
+    "pfr_id": "DorsKh00",
+    "espn_id_new": 4027919
   },
   {
     "mfl_id": 15130,
-    "sleeper_id": 7347,
-    "pfr_id": "HughJu00",
     "gsis_id": "00-0036077",
     "pff_id": 49545,
-    "espn_id": 4040901,
-    "yahoo_id": 33296
+    "sleeper_id": 7347,
+    "yahoo_id": 33296,
+    "pfr_id": "HughJu00"
   },
   {
     "mfl_id": 15131,
-    "sleeper_id": 7251,
     "gsis_id": "00-0036118",
     "pff_id": 34207,
-    "espn_id": 3914450,
+    "sleeper_id": 7251,
     "yahoo_id": 33310
   },
   {
     "mfl_id": 15132,
-    "sleeper_id": 5470,
     "gsis_id": "00-0034125",
     "pff_id": 48993,
-    "espn_id": 3044732,
+    "sleeper_id": 5470,
     "yahoo_id": 31420
   },
   {
     "mfl_id": 15133,
-    "sleeper_id": 7312,
-    "pfr_id": "HarpMa00",
     "gsis_id": "00-0036084",
     "pff_id": 49537,
-    "espn_id": 4038440,
-    "yahoo_id": 33316
+    "sleeper_id": 7312,
+    "yahoo_id": 33316,
+    "pfr_id": "HarpMa00"
   },
   {
     "mfl_id": 15134,
-    "sleeper_id": 7324,
     "gsis_id": "00-0035906",
     "pff_id": 82302,
-    "espn_id": 4365493,
+    "sleeper_id": 7324,
     "yahoo_id": 32985
   },
   {
     "mfl_id": 15137,
-    "sleeper_id": 7051,
-    "pfr_id": "ArnoGr01",
     "gsis_id": "00-0035995",
     "pff_id": 43528,
+    "sleeper_id": 7051,
+    "yahoo_id": 32961,
     "espn_id": 4035389,
-    "yahoo_id": 32961
+    "pfr_id": "ArnoGr01",
+    "espn_id_new": 4035389
   },
   {
     "mfl_id": 15140,
-    "sleeper_id": 6314,
     "gsis_id": "00-0035357",
     "pff_id": 49395,
+    "sleeper_id": 6314,
+    "yahoo_id": 32416,
     "espn_id": 3916577,
-    "yahoo_id": 32416
+    "espn_id_new": 3916577
   },
   {
     "mfl_id": 15141,
-    "sleeper_id": 7451,
     "gsis_id": "00-0036045",
     "pff_id": 33560,
+    "sleeper_id": 7451,
+    "yahoo_id": 33272,
     "espn_id": 4034496,
-    "yahoo_id": 33272
+    "espn_id_new": 4034496
   },
   {
     "mfl_id": 15142,
-    "sleeper_id": 7188,
-    "pfr_id": "HallTy01",
     "gsis_id": "00-0035783",
     "pff_id": 43958,
+    "sleeper_id": 7188,
+    "yahoo_id": 33058,
     "espn_id": 4048718,
-    "yahoo_id": 33058
+    "pfr_id": "HallTy01",
+    "espn_id_new": 4048718
   },
   {
     "mfl_id": 15146,
-    "sleeper_id": 5327,
     "gsis_id": "00-0034731",
     "pff_id": 62935,
-    "espn_id": 3915388,
+    "sleeper_id": 5327,
     "yahoo_id": 31168
   },
   {
     "mfl_id": 15147,
-    "sleeper_id": 7392,
-    "pfr_id": "GuidJa01",
     "gsis_id": "00-0036149",
     "pff_id": 56262,
-    "espn_id": 4243250,
-    "yahoo_id": 33333
+    "sleeper_id": 7392,
+    "yahoo_id": 33333,
+    "pfr_id": "GuidJa01"
   },
   {
     "mfl_id": 15148,
-    "sleeper_id": 7224,
     "gsis_id": "00-0036037",
     "pff_id": 43580,
+    "sleeper_id": 7224,
+    "yahoo_id": 33137,
     "espn_id": 4044133,
-    "yahoo_id": 33137
+    "espn_id_new": 4044133
   },
   {
     "mfl_id": 15149,
-    "sleeper_id": 7279,
-    "pfr_id": "HarrDe11",
     "gsis_id": "00-0035848",
     "pff_id": 84418,
-    "espn_id": 4374496,
-    "yahoo_id": 33215
+    "sleeper_id": 7279,
+    "yahoo_id": 33215,
+    "pfr_id": "HarrDe11"
   },
   {
     "mfl_id": 15151,
-    "sleeper_id": 7197,
-    "pfr_id": "WelcKr00",
     "gsis_id": "00-0036157",
     "pff_id": 51283,
-    "espn_id": 4036153,
-    "yahoo_id": 33005
+    "sleeper_id": 7197,
+    "yahoo_id": 33005,
+    "pfr_id": "WelcKr00"
   },
   {
     "mfl_id": 15152,
-    "sleeper_id": 7398,
-    "pfr_id": "WalkRe01",
     "gsis_id": "00-0035923",
     "pff_id": 26885,
-    "espn_id": 4046605,
-    "yahoo_id": 33086
+    "sleeper_id": 7398,
+    "yahoo_id": 33086,
+    "pfr_id": "WalkRe01"
   },
   {
     "mfl_id": 15154,
-    "sleeper_id": 7515,
-    "gsis_id": "00-0031385"
+    "gsis_id": "00-0031385",
+    "sleeper_id": 7515
   },
   {
     "mfl_id": 15155,
-    "sleeper_id": 7027,
-    "pfr_id": "MaydJa01",
     "gsis_id": "00-0035808",
     "pff_id": 43058,
-    "espn_id": 4040975,
-    "yahoo_id": 33201
+    "sleeper_id": 7027,
+    "yahoo_id": 33201,
+    "pfr_id": "MaydJa01"
   },
   {
     "mfl_id": 15156,
-    "sleeper_id": 7078,
-    "pfr_id": "BrowTo03",
     "gsis_id": "00-0036111",
     "pff_id": 48344,
-    "espn_id": 3915821,
-    "yahoo_id": 33303
+    "sleeper_id": 7078,
+    "yahoo_id": 33303,
+    "pfr_id": "BrowTo03"
   },
   {
     "mfl_id": 15159,
-    "sleeper_id": 5572,
     "gsis_id": "00-0034318",
     "pff_id": 48889,
-    "espn_id": 3122690,
+    "sleeper_id": 5572,
     "yahoo_id": 31518
   },
   {
     "mfl_id": 15160,
-    "sleeper_id": 7271,
-    "pfr_id": "BlacHe00",
     "gsis_id": "00-0035962",
     "pff_id": 25687,
-    "espn_id": 3928920,
-    "yahoo_id": 33222
+    "sleeper_id": 7271,
+    "yahoo_id": 33222,
+    "pfr_id": "BlacHe00"
   },
   {
     "mfl_id": 15162,
-    "sleeper_id": 6517,
     "gsis_id": "00-0035085",
     "pff_id": 39094,
-    "espn_id": 3128675,
+    "sleeper_id": 6517,
     "yahoo_id": 32276
   },
   {
     "mfl_id": 15163,
-    "sleeper_id": 6332,
     "gsis_id": "00-0035130",
     "pff_id": 51496,
-    "espn_id": 3909365,
+    "sleeper_id": 6332,
     "yahoo_id": 32346
   },
   {
     "mfl_id": 15165,
-    "sleeper_id": 6999,
-    "pfr_id": "JoneBe03",
     "gsis_id": "00-0035841",
     "pff_id": 44035,
+    "sleeper_id": 6999,
+    "yahoo_id": 33239,
     "espn_id": 4035299,
-    "yahoo_id": 33239
+    "pfr_id": "JoneBe03",
+    "espn_id_new": 4035299
   },
   {
     "mfl_id": 15167,
-    "sleeper_id": 7208,
     "gsis_id": "00-0036189",
     "pff_id": 36116,
-    "espn_id": 3917159,
+    "sleeper_id": 7208,
     "yahoo_id": 33358
   },
   {
     "mfl_id": 15168,
-    "sleeper_id": 7405,
     "gsis_id": "00-0035998",
     "pff_id": 47826,
-    "espn_id": 3917576,
+    "sleeper_id": 7405,
     "yahoo_id": 32964
   },
   {
     "mfl_id": 15170,
-    "sleeper_id": 6916,
-    "pfr_id": "SamuSt01",
     "gsis_id": "00-0035970",
     "pff_id": 55893,
-    "espn_id": 4240024,
-    "yahoo_id": 33231
+    "sleeper_id": 6916,
+    "yahoo_id": 33231,
+    "pfr_id": "SamuSt01"
   },
   {
     "mfl_id": 15171,
-    "sleeper_id": 7516,
     "gsis_id": "00-0036458",
     "pff_id": 29601,
-    "espn_id": 3045246
+    "sleeper_id": 7516
   },
   {
     "mfl_id": 15172,
-    "sleeper_id": 7055,
     "gsis_id": "00-0036033",
     "pff_id": 45767,
-    "espn_id": 4038539,
+    "sleeper_id": 7055,
     "yahoo_id": 33099
   },
   {
     "mfl_id": 15173,
-    "sleeper_id": 7443,
-    "pfr_id": "TartTe00",
     "gsis_id": "00-0036181",
     "pff_id": 82261,
+    "sleeper_id": 7443,
+    "yahoo_id": 33347,
     "espn_id": 4374269,
-    "yahoo_id": 33347
+    "pfr_id": "TartTe00",
+    "espn_id_new": 4374269
   },
   {
     "mfl_id": 15176,
-    "sleeper_id": 7169,
-    "pfr_id": "WhitJa05",
     "gsis_id": "00-0036043",
     "pff_id": 50465,
-    "espn_id": 3821572,
-    "yahoo_id": 33089
+    "sleeper_id": 7169,
+    "yahoo_id": 33089,
+    "pfr_id": "WhitJa05"
   },
   {
     "mfl_id": 15177,
-    "sleeper_id": 6946,
     "gsis_id": "00-0036087",
     "pff_id": 43336,
+    "sleeper_id": 6946,
+    "yahoo_id": 33319,
     "espn_id": 4039010,
-    "yahoo_id": 33319
+    "espn_id_new": 4039010
   },
   {
     "mfl_id": 15179,
-    "sleeper_id": 5179,
     "gsis_id": "00-0034463",
     "pff_id": 48487,
-    "espn_id": 3044706,
+    "sleeper_id": 5179,
     "yahoo_id": 31578
   },
   {
     "mfl_id": 15180,
-    "sleeper_id": 7293,
-    "pfr_id": "BarcLu00",
     "gsis_id": "00-0036101",
     "pff_id": 83079,
-    "espn_id": 4361499,
-    "yahoo_id": 33115
+    "sleeper_id": 7293,
+    "yahoo_id": 33115,
+    "pfr_id": "BarcLu00"
   },
   {
     "mfl_id": 15181,
-    "sleeper_id": 6104,
-    "pfr_id": "HoldAl01",
     "gsis_id": "00-0034948",
     "pff_id": 38567,
-    "espn_id": 3117249,
-    "yahoo_id": 32218
+    "sleeper_id": 6104,
+    "yahoo_id": 32218,
+    "pfr_id": "HoldAl01"
   },
   {
     "mfl_id": 15183,
-    "sleeper_id": 7210,
-    "pfr_id": "HintKe00",
     "gsis_id": "00-0035864",
-    "pff_id": 34045
+    "pff_id": 34045,
+    "sleeper_id": 7210,
+    "espn_id": 3700815,
+    "pfr_id": "HintKe00",
+    "espn_id_new": 3700815
   },
   {
     "mfl_id": 15185,
-    "sleeper_id": 7381,
-    "pfr_id": "LaloNi00",
     "gsis_id": "00-0035816",
     "pff_id": 106295,
-    "espn_id": 4030955,
-    "yahoo_id": 33051
+    "sleeper_id": 7381,
+    "yahoo_id": 33051,
+    "pfr_id": "LaloNi00"
   },
   {
     "mfl_id": 15186,
-    "sleeper_id": 7281,
     "gsis_id": "00-0035850",
     "pff_id": 28668,
-    "espn_id": 4041572,
+    "sleeper_id": 7281,
     "yahoo_id": 33212
   },
   {
     "mfl_id": 15187,
-    "sleeper_id": 6640,
     "gsis_id": "00-0035210",
     "pff_id": 50480,
-    "espn_id": 3919107,
+    "sleeper_id": 6640,
     "yahoo_id": 32396
   },
   {
     "mfl_id": 15189,
-    "sleeper_id": 7194,
-    "pfr_id": "CrawAa00",
     "gsis_id": "00-0036191",
     "pff_id": 48721,
-    "espn_id": 3895837,
-    "yahoo_id": 33008
+    "sleeper_id": 7194,
+    "yahoo_id": 33008,
+    "pfr_id": "CrawAa00"
   },
   {
     "mfl_id": 15191,
-    "sleeper_id": 7259,
     "gsis_id": "00-0036011",
     "pff_id": 91112,
-    "espn_id": 4030779,
+    "sleeper_id": 7259,
     "yahoo_id": 33190
   },
   {
     "mfl_id": 15194,
-    "sleeper_id": 7329,
-    "pfr_id": "ChriCo00",
     "gsis_id": "00-0035900",
     "pff_id": 43856,
+    "sleeper_id": 7329,
+    "yahoo_id": 32977,
     "espn_id": 4036959,
-    "yahoo_id": 32977
+    "pfr_id": "ChriCo00",
+    "espn_id_new": 4036959
   },
   {
     "mfl_id": 15195,
-    "sleeper_id": 6933,
-    "pfr_id": "WillRa03",
     "gsis_id": "00-0036007",
     "pff_id": 27300,
-    "espn_id": 3929834,
-    "yahoo_id": 32973
+    "sleeper_id": 6933,
+    "yahoo_id": 32973,
+    "pfr_id": "WillRa03"
   },
   {
     "mfl_id": 15197,
-    "sleeper_id": 7170,
-    "pfr_id": "WillJa09",
     "gsis_id": "00-0035925",
-    "espn_id": 3911073,
-    "yahoo_id": 33090
+    "sleeper_id": 7170,
+    "yahoo_id": 33090,
+    "pfr_id": "WillJa09"
   },
   {
     "mfl_id": 15198,
-    "sleeper_id": 6243,
     "gsis_id": "00-0035422",
     "pff_id": 49401,
-    "espn_id": 3915255,
+    "sleeper_id": 6243,
     "yahoo_id": 32199
   },
   {
     "mfl_id": 15199,
-    "sleeper_id": 6975,
-    "pfr_id": "DaniDa04",
     "gsis_id": "00-0035802",
     "pff_id": 48659,
-    "espn_id": 3919607,
-    "yahoo_id": 33195
+    "sleeper_id": 6975,
+    "yahoo_id": 33195,
+    "pfr_id": "DaniDa04"
   },
   {
     "mfl_id": 15200,
-    "sleeper_id": 7518,
     "gsis_id": "00-0036459",
+    "sleeper_id": 7518,
     "yahoo_id": 33372
   },
   {
     "mfl_id": 15201,
-    "sleeper_id": 6266,
     "gsis_id": "00-0035188",
     "pff_id": 43823,
-    "espn_id": 4039292,
+    "sleeper_id": 6266,
     "yahoo_id": 32171
   },
   {
     "mfl_id": 15202,
-    "sleeper_id": 7276,
-    "pfr_id": "AlufAu00",
     "gsis_id": "00-0036065",
     "pff_id": 79271,
-    "espn_id": 3911982,
-    "yahoo_id": 33156
+    "sleeper_id": 7276,
+    "yahoo_id": 33156,
+    "pfr_id": "AlufAu00"
   },
   {
     "mfl_id": 15203,
-    "sleeper_id": 7364,
-    "pfr_id": "LyncBl00",
     "gsis_id": "00-0035984",
     "pff_id": 47621,
+    "sleeper_id": 7364,
+    "yahoo_id": 33034,
     "espn_id": 3892773,
-    "yahoo_id": 33034
+    "pfr_id": "LyncBl00",
+    "espn_id_new": 3892773
   },
   {
     "mfl_id": 15204,
-    "sleeper_id": 7046,
-    "pfr_id": "ReedJR01",
     "gsis_id": "00-0035830",
     "pff_id": 38339,
-    "espn_id": 3917012,
-    "yahoo_id": 33135
+    "sleeper_id": 7046,
+    "yahoo_id": 33135,
+    "pfr_id": "ReedJR01"
   },
   {
     "mfl_id": 15206,
-    "sleeper_id": 7244,
-    "pfr_id": "BradJa01",
     "gsis_id": "00-0036110",
     "pff_id": 27003,
-    "espn_id": 3917569,
-    "yahoo_id": 33302
+    "sleeper_id": 7244,
+    "yahoo_id": 33302,
+    "pfr_id": "BradJa01"
   },
   {
     "mfl_id": 15208,
-    "sleeper_id": 7302,
-    "pfr_id": "CobbOm00",
     "gsis_id": "00-0035879",
     "pff_id": 42867,
-    "espn_id": 4043618,
-    "yahoo_id": 32953
+    "sleeper_id": 7302,
+    "yahoo_id": 32953,
+    "pfr_id": "CobbOm00"
   },
   {
     "mfl_id": 15209,
-    "sleeper_id": 6645,
     "gsis_id": "00-0035393",
-    "espn_id": 3910754,
+    "sleeper_id": 6645,
     "yahoo_id": 32463
   },
   {
     "mfl_id": 15210,
-    "sleeper_id": 7474,
-    "pfr_id": "JoneKe03",
     "gsis_id": "00-0036203",
     "pff_id": 28092,
-    "espn_id": 4040621,
-    "yahoo_id": 33174
+    "sleeper_id": 7474,
+    "yahoo_id": 33174,
+    "pfr_id": "JoneKe03"
   },
   {
     "mfl_id": 15212,
-    "sleeper_id": 7325,
     "gsis_id": "00-0035903",
     "pff_id": 27949,
+    "sleeper_id": 7325,
+    "yahoo_id": 32982,
     "espn_id": 3915990,
-    "yahoo_id": 32982
+    "espn_id_new": 3915990
   },
   {
     "mfl_id": 15213,
-    "sleeper_id": 6233,
     "gsis_id": "00-0035436",
     "pff_id": 47123,
-    "espn_id": 3121378,
+    "sleeper_id": 6233,
     "yahoo_id": 32551
   },
   {
     "mfl_id": 15214,
-    "sleeper_id": 7502,
-    "pfr_id": "DafnDo00",
     "gsis_id": "00-0036456",
-    "pff_id": 62825
+    "pff_id": 62825,
+    "sleeper_id": 7502,
+    "pfr_id": "DafnDo00"
   },
   {
     "mfl_id": 15216,
-    "sleeper_id": 6335,
     "gsis_id": "00-0035462",
     "pff_id": 56733,
-    "espn_id": 4241221,
+    "sleeper_id": 6335,
     "yahoo_id": 32515
   },
   {
     "mfl_id": 15217,
-    "sleeper_id": 7459,
-    "pfr_id": "BerrRa01",
     "gsis_id": "00-0036086",
     "pff_id": 28071,
-    "espn_id": 3915508,
-    "yahoo_id": 33024
+    "sleeper_id": 7459,
+    "yahoo_id": 33024,
+    "pfr_id": "BerrRa01"
   },
   {
     "mfl_id": 15220,
-    "sleeper_id": 7203,
-    "pfr_id": "WillAn03",
     "gsis_id": "00-0036188",
     "pff_id": 40197,
-    "espn_id": 4040629,
-    "yahoo_id": 33359
+    "sleeper_id": 7203,
+    "yahoo_id": 33359,
+    "pfr_id": "WillAn03"
   },
   {
     "mfl_id": 15222,
-    "sleeper_id": 6321,
     "gsis_id": "00-0035135",
     "pff_id": 48467,
-    "espn_id": 3914553,
+    "sleeper_id": 6321,
     "yahoo_id": 32351
   },
   {
     "mfl_id": 15224,
-    "sleeper_id": 7352,
-    "pfr_id": "ColeMa03",
     "gsis_id": "00-0035838",
     "pff_id": 113168,
-    "espn_id": 4041703,
-    "yahoo_id": 33236
+    "sleeper_id": 7352,
+    "yahoo_id": 33236,
+    "pfr_id": "ColeMa03"
   },
   {
     "mfl_id": 15225,
-    "sleeper_id": 7406,
-    "pfr_id": "RileEl01",
     "gsis_id": "00-0036002",
     "pff_id": 44440,
+    "sleeper_id": 7406,
+    "yahoo_id": 32968,
     "espn_id": 4036924,
-    "yahoo_id": 32968
+    "pfr_id": "RileEl01",
+    "espn_id_new": 4036924
   },
   {
     "mfl_id": 15226,
-    "sleeper_id": 7491,
-    "pfr_id": "LattCe00",
     "gsis_id": "00-0036058",
-    "espn_id": 4036138,
-    "yahoo_id": 33285
+    "sleeper_id": 7491,
+    "yahoo_id": 33285,
+    "pfr_id": "LattCe00"
   },
   {
     "mfl_id": 15228,
-    "sleeper_id": 5952,
     "gsis_id": "00-0034944",
     "pff_id": 51448,
-    "espn_id": 2971641,
+    "sleeper_id": 5952,
     "yahoo_id": 32212
   },
   {
     "mfl_id": 15229,
-    "sleeper_id": 6876,
-    "pfr_id": "GreeAJ00",
     "gsis_id": "00-0036114",
     "pff_id": 50394,
+    "sleeper_id": 6876,
+    "yahoo_id": 33306,
     "espn_id": 4038437,
-    "yahoo_id": 33306
+    "pfr_id": "GreeAJ00",
+    "espn_id_new": 4038437
   },
   {
     "mfl_id": 15237,
+    "yahoo_id": 33389,
     "espn_id": 4360310,
-    "yahoo_id": 33389
+    "espn_id_new": 4360310
   },
   {
     "mfl_id": 15238,
+    "yahoo_id": 33399,
     "espn_id": 4362887,
-    "yahoo_id": 33399
+    "espn_id_new": 4362887
   },
   {
     "mfl_id": 15239,
+    "yahoo_id": 33390,
     "espn_id": 4361259,
-    "yahoo_id": 33390
+    "espn_id_new": 4361259
   },
   {
     "mfl_id": 15240,
+    "yahoo_id": 33391,
     "espn_id": 4383351,
-    "yahoo_id": 33391
+    "espn_id_new": 4383351
   },
   {
     "mfl_id": 15241,
+    "yahoo_id": 33403,
     "espn_id": 4241464,
-    "yahoo_id": 33403
+    "espn_id_new": 4241464
   },
   {
     "mfl_id": 15242,
-    "sleeper_id": 7605,
-    "pfr_id": "TrasKy00",
     "gsis_id": "00-0036928",
     "pff_id": 39987,
+    "sleeper_id": 7605,
+    "yahoo_id": 33452,
     "espn_id": 4034946,
-    "yahoo_id": 33452
+    "pfr_id": "TrasKy00",
+    "espn_id_new": 4034946
   },
   {
     "mfl_id": 15243,
+    "yahoo_id": 33454,
     "espn_id": 4240904,
-    "yahoo_id": 33454
+    "espn_id_new": 4240904
   },
   {
     "mfl_id": 15244,
-    "sleeper_id": 7531,
     "gsis_id": "00-0036825",
     "pff_id": 40217,
-    "yahoo_id": 33729
+    "sleeper_id": 7531,
+    "yahoo_id": 33729,
+    "espn_id": 4034948,
+    "espn_id_new": 4034948
   },
   {
     "mfl_id": 15245,
@@ -9021,26 +9033,32 @@
   },
   {
     "mfl_id": 15246,
-    "sleeper_id": 7589,
-    "pfr_id": "BookIa00",
     "gsis_id": "00-0036929",
     "pff_id": 40216,
-    "yahoo_id": 33521
+    "sleeper_id": 7589,
+    "yahoo_id": 33521,
+    "espn_id": 4046678,
+    "pfr_id": "BookIa00",
+    "espn_id_new": 4046678
   },
   {
     "mfl_id": 15248,
-    "sleeper_id": 8002,
     "gsis_id": "00-0036679",
     "pff_id": 12659,
-    "yahoo_id": 33879
+    "sleeper_id": 8002,
+    "yahoo_id": 33879,
+    "espn_id": 4039034,
+    "espn_id_new": 4039034
   },
   {
     "mfl_id": 15250,
-    "sleeper_id": 7583,
-    "pfr_id": "EhliSa00",
     "gsis_id": "00-0036879",
     "pff_id": 60555,
-    "yahoo_id": 33606
+    "sleeper_id": 7583,
+    "yahoo_id": 33606,
+    "espn_id": 4241820,
+    "pfr_id": "EhliSa00",
+    "espn_id_new": 4241820
   },
   {
     "mfl_id": 15251,
@@ -9049,73 +9067,83 @@
   },
   {
     "mfl_id": 15252,
+    "yahoo_id": 33455,
     "espn_id": 4242546,
-    "yahoo_id": 33455
+    "espn_id_new": 4242546
   },
   {
     "mfl_id": 15253,
+    "yahoo_id": 33413,
     "espn_id": 4239996,
-    "yahoo_id": 33413
+    "espn_id_new": 4239996
   },
   {
     "mfl_id": 15254,
+    "yahoo_id": 33412,
     "espn_id": 4241457,
-    "yahoo_id": 33412
+    "espn_id_new": 4241457
   },
   {
     "mfl_id": 15255,
+    "yahoo_id": 33538,
     "espn_id": 4371733,
-    "yahoo_id": 33538
+    "espn_id_new": 4371733
   },
   {
     "mfl_id": 15256,
+    "yahoo_id": 33423,
     "espn_id": 4361579,
-    "yahoo_id": 33423
+    "espn_id_new": 4361579
   },
   {
     "mfl_id": 15257,
+    "yahoo_id": 33476,
     "espn_id": 4241401,
-    "yahoo_id": 33476
+    "espn_id_new": 4241401
   },
   {
     "mfl_id": 15258,
-    "espn_id": 4240456,
-    "yahoo_id": 33495
+    "yahoo_id": 33495,
+    "espn_id": 4240657,
+    "espn_id_new": 4240657
   },
   {
     "mfl_id": 15259,
+    "yahoo_id": 33508,
     "espn_id": 4569173,
-    "yahoo_id": 33508
+    "espn_id_new": 4569173
   },
   {
     "mfl_id": 15260,
-    "sleeper_id": 7537,
-    "pfr_id": "PattJa01",
     "gsis_id": "00-0036755",
     "pff_id": 77745,
-    "espn_id": 4362452,
+    "sleeper_id": 7537,
     "yahoo_id": 33706,
+    "espn_id": 4362452,
+    "pfr_id": "PattJa01",
     "ras_id": 19304,
-    "otc_id": 9863
+    "otc_id": 9863,
+    "espn_id_new": 4362452
   },
   {
     "mfl_id": 15261,
+    "yahoo_id": 33514,
     "espn_id": 4241416,
-    "yahoo_id": 33514
+    "espn_id_new": 4241416
   },
   {
     "mfl_id": 15262,
-    "sleeper_id": 7599,
-    "pfr_id": "JeffJe00",
     "gsis_id": "00-0036670",
     "pff_id": 83740,
-    "espn_id": 4374033,
-    "yahoo_id": 33644
+    "sleeper_id": 7599,
+    "yahoo_id": 33644,
+    "pfr_id": "JeffJe00"
   },
   {
     "mfl_id": 15263,
+    "yahoo_id": 33582,
     "espn_id": 4241555,
-    "yahoo_id": 33582
+    "espn_id_new": 4241555
   },
   {
     "mfl_id": 15264,
@@ -9124,87 +9152,89 @@
   },
   {
     "mfl_id": 15265,
-    "espn_id": 4259805,
     "yahoo_id": 33643
   },
   {
     "mfl_id": 15266,
-    "sleeper_id": 7560,
-    "pfr_id": "WillPo01",
     "gsis_id": "00-0036734",
-    "yahoo_id": 33850
+    "sleeper_id": 7560,
+    "yahoo_id": 33850,
+    "pfr_id": "WillPo01"
   },
   {
     "mfl_id": 15267,
-    "sleeper_id": 7918,
     "gsis_id": "00-0036819",
     "pff_id": 40265,
+    "sleeper_id": 7918,
     "yahoo_id": 33784
   },
   {
     "mfl_id": 15268,
-    "sleeper_id": 7563,
     "gsis_id": "00-0036827",
+    "sleeper_id": 7563,
     "yahoo_id": 33731
   },
   {
     "mfl_id": 15269,
-    "sleeper_id": 8085,
-    "pfr_id": "SargMe00",
     "gsis_id": "00-0036698",
     "pff_id": 83684,
-    "espn_id": 4379504
+    "sleeper_id": 8085,
+    "pfr_id": "SargMe00"
   },
   {
     "mfl_id": 15270,
+    "yahoo_id": 33599,
     "espn_id": 4035826,
-    "yahoo_id": 33599
+    "espn_id_new": 4035826
   },
   {
     "mfl_id": 15271,
+    "yahoo_id": 33605,
     "espn_id": 4035886,
-    "yahoo_id": 33605
+    "espn_id_new": 4035886
   },
   {
     "mfl_id": 15272,
+    "yahoo_id": 33586,
     "espn_id": 4241205,
-    "yahoo_id": 33586
+    "espn_id_new": 4241205
   },
   {
     "mfl_id": 15273,
-    "sleeper_id": 7904,
     "gsis_id": "00-0036548",
+    "sleeper_id": 7904,
     "yahoo_id": 33692
   },
   {
     "mfl_id": 15274,
-    "sleeper_id": 7993,
-    "pfr_id": "RagaTr00",
     "gsis_id": "00-0036523",
     "pff_id": 42174,
-    "yahoo_id": 33809
+    "sleeper_id": 7993,
+    "yahoo_id": 33809,
+    "pfr_id": "RagaTr00"
   },
   {
     "mfl_id": 15275,
+    "yahoo_id": 33590,
     "espn_id": 4046530,
-    "yahoo_id": 33590
+    "espn_id_new": 4046530
   },
   {
     "mfl_id": 15276,
-    "sleeper_id": 7867,
-    "pfr_id": "BrowSp01",
     "gsis_id": "00-0036543",
     "pff_id": 57441,
-    "espn_id": 4239768
+    "sleeper_id": 7867,
+    "pfr_id": "BrowSp01"
   },
   {
     "mfl_id": 15277,
-    "sleeper_id": 7551,
-    "pfr_id": "JackDe02",
     "gsis_id": "00-0036493",
     "pff_id": 57189,
+    "sleeper_id": 7551,
+    "yahoo_id": 33798,
     "espn_id": 4240455,
-    "yahoo_id": 33798
+    "pfr_id": "JackDe02",
+    "espn_id_new": 4240455
   },
   {
     "mfl_id": 15279,
@@ -9213,67 +9243,77 @@
   },
   {
     "mfl_id": 15281,
+    "yahoo_id": 33393,
     "espn_id": 4362628,
-    "yahoo_id": 33393
+    "espn_id_new": 4362628
   },
   {
     "mfl_id": 15282,
+    "yahoo_id": 33398,
     "espn_id": 4241478,
-    "yahoo_id": 33398
+    "espn_id_new": 4241478
   },
   {
     "mfl_id": 15283,
+    "yahoo_id": 33437,
     "espn_id": 4372485,
-    "yahoo_id": 33437
+    "espn_id_new": 4372485
   },
   {
     "mfl_id": 15284,
+    "yahoo_id": 33394,
     "espn_id": 4372016,
-    "yahoo_id": 33394
+    "espn_id_new": 4372016
   },
   {
     "mfl_id": 15285,
+    "yahoo_id": 33519,
     "espn_id": 4241424,
-    "yahoo_id": 33519
+    "espn_id_new": 4241424
   },
   {
     "mfl_id": 15286,
-    "espn_id": 4371974
+    "espn_id": 4371974,
+    "espn_id_new": 4371974
   },
   {
     "mfl_id": 15287,
+    "yahoo_id": 33500,
     "espn_id": 4374302,
-    "yahoo_id": 33500
+    "espn_id_new": 4374302
   },
   {
     "mfl_id": 15288,
+    "yahoo_id": 33422,
     "espn_id": 4372414,
-    "yahoo_id": 33422
+    "espn_id_new": 4372414
   },
   {
     "mfl_id": 15289,
-    "espn_id": 4240600,
     "yahoo_id": 33408
   },
   {
     "mfl_id": 15290,
-    "espn_id": 4258173
+    "espn_id": 4258173,
+    "espn_id_new": 4258173
   },
   {
     "mfl_id": 15291,
-    "sleeper_id": 7586,
-    "pfr_id": "NewsDa00",
     "gsis_id": "00-0036907",
-    "pff_id": 61510
+    "pff_id": 61510,
+    "sleeper_id": 7586,
+    "pfr_id": "NewsDa00"
   },
   {
     "mfl_id": 15292,
+    "yahoo_id": 33470,
     "espn_id": 4361577,
-    "yahoo_id": 33470
+    "espn_id_new": 4361577
   },
   {
     "mfl_id": 15293,
-    "espn_id": 4360939
+    "espn_id": 4360939,
+    "espn_id_new": 4360939
   },
   {
     "mfl_id": 15294,
@@ -9287,47 +9327,54 @@
   },
   {
     "mfl_id": 15296,
+    "yahoo_id": 33479,
     "espn_id": 4371986,
-    "yahoo_id": 33479
+    "espn_id_new": 4371986
   },
   {
     "mfl_id": 15297,
+    "yahoo_id": 33473,
     "espn_id": 4239992,
-    "yahoo_id": 33473
+    "espn_id_new": 4239992
   },
   {
     "mfl_id": 15298,
+    "yahoo_id": 33592,
     "espn_id": 4259499,
-    "yahoo_id": 33592
+    "espn_id_new": 4259499
   },
   {
     "mfl_id": 15300,
-    "sleeper_id": 7550,
     "gsis_id": "00-0036721",
     "pff_id": 52050,
+    "sleeper_id": 7550,
     "yahoo_id": 33897
   },
   {
     "mfl_id": 15301,
+    "yahoo_id": 33445,
     "espn_id": 4360797,
-    "yahoo_id": 33445
+    "espn_id_new": 4360797
   },
   {
     "mfl_id": 15302,
-    "espn_id": 4043016
+    "espn_id": 4043016,
+    "espn_id_new": 4043016
   },
   {
     "mfl_id": 15303,
+    "yahoo_id": 33567,
     "espn_id": 4360739,
-    "yahoo_id": 33567
+    "espn_id_new": 4360739
   },
   {
     "mfl_id": 15304,
-    "sleeper_id": 7530,
-    "pfr_id": "DarbFr00",
     "gsis_id": "00-0036951",
     "pff_id": 40988,
-    "espn_id": 4047836
+    "sleeper_id": 7530,
+    "espn_id": 4047836,
+    "pfr_id": "DarbFr00",
+    "espn_id_new": 4047836
   },
   {
     "mfl_id": 15305,
@@ -9336,44 +9383,45 @@
   },
   {
     "mfl_id": 15306,
-    "espn_id": 4047648
+    "espn_id": 4047648,
+    "espn_id_new": 4047648
   },
   {
     "mfl_id": 15307,
-    "sleeper_id": 7862,
     "gsis_id": "00-0036776",
-    "espn_id": 4043158,
+    "sleeper_id": 7862,
     "yahoo_id": 33709
   },
   {
     "mfl_id": 15308,
+    "yahoo_id": 33447,
     "espn_id": 4362630,
-    "yahoo_id": 33447
+    "espn_id_new": 4362630
   },
   {
     "mfl_id": 15309,
-    "sleeper_id": 7860,
     "gsis_id": "00-0036773",
+    "sleeper_id": 7860,
     "yahoo_id": 33711
   },
   {
     "mfl_id": 15311,
-    "sleeper_id": 7996,
-    "pfr_id": "StonDi00",
     "gsis_id": "00-0036526",
     "pff_id": 48304,
-    "espn_id": 4038460,
-    "yahoo_id": 33812
+    "sleeper_id": 7996,
+    "yahoo_id": 33812,
+    "pfr_id": "StonDi00"
   },
   {
     "mfl_id": 15312,
-    "sleeper_id": 7548,
     "gsis_id": "00-0036495",
+    "sleeper_id": 7548,
     "yahoo_id": 33800
   },
   {
     "mfl_id": 15313,
-    "espn_id": 4242231
+    "espn_id": 4242231,
+    "espn_id_new": 4242231
   },
   {
     "mfl_id": 15314,
@@ -9387,14 +9435,15 @@
   },
   {
     "mfl_id": 15316,
-    "sleeper_id": 7541,
-    "pfr_id": "PoweCo00",
     "gsis_id": "00-0036647",
-    "pff_id": 40689
+    "pff_id": 40689,
+    "sleeper_id": 7541,
+    "espn_id": 4035465,
+    "pfr_id": "PoweCo00",
+    "espn_id_new": 4035465
   },
   {
-    "mfl_id": 15317,
-    "espn_id": 4039307
+    "mfl_id": 15317
   },
   {
     "mfl_id": 15318,
@@ -9403,11 +9452,11 @@
   },
   {
     "mfl_id": 15319,
-    "espn_id": 4242433
+    "espn_id": 4242433,
+    "espn_id_new": 4242433
   },
   {
-    "mfl_id": 15321,
-    "espn_id": 4243830
+    "mfl_id": 15321
   },
   {
     "mfl_id": 15322,
@@ -9421,23 +9470,25 @@
   },
   {
     "mfl_id": 15324,
-    "sleeper_id": 7579,
     "gsis_id": "00-0036676",
     "pff_id": 84457,
-    "yahoo_id": 33830
+    "sleeper_id": 7579,
+    "yahoo_id": 33830,
+    "espn_id": 4363409,
+    "espn_id_new": 4363409
   },
   {
     "mfl_id": 15325,
-    "sleeper_id": 7956,
     "gsis_id": "00-0036810",
     "pff_id": 42109,
-    "espn_id": 4031033,
+    "sleeper_id": 7956,
     "yahoo_id": 33858
   },
   {
     "mfl_id": 15326,
+    "yahoo_id": 33645,
     "espn_id": 4373642,
-    "yahoo_id": 33645
+    "espn_id_new": 4373642
   },
   {
     "mfl_id": 15327,
@@ -9446,88 +9497,99 @@
   },
   {
     "mfl_id": 15328,
-    "sleeper_id": 8005,
-    "pfr_id": "BlacTa00",
     "gsis_id": "00-0036491",
     "pff_id": 61442,
-    "yahoo_id": 33797
+    "sleeper_id": 8005,
+    "yahoo_id": 33797,
+    "pfr_id": "BlacTa00"
   },
   {
     "mfl_id": 15329,
+    "yahoo_id": 33392,
     "espn_id": 4360248,
-    "yahoo_id": 33392
+    "espn_id_new": 4360248
   },
   {
     "mfl_id": 15330,
+    "yahoo_id": 33535,
     "espn_id": 4362504,
-    "yahoo_id": 33535
+    "espn_id_new": 4362504
   },
   {
     "mfl_id": 15331,
+    "yahoo_id": 33443,
     "espn_id": 4361411,
-    "yahoo_id": 33443
+    "espn_id_new": 4361411
   },
   {
     "mfl_id": 15332,
+    "yahoo_id": 33471,
     "espn_id": 4372780,
-    "yahoo_id": 33471
+    "espn_id_new": 4372780
   },
   {
     "mfl_id": 15333,
+    "yahoo_id": 33485,
     "espn_id": 4240023,
-    "yahoo_id": 33485
+    "espn_id_new": 4240023
   },
   {
     "mfl_id": 15334,
+    "yahoo_id": 33469,
     "espn_id": 4239944,
-    "yahoo_id": 33469
+    "espn_id_new": 4239944
   },
   {
     "mfl_id": 15335,
+    "yahoo_id": 33533,
     "espn_id": 4040612,
-    "yahoo_id": 33533
+    "espn_id_new": 4040612
   },
   {
     "mfl_id": 15336,
-    "sleeper_id": 7859,
     "gsis_id": "00-0036766",
+    "sleeper_id": 7859,
     "yahoo_id": 33714
   },
   {
     "mfl_id": 15337,
+    "yahoo_id": 33550,
     "espn_id": 4240472,
-    "yahoo_id": 33550
+    "espn_id_new": 4240472
   },
   {
     "mfl_id": 15338,
-    "sleeper_id": 8018,
     "gsis_id": "00-0036718",
     "pff_id": 40860,
+    "sleeper_id": 8018,
     "yahoo_id": 33892
   },
   {
     "mfl_id": 15339,
-    "sleeper_id": 7597,
-    "pfr_id": "YeboKe00",
     "gsis_id": "00-0036510",
     "pff_id": 42196,
-    "yahoo_id": 33705
+    "sleeper_id": 7597,
+    "yahoo_id": 33705,
+    "espn_id": 4044144,
+    "pfr_id": "YeboKe00",
+    "espn_id_new": 4044144
   },
   {
     "mfl_id": 15340,
-    "sleeper_id": 7972,
-    "pfr_id": "PoljTo00",
     "gsis_id": "00-0036583",
     "pff_id": 40148,
-    "yahoo_id": 33791
+    "sleeper_id": 7972,
+    "yahoo_id": 33791,
+    "pfr_id": "PoljTo00"
   },
   {
     "mfl_id": 15341,
-    "sleeper_id": 7536,
     "gsis_id": "00-0036590",
     "pff_id": 61182,
+    "sleeper_id": 7536,
+    "yahoo_id": 33819,
     "espn_id": 4244049,
-    "yahoo_id": 33819
+    "espn_id_new": 4244049
   },
   {
     "mfl_id": 15342,
@@ -9536,135 +9598,160 @@
   },
   {
     "mfl_id": 15343,
-    "sleeper_id": 7943,
     "gsis_id": "00-0036640",
     "pff_id": 143780,
-    "yahoo_id": 33556
+    "sleeper_id": 7943,
+    "yahoo_id": 33556,
+    "espn_id": 4746079,
+    "espn_id_new": 4746079
   },
   {
     "mfl_id": 15344,
-    "sleeper_id": 7716,
-    "pfr_id": "BateJo00",
     "gsis_id": "00-0036628",
     "pff_id": 42275,
-    "espn_id": 4048228,
+    "sleeper_id": 7716,
     "yahoo_id": 33512,
+    "espn_id": 4048228,
+    "pfr_id": "BateJo00",
     "ras_id": 19418,
-    "otc_id": 9588
+    "otc_id": 9588,
+    "espn_id_new": 4048228
   },
   {
     "mfl_id": 15345,
+    "yahoo_id": 33409,
     "espn_id": 4258194,
-    "yahoo_id": 33409
+    "espn_id_new": 4258194
   },
   {
     "mfl_id": 15346,
-    "espn_id": 4362506
+    "espn_id": 4362506,
+    "espn_id_new": 4362506
   },
   {
     "mfl_id": 15347,
-    "espn_id": 4036076
+    "espn_id": 4036076,
+    "espn_id_new": 4036076
   },
   {
     "mfl_id": 15348,
+    "yahoo_id": 33449,
     "espn_id": 4037239,
-    "yahoo_id": 33449
+    "espn_id_new": 4037239
   },
   {
     "mfl_id": 15349,
+    "yahoo_id": 33406,
     "espn_id": 4242975,
-    "yahoo_id": 33406
+    "espn_id_new": 4242975
   },
   {
     "mfl_id": 15350,
-    "espn_id": 4361423
+    "espn_id": 4361423,
+    "espn_id_new": 4361423
   },
   {
     "mfl_id": 15351,
-    "espn_id": 4258599
+    "espn_id": 4258599,
+    "espn_id_new": 4258599
   },
   {
     "mfl_id": 15352,
-    "espn_id": 4244606
+    "espn_id": 4244606,
+    "espn_id_new": 4244606
   },
   {
     "mfl_id": 15353,
-    "espn_id": 4037521
+    "espn_id": 4037521,
+    "espn_id_new": 4037521
   },
   {
     "mfl_id": 15354,
-    "sleeper_id": 8009,
     "gsis_id": "00-0036508",
+    "sleeper_id": 8009,
     "yahoo_id": 33650
   },
   {
     "mfl_id": 15355,
-    "espn_id": 4362759
+    "espn_id": 4362759,
+    "espn_id_new": 4362759
   },
   {
     "mfl_id": 15356,
-    "espn_id": 4241987
+    "espn_id": 4241987,
+    "espn_id_new": 4241987
   },
   {
     "mfl_id": 15357,
+    "yahoo_id": 33426,
     "espn_id": 4372030,
-    "yahoo_id": 33426
+    "espn_id_new": 4372030
   },
   {
     "mfl_id": 15358,
-    "espn_id": 4361366
+    "espn_id": 4361366,
+    "espn_id_new": 4361366
   },
   {
     "mfl_id": 15359,
-    "espn_id": 4259647
+    "espn_id": 4259647,
+    "espn_id_new": 4259647
   },
   {
-    "mfl_id": 15360,
-    "espn_id": 4240859
+    "mfl_id": 15360
   },
   {
     "mfl_id": 15361,
+    "yahoo_id": 33396,
     "espn_id": 4362847,
-    "yahoo_id": 33396
+    "espn_id_new": 4362847
   },
   {
     "mfl_id": 15362,
-    "espn_id": 4372012
+    "espn_id": 4372012,
+    "espn_id_new": 4372012
   },
   {
     "mfl_id": 15363,
-    "espn_id": 4240401
+    "espn_id": 4240401,
+    "espn_id_new": 4240401
   },
   {
     "mfl_id": 15364,
-    "espn_id": 4361939
+    "espn_id": 4361939,
+    "espn_id_new": 4361939
   },
   {
     "mfl_id": 15365,
+    "yahoo_id": 33431,
     "espn_id": 4362487,
-    "yahoo_id": 33431
+    "espn_id_new": 4362487
   },
   {
     "mfl_id": 15366,
+    "yahoo_id": 33424,
     "espn_id": 4373809,
-    "yahoo_id": 33424
+    "espn_id_new": 4373809
   },
   {
     "mfl_id": 15367,
+    "yahoo_id": 33574,
     "espn_id": 4240030,
-    "yahoo_id": 33574
+    "espn_id_new": 4240030
   },
   {
     "mfl_id": 15368,
+    "yahoo_id": 33537,
     "espn_id": 4360234,
-    "yahoo_id": 33537
+    "espn_id_new": 4360234
   },
   {
     "mfl_id": 15369,
-    "sleeper_id": 7922,
     "gsis_id": "00-0036816",
+    "sleeper_id": 7922,
+    "yahoo_id": 33781,
     "espn_id": 4243371,
-    "yahoo_id": 33781
+    "espn_id_new": 4243371
   },
   {
     "mfl_id": 15370,
@@ -9673,659 +9760,719 @@
   },
   {
     "mfl_id": 15371,
-    "sleeper_id": 7222,
     "gsis_id": "00-0035946",
     "pff_id": 28430,
+    "sleeper_id": 7222,
+    "yahoo_id": 33131,
     "espn_id": 4039164,
-    "yahoo_id": 33131
+    "espn_id_new": 4039164
   },
   {
     "mfl_id": 15372,
-    "sleeper_id": 7618,
     "gsis_id": "00-0036470",
     "pff_id": 34130,
+    "sleeper_id": 7618,
     "yahoo_id": 33382
   },
   {
     "mfl_id": 15373,
-    "espn_id": 4240778
+    "espn_id": 4240778,
+    "espn_id_new": 4240778
   },
   {
     "mfl_id": 15374,
-    "sleeper_id": 7622,
-    "pfr_id": "ReyeSa00",
     "gsis_id": "00-0036474",
     "pff_id": 143769,
-    "yahoo_id": 33386
+    "sleeper_id": 7622,
+    "yahoo_id": 33386,
+    "pfr_id": "ReyeSa00"
   },
   {
     "mfl_id": 15375,
+    "yahoo_id": 33414,
     "espn_id": 4361266,
-    "yahoo_id": 33414
+    "espn_id_new": 4361266
   },
   {
     "mfl_id": 15376,
+    "yahoo_id": 33416,
     "espn_id": 4240269,
-    "yahoo_id": 33416
+    "espn_id_new": 4240269
   },
   {
     "mfl_id": 15377,
+    "yahoo_id": 33417,
     "espn_id": 4259561,
-    "yahoo_id": 33417
+    "espn_id_new": 4259561
   },
   {
     "mfl_id": 15378,
+    "yahoo_id": 33419,
     "espn_id": 4361422,
-    "yahoo_id": 33419
+    "espn_id_new": 4361422
   },
   {
     "mfl_id": 15379,
-    "espn_id": 4243333
+    "espn_id": 4243333,
+    "espn_id_new": 4243333
   },
   {
     "mfl_id": 15380,
+    "yahoo_id": 33421,
     "espn_id": 4379397,
-    "yahoo_id": 33421
+    "espn_id_new": 4379397
   },
   {
     "mfl_id": 15381,
-    "espn_id": 4042119
+    "espn_id": 4042119,
+    "espn_id_new": 4042119
   },
   {
     "mfl_id": 15382,
+    "yahoo_id": 33429,
     "espn_id": 4039020,
-    "yahoo_id": 33429
+    "espn_id_new": 4039020
   },
   {
     "mfl_id": 15383,
-    "espn_id": 4362629
+    "espn_id": 4362629,
+    "espn_id_new": 4362629
   },
   {
     "mfl_id": 15384,
+    "yahoo_id": 33435,
     "espn_id": 4363034,
-    "yahoo_id": 33435
+    "espn_id_new": 4363034
   },
   {
     "mfl_id": 15385,
-    "espn_id": 4379409
+    "espn_id": 4379409,
+    "espn_id_new": 4379409
   },
   {
     "mfl_id": 15386,
-    "espn_id": 4242659
+    "espn_id": 4242659,
+    "espn_id_new": 4242659
   },
   {
     "mfl_id": 15387,
-    "espn_id": 4241993
+    "espn_id": 4241993,
+    "espn_id_new": 4241993
   },
   {
     "mfl_id": 15388,
-    "espn_id": 4362094
+    "espn_id": 4362094,
+    "espn_id_new": 4362094
   },
   {
     "mfl_id": 15389,
-    "espn_id": 4040979
+    "espn_id": 4040979,
+    "espn_id_new": 4040979
   },
   {
     "mfl_id": 15390,
+    "yahoo_id": 33460,
     "espn_id": 4361662,
-    "yahoo_id": 33460
+    "espn_id_new": 4361662
   },
   {
     "mfl_id": 15391,
-    "espn_id": 4239699
+    "espn_id": 4239699,
+    "espn_id_new": 4239699
   },
   {
     "mfl_id": 15392,
-    "espn_id": 4258206
+    "espn_id": 4258206,
+    "espn_id_new": 4258206
   },
   {
     "mfl_id": 15393,
+    "yahoo_id": 33463,
     "espn_id": 4035840,
-    "yahoo_id": 33463
+    "espn_id_new": 4035840
   },
   {
     "mfl_id": 15394,
+    "yahoo_id": 33464,
     "espn_id": 4242547,
-    "yahoo_id": 33464
+    "espn_id_new": 4242547
   },
   {
     "mfl_id": 15395,
-    "espn_id": 4239719
+    "espn_id": 4239719,
+    "espn_id_new": 4239719
   },
   {
     "mfl_id": 15396,
-    "espn_id": 4037626
+    "espn_id": 4037626,
+    "espn_id_new": 4037626
   },
   {
     "mfl_id": 15397,
-    "espn_id": 4036132
+    "espn_id": 4036132,
+    "espn_id_new": 4036132
   },
   {
     "mfl_id": 15398,
+    "yahoo_id": 33478,
     "espn_id": 4036063,
-    "yahoo_id": 33478
+    "espn_id_new": 4036063
   },
   {
     "mfl_id": 15399,
-    "espn_id": 4240692
+    "espn_id": 4240692,
+    "espn_id_new": 4240692
   },
   {
-    "mfl_id": 15400,
-    "espn_id": 4360274
+    "mfl_id": 15400
   },
   {
     "mfl_id": 15401,
-    "espn_id": 4570470
+    "espn_id": 4570470,
+    "espn_id_new": 4570470
   },
   {
     "mfl_id": 15402,
-    "espn_id": 4243328
+    "espn_id": 4243328,
+    "espn_id_new": 4243328
   },
   {
     "mfl_id": 15403,
-    "espn_id": 4258209
+    "espn_id": 4258209,
+    "espn_id_new": 4258209
   },
   {
     "mfl_id": 15404,
-    "espn_id": 4362851
+    "espn_id": 4362851,
+    "espn_id_new": 4362851
   },
   {
     "mfl_id": 15405,
+    "yahoo_id": 33492,
     "espn_id": 4035824,
-    "yahoo_id": 33492
+    "espn_id_new": 4035824
   },
   {
-    "mfl_id": 15406,
-    "espn_id": 4261606
+    "mfl_id": 15406
   },
   {
     "mfl_id": 15407,
-    "espn_id": 4036026
+    "espn_id": 4036026,
+    "espn_id_new": 4036026
   },
   {
     "mfl_id": 15408,
-    "espn_id": 4243923
+    "espn_id": 4243923,
+    "espn_id_new": 4243923
   },
   {
     "mfl_id": 15409,
-    "espn_id": 4260409
+    "espn_id": 4260409,
+    "espn_id_new": 4260409
   },
   {
     "mfl_id": 15410,
-    "espn_id": 4040940
+    "espn_id": 4040940,
+    "espn_id_new": 4040940
   },
   {
     "mfl_id": 15411,
-    "espn_id": 4030924
+    "espn_id": 4030924,
+    "espn_id_new": 4030924
   },
   {
     "mfl_id": 15412,
-    "espn_id": 4372518
+    "espn_id": 4372518,
+    "espn_id_new": 4372518
   },
   {
     "mfl_id": 15413,
-    "espn_id": 4240475
+    "espn_id": 4240475,
+    "espn_id_new": 4240475
   },
   {
-    "mfl_id": 15414,
-    "espn_id": 4035537
+    "mfl_id": 15414
   },
   {
     "mfl_id": 15415,
-    "espn_id": 4034957
+    "espn_id": 4034957,
+    "espn_id_new": 4034957
   },
   {
-    "mfl_id": 15416,
-    "espn_id": 4242228
+    "mfl_id": 15416
   },
   {
-    "mfl_id": 15417,
-    "espn_id": 4045161
+    "mfl_id": 15417
   },
   {
     "mfl_id": 15418,
-    "espn_id": 4035861
+    "espn_id": 4035861,
+    "espn_id_new": 4035861
   },
   {
     "mfl_id": 15419,
-    "sleeper_id": 7602,
-    "pfr_id": "GranKy00",
     "gsis_id": "00-0036876",
     "pff_id": 40630,
-    "espn_id": 4039160,
+    "sleeper_id": 7602,
     "yahoo_id": 33515,
+    "espn_id": 4039160,
+    "pfr_id": "GranKy00",
     "ras_id": 19436,
-    "otc_id": 9591
+    "otc_id": 9591,
+    "espn_id_new": 4039160
   },
   {
-    "mfl_id": 15420,
-    "espn_id": 4032200
+    "mfl_id": 15420
   },
   {
     "mfl_id": 15421,
-    "espn_id": 4035604
+    "espn_id": 4035604,
+    "espn_id_new": 4035604
   },
   {
     "mfl_id": 15422,
+    "yahoo_id": 33524,
     "espn_id": 4240595,
-    "yahoo_id": 33524
+    "espn_id_new": 4240595
   },
   {
     "mfl_id": 15423,
-    "espn_id": 4241373
+    "espn_id": 4241373,
+    "espn_id_new": 4241373
   },
   {
     "mfl_id": 15424,
-    "espn_id": 4240900
+    "espn_id": 4240900,
+    "espn_id_new": 4240900
   },
   {
     "mfl_id": 15425,
-    "sleeper_id": 7703,
-    "pfr_id": "HarrJa03",
     "gsis_id": "00-0036918",
+    "sleeper_id": 7703,
+    "yahoo_id": 33529,
     "espn_id": 3932144,
-    "yahoo_id": 33529
+    "pfr_id": "HarrJa03",
+    "espn_id_new": 3932144
   },
   {
-    "mfl_id": 15426,
-    "espn_id": 4241195
+    "mfl_id": 15426
   },
   {
-    "mfl_id": 15427,
-    "espn_id": 4240026
+    "mfl_id": 15427
   },
   {
     "mfl_id": 15428,
-    "espn_id": 4361331
+    "espn_id": 4361331,
+    "espn_id_new": 4361331
   },
   {
     "mfl_id": 15429,
-    "espn_id": 4262197
+    "espn_id": 4262197,
+    "espn_id_new": 4262197
   },
   {
     "mfl_id": 15430,
-    "espn_id": 4362077
+    "espn_id": 4362077,
+    "espn_id_new": 4362077
   },
   {
     "mfl_id": 15431,
-    "espn_id": 4245655
+    "espn_id": 4245655,
+    "espn_id_new": 4245655
   },
   {
     "mfl_id": 15432,
-    "espn_id": 4240657,
-    "yahoo_id": 33495
+    "yahoo_id": 33495,
+    "espn_id": 4240456,
+    "espn_id_new": 4240456
   },
   {
     "mfl_id": 15433,
-    "espn_id": 4035798
+    "espn_id": 4035798,
+    "espn_id_new": 4035798
   },
   {
     "mfl_id": 15434,
+    "yahoo_id": 33545,
     "espn_id": 4240573,
-    "yahoo_id": 33545
+    "espn_id_new": 4240573
   },
   {
     "mfl_id": 15435,
-    "espn_id": 4360484,
     "yahoo_id": 33546
   },
   {
-    "mfl_id": 15436,
-    "espn_id": 4241995
+    "mfl_id": 15436
   },
   {
     "mfl_id": 15437,
-    "espn_id": 4239088
+    "espn_id": 4239088,
+    "espn_id_new": 4239088
   },
   {
-    "mfl_id": 15438,
-    "espn_id": 4371949
+    "mfl_id": 15438
   },
   {
-    "mfl_id": 15439,
-    "espn_id": 4240602
+    "mfl_id": 15439
   },
   {
     "mfl_id": 15440,
-    "espn_id": 4243332
+    "espn_id": 4243332,
+    "espn_id_new": 4243332
   },
   {
     "mfl_id": 15441,
-    "espn_id": 4240542
+    "espn_id": 4240542,
+    "espn_id_new": 4240542
   },
   {
     "mfl_id": 15442,
-    "espn_id": 4240686
+    "espn_id": 4240686,
+    "espn_id_new": 4240686
   },
   {
     "mfl_id": 15443,
-    "espn_id": 4241807
+    "espn_id": 4241807,
+    "espn_id_new": 4241807
   },
   {
-    "mfl_id": 15444,
-    "espn_id": 4039028
+    "mfl_id": 15444
   },
   {
     "mfl_id": 15445,
+    "yahoo_id": 33560,
     "espn_id": 4242488,
-    "yahoo_id": 33560
+    "espn_id_new": 4242488
   },
   {
     "mfl_id": 15446,
-    "sleeper_id": 7818,
-    "pfr_id": "SlatTe00",
     "gsis_id": "00-0036642",
-    "pff_id": 56597
+    "pff_id": 56597,
+    "sleeper_id": 7818,
+    "pfr_id": "SlatTe00"
   },
   {
     "mfl_id": 15447,
-    "sleeper_id": 7817,
     "gsis_id": "00-0036855",
     "pff_id": 56428,
-    "espn_id": 4242292
+    "sleeper_id": 7817,
+    "espn_id": 4242292,
+    "espn_id_new": 4242292
   },
   {
     "mfl_id": 15448,
-    "espn_id": 4240706
+    "espn_id": 4240706,
+    "espn_id_new": 4240706
   },
   {
     "mfl_id": 15449,
-    "espn_id": 4242521
+    "espn_id": 4242521,
+    "espn_id_new": 4242521
   },
   {
     "mfl_id": 15450,
-    "espn_id": 4372085
+    "espn_id": 4372085,
+    "espn_id_new": 4372085
   },
   {
     "mfl_id": 15451,
-    "espn_id": 4036430
+    "espn_id": 4036430,
+    "espn_id_new": 4036430
   },
   {
     "mfl_id": 15452,
-    "espn_id": 4360853
+    "espn_id": 4360853,
+    "espn_id_new": 4360853
   },
   {
     "mfl_id": 15453,
-    "espn_id": 4046693
+    "espn_id": 4046693,
+    "espn_id_new": 4046693
   },
   {
     "mfl_id": 15454,
-    "espn_id": 4048259
+    "espn_id": 4048259,
+    "espn_id_new": 4048259
   },
   {
     "mfl_id": 15455,
-    "sleeper_id": 7808,
     "gsis_id": "00-0036565",
-    "pff_id": 57070
+    "pff_id": 57070,
+    "sleeper_id": 7808
   },
   {
     "mfl_id": 15456,
-    "espn_id": 4036141
+    "espn_id": 4036141,
+    "espn_id_new": 4036141
   },
   {
-    "mfl_id": 15457,
-    "espn_id": 4241199
+    "mfl_id": 15457
   },
   {
     "mfl_id": 15458,
-    "espn_id": 4243218
+    "espn_id": 4243218,
+    "espn_id_new": 4243218
   },
   {
-    "mfl_id": 15459,
-    "espn_id": 4052031
+    "mfl_id": 15459
   },
   {
     "mfl_id": 15460,
-    "espn_id": 4259978
+    "espn_id": 4259978,
+    "espn_id_new": 4259978
   },
   {
     "mfl_id": 15461,
-    "espn_id": 4040805
+    "espn_id": 4040805,
+    "espn_id_new": 4040805
   },
   {
     "mfl_id": 15462,
+    "yahoo_id": 33584,
     "espn_id": 4245645,
-    "yahoo_id": 33584
+    "espn_id_new": 4245645
   },
   {
-    "mfl_id": 15463,
-    "espn_id": 4240716
+    "mfl_id": 15463
   },
   {
     "mfl_id": 15464,
-    "espn_id": 4567979
+    "espn_id": 4567979,
+    "espn_id_new": 4567979
   },
   {
-    "mfl_id": 15465,
-    "espn_id": 4038430
+    "mfl_id": 15465
   },
   {
-    "mfl_id": 15466,
-    "espn_id": 4035590
+    "mfl_id": 15466
   },
   {
     "mfl_id": 15467,
+    "gsis_id": "00-0036858",
     "sleeper_id": 7789,
-    "gsis_id": "00-0036858"
+    "espn_id": 4037311,
+    "espn_id_new": 4037311
   },
   {
     "mfl_id": 15468,
-    "espn_id": 4240464
+    "espn_id": 4240464,
+    "espn_id_new": 4240464
   },
   {
     "mfl_id": 15469,
-    "espn_id": 4036060
+    "espn_id": 4036060,
+    "espn_id_new": 4036060
   },
   {
     "mfl_id": 15470,
-    "sleeper_id": 7786,
-    "pfr_id": "WildRa00",
     "gsis_id": "00-0036573",
     "pff_id": 83111,
-    "espn_id": 4372560
+    "sleeper_id": 7786,
+    "pfr_id": "WildRa00"
   },
   {
-    "mfl_id": 15471,
-    "espn_id": 4038944
+    "mfl_id": 15471
   },
   {
-    "mfl_id": 15472,
-    "espn_id": 4044145
+    "mfl_id": 15472
   },
   {
     "mfl_id": 15473,
-    "espn_id": 4239947
+    "espn_id": 4239947,
+    "espn_id_new": 4239947
   },
   {
-    "mfl_id": 15474,
-    "espn_id": 4568981
+    "mfl_id": 15474
   },
   {
     "mfl_id": 15475,
-    "sleeper_id": 7779,
-    "pfr_id": "StevJa00",
     "gsis_id": "00-0036925",
-    "pff_id": 61402
+    "pff_id": 61402,
+    "sleeper_id": 7779,
+    "pfr_id": "StevJa00"
   },
   {
     "mfl_id": 15476,
-    "espn_id": 4362855
+    "espn_id": 4362855,
+    "espn_id_new": 4362855
   },
   {
-    "mfl_id": 15477,
-    "espn_id": 4242485
+    "mfl_id": 15477
   },
   {
     "mfl_id": 15478,
-    "sleeper_id": 7944,
-    "pfr_id": "StraMi03",
     "gsis_id": "00-0036482",
     "pff_id": 143358,
-    "espn_id": 4589245,
+    "sleeper_id": 7944,
     "yahoo_id": 33620,
+    "pfr_id": "StraMi03",
     "ras_id": 19156,
     "otc_id": 9693
   },
   {
-    "mfl_id": 15479,
-    "espn_id": 4259989
+    "mfl_id": 15479
   },
   {
     "mfl_id": 15480,
-    "espn_id": 4036224,
     "yahoo_id": 33621
   },
   {
     "mfl_id": 15481,
-    "espn_id": 4243916
+    "espn_id": 4243916,
+    "espn_id_new": 4243916
   },
   {
-    "mfl_id": 15482,
-    "espn_id": 4241344
+    "mfl_id": 15482
   },
   {
-    "mfl_id": 15483,
-    "espn_id": 4242211
+    "mfl_id": 15483
   },
   {
     "mfl_id": 15484,
-    "espn_id": 4040608
+    "espn_id": 4040608,
+    "espn_id_new": 4040608
   },
   {
     "mfl_id": 15485,
-    "sleeper_id": 7764,
-    "pfr_id": "BradWi00",
     "gsis_id": "00-0036664",
-    "pff_id": 44184
+    "pff_id": 44184,
+    "sleeper_id": 7764,
+    "pfr_id": "BradWi00"
   },
   {
-    "mfl_id": 15486,
-    "espn_id": 4259570
+    "mfl_id": 15486
   },
   {
     "mfl_id": 15487,
+    "gsis_id": "00-0036889",
     "sleeper_id": 7762,
-    "pfr_id": "WiggJa00",
-    "gsis_id": "00-0036889"
+    "pfr_id": "WiggJa00"
   },
   {
     "mfl_id": 15488,
-    "sleeper_id": 7539,
     "gsis_id": "00-0036578",
-    "pff_id": 40903
+    "pff_id": 40903,
+    "sleeper_id": 7539,
+    "espn_id": 4037478,
+    "espn_id_new": 4037478
   },
   {
     "mfl_id": 15489,
-    "espn_id": 4241396,
     "yahoo_id": 33633
   },
   {
     "mfl_id": 15490,
-    "espn_id": 4045169
+    "espn_id": 4045169,
+    "espn_id_new": 4045169
   },
   {
     "mfl_id": 15491,
-    "espn_id": 4035656
+    "espn_id": 4035656,
+    "espn_id_new": 4035656
   },
   {
     "mfl_id": 15492,
-    "espn_id": 4256074
+    "espn_id": 4256074,
+    "espn_id_new": 4256074
   },
   {
     "mfl_id": 15493,
-    "sleeper_id": 7755,
-    "pfr_id": "WilcCh00",
     "gsis_id": "00-0036667",
-    "pff_id": 43308
+    "pff_id": 43308,
+    "sleeper_id": 7755,
+    "pfr_id": "WilcCh00"
   },
   {
-    "mfl_id": 15494,
-    "espn_id": 4820589
+    "mfl_id": 15494
   },
   {
     "mfl_id": 15495,
-    "sleeper_id": 7754,
-    "pfr_id": "SpenMa00",
     "gsis_id": "00-0036668",
-    "pff_id": 50306
+    "pff_id": 50306,
+    "sleeper_id": 7754,
+    "pfr_id": "SpenMa00"
   },
   {
     "mfl_id": 15496,
-    "espn_id": 4240485
+    "espn_id": 4240485,
+    "espn_id_new": 4240485
   },
   {
     "mfl_id": 15497,
-    "sleeper_id": 7752,
     "gsis_id": "00-0036939",
-    "pff_id": 61639
+    "pff_id": 61639,
+    "sleeper_id": 7752
   },
   {
     "mfl_id": 15498,
-    "espn_id": 4240255
+    "espn_id": 4240255,
+    "espn_id_new": 4240255
   },
   {
     "mfl_id": 15499,
-    "sleeper_id": 7467,
     "gsis_id": "00-0035859",
+    "sleeper_id": 7467,
+    "yahoo_id": 33112,
     "espn_id": 4045180,
-    "yahoo_id": 33112
+    "espn_id_new": 4045180
   },
   {
     "mfl_id": 15500,
-    "sleeper_id": 7261,
     "gsis_id": "00-0036013",
+    "sleeper_id": 7261,
+    "yahoo_id": 33192,
     "espn_id": 4371989,
-    "yahoo_id": 33192
+    "espn_id_new": 4371989
   },
   {
     "mfl_id": 15501,
-    "sleeper_id": 7890,
     "gsis_id": "00-0036750",
     "pff_id": 41248,
+    "sleeper_id": 7890,
     "yahoo_id": 33770
   },
   {
     "mfl_id": 15502,
-    "sleeper_id": 8051,
-    "pfr_id": "JohnJo06",
     "gsis_id": "00-0036799",
     "pff_id": 88760,
-    "yahoo_id": 33859
+    "sleeper_id": 8051,
+    "yahoo_id": 33859,
+    "pfr_id": "JohnJo06"
   },
   {
     "mfl_id": 15503,
-    "sleeper_id": 8058,
-    "pfr_id": "McCrNa00",
     "gsis_id": "00-0036582",
-    "espn_id": 4820592,
-    "yahoo_id": 33793
+    "sleeper_id": 8058,
+    "yahoo_id": 33793,
+    "pfr_id": "McCrNa00"
   },
   {
     "mfl_id": 15504,
-    "sleeper_id": 7552,
     "gsis_id": "00-0036818",
+    "sleeper_id": 7552,
     "yahoo_id": 33783
   },
   {
     "mfl_id": 15505,
-    "sleeper_id": 7741,
     "gsis_id": "00-0036829",
     "pff_id": 57156,
+    "sleeper_id": 7741,
+    "yahoo_id": 33732,
     "espn_id": 4244732,
-    "yahoo_id": 33732
+    "espn_id_new": 4244732
   },
   {
     "mfl_id": 15506,
-    "sleeper_id": 7992,
-    "pfr_id": "BushMa00",
     "gsis_id": "00-0036519",
     "pff_id": 52008,
-    "yahoo_id": 33804
+    "sleeper_id": 7992,
+    "yahoo_id": 33804,
+    "pfr_id": "BushMa00"
   },
   {
     "mfl_id": 15507,
-    "sleeper_id": 7961,
     "gsis_id": "00-0036757",
+    "sleeper_id": 7961,
     "yahoo_id": 33867
   },
   {
@@ -10340,31 +10487,33 @@
   },
   {
     "mfl_id": 15510,
-    "sleeper_id": 7970,
-    "pfr_id": "WashAr00",
     "gsis_id": "00-0036587",
     "pff_id": 77848,
-    "yahoo_id": 33788
+    "sleeper_id": 7970,
+    "yahoo_id": 33788,
+    "espn_id": 4362492,
+    "pfr_id": "WashAr00",
+    "espn_id_new": 4362492
   },
   {
     "mfl_id": 15511,
-    "sleeper_id": 8042,
     "gsis_id": "00-0036515",
+    "sleeper_id": 8042,
     "yahoo_id": 33700
   },
   {
     "mfl_id": 15512,
-    "sleeper_id": 8029,
-    "pfr_id": "WilsMa05",
     "gsis_id": "00-0036689",
     "pff_id": 56977,
-    "yahoo_id": 33750
+    "sleeper_id": 8029,
+    "yahoo_id": 33750,
+    "pfr_id": "WilsMa05"
   },
   {
     "mfl_id": 15513,
-    "sleeper_id": 7573,
     "gsis_id": "00-0036782",
     "pff_id": 42194,
+    "sleeper_id": 7573,
     "yahoo_id": 33875
   },
   {
@@ -10374,15 +10523,15 @@
   },
   {
     "mfl_id": 15515,
-    "sleeper_id": 7849,
     "gsis_id": "00-0036711",
     "pff_id": 62775,
+    "sleeper_id": 7849,
     "yahoo_id": 33914
   },
   {
     "mfl_id": 15516,
-    "sleeper_id": 8040,
     "gsis_id": "00-0036488",
+    "sleeper_id": 8040,
     "yahoo_id": 33787
   },
   {
@@ -10397,11 +10546,11 @@
   },
   {
     "mfl_id": 15519,
-    "sleeper_id": 7732,
-    "pfr_id": "HillJu01",
     "gsis_id": "00-0036673",
     "pff_id": 28079,
-    "yahoo_id": 33827
+    "sleeper_id": 7732,
+    "yahoo_id": 33827,
+    "pfr_id": "HillJu01"
   },
   {
     "mfl_id": 15520,
@@ -10410,39 +10559,39 @@
   },
   {
     "mfl_id": 15521,
-    "sleeper_id": 7936,
-    "pfr_id": "OgboAm00",
     "gsis_id": "00-0036716",
     "pff_id": 42449,
+    "sleeper_id": 7936,
+    "yahoo_id": 33680,
     "espn_id": 4038432,
-    "yahoo_id": 33680
+    "pfr_id": "OgboAm00",
+    "espn_id_new": 4038432
   },
   {
     "mfl_id": 15522,
-    "sleeper_id": 7901,
     "gsis_id": "00-0036541",
     "pff_id": 45380,
+    "sleeper_id": 7901,
     "yahoo_id": 33658
   },
   {
     "mfl_id": 15523,
-    "sleeper_id": 7617,
     "gsis_id": "00-0036469",
+    "sleeper_id": 7617,
+    "yahoo_id": 33381,
     "espn_id": 3919602,
-    "yahoo_id": 33381
+    "espn_id_new": 3919602
   },
   {
     "mfl_id": 15524,
-    "sleeper_id": 7314,
     "gsis_id": "00-0036168",
-    "espn_id": 3932960,
+    "sleeper_id": 7314,
     "yahoo_id": 33352
   },
   {
     "mfl_id": 15525,
-    "sleeper_id": 7173,
     "gsis_id": "00-0035786",
-    "espn_id": 3919609,
+    "sleeper_id": 7173,
     "yahoo_id": 33063
   },
   {
@@ -10452,35 +10601,36 @@
   },
   {
     "mfl_id": 15527,
-    "sleeper_id": 8004,
     "gsis_id": "00-0036683",
     "pff_id": 56307,
-    "espn_id": 4037559
+    "sleeper_id": 8004,
+    "espn_id": 4037559,
+    "espn_id_new": 4037559
   },
   {
     "mfl_id": 15528,
-    "sleeper_id": 7438,
-    "pfr_id": "WilkKr00",
     "gsis_id": "00-0036183",
     "pff_id": 28729,
-    "espn_id": 3910176,
-    "yahoo_id": 33349
+    "sleeper_id": 7438,
+    "yahoo_id": 33349,
+    "pfr_id": "WilkKr00"
   },
   {
     "mfl_id": 15529,
-    "sleeper_id": 7337,
     "gsis_id": "00-0036080",
     "pff_id": 61812,
+    "sleeper_id": 7337,
+    "yahoo_id": 33299,
     "espn_id": 4245174,
-    "yahoo_id": 33299
+    "espn_id_new": 4245174
   },
   {
     "mfl_id": 15530,
-    "sleeper_id": 7982,
-    "pfr_id": "EtheDo00",
     "gsis_id": "00-0036824",
     "pff_id": 57937,
-    "yahoo_id": 33728
+    "sleeper_id": 7982,
+    "yahoo_id": 33728,
+    "pfr_id": "EtheDo00"
   },
   {
     "mfl_id": 15531,
@@ -10489,67 +10639,68 @@
   },
   {
     "mfl_id": 15532,
-    "sleeper_id": 7412,
     "gsis_id": "00-0036449",
-    "espn_id": 4683485,
+    "sleeper_id": 7412,
     "yahoo_id": 33188
   },
   {
     "mfl_id": 15533,
-    "sleeper_id": 6753,
     "gsis_id": "00-0035715",
     "pff_id": 32342,
+    "sleeper_id": 6753,
+    "yahoo_id": 32630,
     "espn_id": 3925346,
-    "yahoo_id": 32630
+    "espn_id_new": 3925346
   },
   {
     "mfl_id": 15534,
-    "sleeper_id": 7854,
-    "pfr_id": "ForrMi00",
     "gsis_id": "00-0036692",
     "pff_id": 47378,
-    "espn_id": 4040714,
-    "yahoo_id": 33836
+    "sleeper_id": 7854,
+    "yahoo_id": 33836,
+    "pfr_id": "ForrMi00"
   },
   {
     "mfl_id": 15535,
-    "sleeper_id": 7436,
     "gsis_id": "00-0036176",
     "pff_id": 115664,
+    "sleeper_id": 7436,
+    "yahoo_id": 33351,
     "espn_id": 4057082,
-    "yahoo_id": 33351
+    "espn_id_new": 4057082
   },
   {
     "mfl_id": 15536,
-    "sleeper_id": 8003,
     "gsis_id": "00-0036678",
     "pff_id": 42913,
+    "sleeper_id": 8003,
     "yahoo_id": 33878
   },
   {
     "mfl_id": 15537,
-    "sleeper_id": 7987,
-    "pfr_id": "HodgDa01",
     "gsis_id": "00-0036730",
     "pff_id": 82319,
-    "espn_id": 4370351,
-    "yahoo_id": 33846
+    "sleeper_id": 7987,
+    "yahoo_id": 33846,
+    "pfr_id": "HodgDa01"
   },
   {
     "mfl_id": 15538,
-    "sleeper_id": 7957,
-    "pfr_id": "RhatJo00",
     "gsis_id": "00-0036802",
     "pff_id": 57718,
-    "yahoo_id": 33862
+    "sleeper_id": 7957,
+    "yahoo_id": 33862,
+    "espn_id": 4258485,
+    "pfr_id": "RhatJo00",
+    "espn_id_new": 4258485
   },
   {
     "mfl_id": 15539,
-    "sleeper_id": 7915,
-    "pfr_id": "AkerLa00",
     "gsis_id": "00-0036598",
     "pff_id": 42212,
-    "yahoo_id": 33664
+    "sleeper_id": 7915,
+    "yahoo_id": 33664,
+    "pfr_id": "AkerLa00"
   },
   {
     "mfl_id": 15540,
@@ -10558,730 +10709,720 @@
   },
   {
     "mfl_id": 15541,
-    "sleeper_id": 7946,
-    "pfr_id": "StolJa00",
     "gsis_id": "00-0036741",
     "pff_id": 42058,
+    "sleeper_id": 7946,
+    "yahoo_id": 33891,
     "espn_id": 4034862,
-    "yahoo_id": 33891
+    "pfr_id": "StolJa00",
+    "espn_id_new": 4034862
   },
   {
     "mfl_id": 15542,
-    "sleeper_id": 7308,
     "gsis_id": "00-0036083",
     "pff_id": 36271,
-    "espn_id": 3929633,
+    "sleeper_id": 7308,
     "yahoo_id": 33315
   },
   {
     "mfl_id": 15543,
-    "sleeper_id": 7421,
     "gsis_id": "00-0035804",
     "pff_id": 35858,
-    "espn_id": 3908558,
+    "sleeper_id": 7421,
     "yahoo_id": 33197
   },
   {
     "mfl_id": 15544,
-    "sleeper_id": 7439,
     "gsis_id": "00-0036173",
     "pff_id": 47412,
-    "espn_id": 3675550,
+    "sleeper_id": 7439,
     "yahoo_id": 33340
   },
   {
     "mfl_id": 15545,
-    "sleeper_id": 7462,
     "gsis_id": "00-0036136",
+    "sleeper_id": 7462,
     "yahoo_id": 33094
   },
   {
     "mfl_id": 15546,
-    "sleeper_id": 7892,
-    "pfr_id": "ParkAJ00",
     "gsis_id": "00-0036752",
     "pff_id": 55983,
+    "sleeper_id": 7892,
+    "yahoo_id": 33772,
     "espn_id": 4046592,
-    "yahoo_id": 33772
+    "pfr_id": "ParkAJ00",
+    "espn_id_new": 4046592
   },
   {
     "mfl_id": 15547,
-    "sleeper_id": 6254,
     "gsis_id": "00-0035542",
     "pff_id": 56123,
-    "espn_id": 4243831,
+    "sleeper_id": 6254,
     "yahoo_id": 32542
   },
   {
     "mfl_id": 15548,
-    "sleeper_id": 7341,
     "gsis_id": "00-0035928",
     "pff_id": 45507,
-    "espn_id": 4040703,
+    "sleeper_id": 7341,
     "yahoo_id": 33247
   },
   {
     "mfl_id": 15549,
-    "sleeper_id": 7889,
-    "pfr_id": "JacoJe00",
     "gsis_id": "00-0036748",
     "pff_id": 83025,
+    "sleeper_id": 7889,
+    "yahoo_id": 33768,
     "espn_id": 4373578,
-    "yahoo_id": 33768
+    "pfr_id": "JacoJe00",
+    "espn_id_new": 4373578
   },
   {
     "mfl_id": 15555,
-    "sleeper_id": 8024,
-    "pfr_id": "MintAn00",
     "gsis_id": "00-0036725",
     "pff_id": 44299,
-    "espn_id": 4035279,
-    "yahoo_id": 33900
+    "sleeper_id": 8024,
+    "yahoo_id": 33900,
+    "pfr_id": "MintAn00"
   },
   {
     "mfl_id": 15559,
-    "sleeper_id": 7344,
     "gsis_id": "00-0035944",
     "pff_id": 44597,
+    "sleeper_id": 7344,
+    "yahoo_id": 33263,
     "espn_id": 4032481,
-    "yahoo_id": 33263
+    "espn_id_new": 4032481
   },
   {
     "mfl_id": 15560,
-    "sleeper_id": 7362,
     "gsis_id": "00-0035985",
     "pff_id": 50012,
-    "espn_id": 3127587,
+    "sleeper_id": 7362,
     "yahoo_id": 33035
   },
   {
     "mfl_id": 15561,
-    "sleeper_id": 7277,
     "gsis_id": "00-0036068",
+    "sleeper_id": 7277,
     "yahoo_id": 33159
   },
   {
     "mfl_id": 15562,
-    "sleeper_id": 7427,
     "gsis_id": "00-0036059",
     "pff_id": 25705,
-    "espn_id": 3916587,
+    "sleeper_id": 7427,
     "yahoo_id": 33286
   },
   {
     "mfl_id": 15563,
-    "sleeper_id": 6894,
     "gsis_id": "00-0035771",
     "pff_id": 47234,
-    "espn_id": 3923392,
+    "sleeper_id": 6894,
     "yahoo_id": 33171
   },
   {
     "mfl_id": 15564,
-    "sleeper_id": 6662,
     "gsis_id": "00-0035572",
     "pff_id": 48369,
+    "sleeper_id": 6662,
+    "yahoo_id": 32588,
     "espn_id": 3144991,
-    "yahoo_id": 32588
+    "espn_id_new": 3144991
   },
   {
     "mfl_id": 15565,
-    "sleeper_id": 7342,
     "gsis_id": "00-0035933",
     "pff_id": 108840,
+    "sleeper_id": 7342,
+    "yahoo_id": 33252,
     "espn_id": 4033234,
-    "yahoo_id": 33252
+    "espn_id_new": 4033234
   },
   {
     "mfl_id": 15568,
-    "sleeper_id": 5674,
     "gsis_id": "00-0034623",
     "pff_id": 51194,
+    "sleeper_id": 5674,
+    "yahoo_id": 31573,
     "espn_id": 3125287,
-    "yahoo_id": 31573
+    "espn_id_new": 3125287
   },
   {
     "mfl_id": 15573,
-    "sleeper_id": 7254,
     "gsis_id": "00-0036137",
     "pff_id": 76843,
+    "sleeper_id": 7254,
     "yahoo_id": 33106
   },
   {
     "mfl_id": 15578,
-    "sleeper_id": 7930,
-    "pfr_id": "JohnRa02",
     "gsis_id": "00-0036611",
     "pff_id": 56356,
-    "yahoo_id": 33654
+    "sleeper_id": 7930,
+    "yahoo_id": 33654,
+    "pfr_id": "JohnRa02"
   },
   {
     "mfl_id": 15580,
-    "sleeper_id": 7519,
-    "pfr_id": "PatrAa00",
     "gsis_id": "00-0036465",
     "pff_id": 48558,
-    "espn_id": 3908943,
-    "yahoo_id": 33373
+    "sleeper_id": 7519,
+    "yahoo_id": 33373,
+    "pfr_id": "PatrAa00"
   },
   {
     "mfl_id": 15581,
-    "sleeper_id": 7159,
     "gsis_id": "00-0036052",
     "pff_id": 37397,
-    "espn_id": 3926936,
+    "sleeper_id": 7159,
     "yahoo_id": 33279
   },
   {
     "mfl_id": 15585,
-    "sleeper_id": 7283,
     "gsis_id": "00-0035857",
     "pff_id": 87178,
-    "espn_id": 4034530,
+    "sleeper_id": 7283,
     "yahoo_id": 33220
   },
   {
     "mfl_id": 15586,
-    "sleeper_id": 7846,
-    "pfr_id": "JohnCa04",
     "gsis_id": "00-0036704",
     "pff_id": 12488,
+    "sleeper_id": 7846,
+    "yahoo_id": 33907,
     "espn_id": 4051069,
-    "yahoo_id": 33907
+    "pfr_id": "JohnCa04",
+    "espn_id_new": 4051069
   },
   {
     "mfl_id": 15588,
-    "sleeper_id": 7852,
     "gsis_id": "00-0036691",
     "pff_id": 57063,
+    "sleeper_id": 7852,
     "yahoo_id": 33835
   },
   {
     "mfl_id": 15589,
-    "sleeper_id": 7039,
     "gsis_id": "00-0035891",
     "pff_id": 61448,
-    "espn_id": 4241983,
+    "sleeper_id": 7039,
     "yahoo_id": 32948
   },
   {
     "mfl_id": 15592,
-    "sleeper_id": 7019,
     "gsis_id": "00-0036076",
     "pff_id": 36669,
-    "espn_id": 3915186,
+    "sleeper_id": 7019,
     "yahoo_id": 32996
   },
   {
     "mfl_id": 15593,
-    "sleeper_id": 7941,
     "gsis_id": "00-0036774",
     "pff_id": 36101,
+    "sleeper_id": 7941,
     "yahoo_id": 33713
   },
   {
     "mfl_id": 15594,
-    "sleeper_id": 7866,
-    "pfr_id": "FaolAu00",
     "gsis_id": "00-0036767",
     "pff_id": 56800,
-    "yahoo_id": 33719
+    "sleeper_id": 7866,
+    "yahoo_id": 33719,
+    "pfr_id": "FaolAu00"
   },
   {
     "mfl_id": 15595,
-    "sleeper_id": 5534,
     "gsis_id": "00-0034248",
     "pff_id": 49190,
+    "sleeper_id": 5534,
+    "yahoo_id": 31451,
     "espn_id": 3932901,
-    "yahoo_id": 31451
+    "espn_id_new": 3932901
   },
   {
     "mfl_id": 15597,
-    "sleeper_id": 8044,
-    "pfr_id": "DunnIs00",
     "gsis_id": "00-0036506",
-    "pff_id": 52129
+    "pff_id": 52129,
+    "sleeper_id": 8044,
+    "pfr_id": "DunnIs00"
   },
   {
     "mfl_id": 15601,
-    "sleeper_id": 7931,
-    "pfr_id": "MerrFo00",
     "gsis_id": "00-0036780",
-    "yahoo_id": 33679
+    "sleeper_id": 7931,
+    "yahoo_id": 33679,
+    "pfr_id": "MerrFo00"
   },
   {
     "mfl_id": 15604,
-    "sleeper_id": 8041,
-    "pfr_id": "ZylsSh00",
     "gsis_id": "00-0036534",
+    "sleeper_id": 8041,
+    "yahoo_id": 33803,
     "espn_id": 4608362,
-    "yahoo_id": 33803
+    "pfr_id": "ZylsSh00",
+    "espn_id_new": 4608362
   },
   {
     "mfl_id": 15606,
-    "sleeper_id": 8055,
     "gsis_id": "00-0036703",
+    "sleeper_id": 8055,
     "yahoo_id": 33906
   },
   {
     "mfl_id": 15608,
-    "sleeper_id": 6962,
     "gsis_id": "00-0036030",
     "pff_id": 50192,
-    "espn_id": 4039075,
+    "sleeper_id": 6962,
     "yahoo_id": 33104
   },
   {
     "mfl_id": 15612,
-    "sleeper_id": 7844,
     "gsis_id": "00-0036705",
     "pff_id": 24176,
-    "espn_id": 4033855,
+    "sleeper_id": 7844,
     "yahoo_id": 33908
   },
   {
     "mfl_id": 15614,
-    "sleeper_id": 7974,
-    "pfr_id": "McClNi00",
     "gsis_id": "00-0036589",
     "pff_id": 49535,
+    "sleeper_id": 7974,
+    "yahoo_id": 33818,
     "espn_id": 4036169,
-    "yahoo_id": 33818
+    "pfr_id": "McClNi00",
+    "espn_id_new": 4036169
   },
   {
     "mfl_id": 15615,
-    "sleeper_id": 5569,
     "gsis_id": "00-0034311",
     "pff_id": 46441,
-    "espn_id": 3040499,
+    "sleeper_id": 5569,
     "yahoo_id": 31510
   },
   {
     "mfl_id": 15617,
-    "sleeper_id": 7912,
-    "pfr_id": "WillTr07",
     "gsis_id": "00-0036546",
     "pff_id": 76643,
-    "yahoo_id": 33684
+    "sleeper_id": 7912,
+    "yahoo_id": 33684,
+    "pfr_id": "WillTr07"
   },
   {
     "mfl_id": 15618,
-    "sleeper_id": 7853,
-    "pfr_id": "JoneNa01",
     "gsis_id": "00-0036695",
     "pff_id": 44363,
-    "espn_id": 4046716,
-    "yahoo_id": 33833
+    "sleeper_id": 7853,
+    "yahoo_id": 33833,
+    "pfr_id": "JoneNa01"
   },
   {
     "mfl_id": 15620,
-    "sleeper_id": 6529,
     "gsis_id": "00-0035345",
     "pff_id": 47358,
-    "espn_id": 3138744,
+    "sleeper_id": 6529,
     "yahoo_id": 32442
   },
   {
     "mfl_id": 15621,
-    "sleeper_id": 7326,
     "gsis_id": "00-0035927",
     "pff_id": 49589,
-    "espn_id": 3674831,
+    "sleeper_id": 7326,
     "yahoo_id": 32980
   },
   {
     "mfl_id": 15622,
-    "sleeper_id": 8020,
-    "pfr_id": "RobiCu00",
     "gsis_id": "00-0036728",
-    "yahoo_id": 33902
+    "sleeper_id": 8020,
+    "yahoo_id": 33902,
+    "espn_id": 4044448,
+    "pfr_id": "RobiCu00",
+    "espn_id_new": 4044448
   },
   {
     "mfl_id": 15626,
-    "sleeper_id": 7891,
-    "pfr_id": "WrigBr01",
     "gsis_id": "00-0036754",
     "pff_id": 60994,
+    "sleeper_id": 7891,
+    "yahoo_id": 33774,
     "espn_id": 4242392,
-    "yahoo_id": 33774
+    "pfr_id": "WrigBr01",
+    "espn_id_new": 4242392
   },
   {
     "mfl_id": 15627,
-    "sleeper_id": 6423,
     "gsis_id": "00-0035423",
     "pff_id": 48922,
-    "espn_id": 3133368,
+    "sleeper_id": 6423,
     "yahoo_id": 32198
   },
   {
     "mfl_id": 15629,
-    "sleeper_id": 8037,
-    "pfr_id": "BronJo01",
     "gsis_id": "00-0036537",
     "pff_id": 36668,
-    "espn_id": 3923400,
-    "yahoo_id": 33687
+    "sleeper_id": 8037,
+    "yahoo_id": 33687,
+    "pfr_id": "BronJo01"
   },
   {
     "mfl_id": 15632,
-    "sleeper_id": 8084,
-    "pfr_id": "GilbMa02",
     "gsis_id": "00-0036530",
     "pff_id": 26144,
-    "yahoo_id": 33659
+    "sleeper_id": 8084,
+    "yahoo_id": 33659,
+    "pfr_id": "GilbMa02"
   },
   {
     "mfl_id": 15633,
-    "sleeper_id": 6902,
     "gsis_id": "00-0036010",
     "pff_id": 51071,
-    "espn_id": 4046680,
+    "sleeper_id": 6902,
     "yahoo_id": 33189
   },
   {
     "mfl_id": 15635,
-    "sleeper_id": 7339,
     "gsis_id": "00-0035935",
     "pff_id": 47918,
-    "espn_id": 3910287,
+    "sleeper_id": 7339,
     "yahoo_id": 33254
   },
   {
     "mfl_id": 15636,
-    "sleeper_id": 8059,
-    "pfr_id": "WadeBa00",
     "gsis_id": "00-0036586",
-    "yahoo_id": 33816
+    "sleeper_id": 8059,
+    "yahoo_id": 33816,
+    "pfr_id": "WadeBa00"
   },
   {
     "mfl_id": 15637,
-    "sleeper_id": 7880,
-    "pfr_id": "HeflJa00",
     "gsis_id": "00-0036788",
     "pff_id": 44570,
-    "yahoo_id": 33755
+    "sleeper_id": 7880,
+    "yahoo_id": 33755,
+    "pfr_id": "HeflJa00"
   },
   {
     "mfl_id": 15640,
-    "sleeper_id": 7877,
-    "pfr_id": "RashHa00",
     "gsis_id": "00-0036517",
-    "yahoo_id": 33702
+    "sleeper_id": 7877,
+    "yahoo_id": 33702,
+    "pfr_id": "RashHa00"
   },
   {
     "mfl_id": 15642,
+    "gsis_id": "00-0036688",
     "sleeper_id": 8031,
-    "pfr_id": "ThomKi00",
-    "gsis_id": "00-0036688"
+    "pfr_id": "ThomKi00"
   },
   {
     "mfl_id": 15643,
-    "sleeper_id": 7234,
     "gsis_id": "00-0035883",
-    "espn_id": 4036055,
+    "sleeper_id": 7234,
     "yahoo_id": 32944
   },
   {
     "mfl_id": 15644,
-    "sleeper_id": 6687,
     "gsis_id": "00-0035609",
     "pff_id": 49103,
-    "espn_id": 3144988,
+    "sleeper_id": 6687,
     "yahoo_id": 32603
   },
   {
     "mfl_id": 15647,
-    "sleeper_id": 8054,
-    "pfr_id": "ArchDa01",
     "gsis_id": "00-0036700",
-    "yahoo_id": 33903
+    "sleeper_id": 8054,
+    "yahoo_id": 33903,
+    "pfr_id": "ArchDa01"
   },
   {
     "mfl_id": 15648,
-    "sleeper_id": 7160,
     "gsis_id": "00-0036205",
-    "espn_id": 4257195,
+    "sleeper_id": 7160,
     "yahoo_id": 33176
   },
   {
     "mfl_id": 15650,
-    "sleeper_id": 8025,
     "gsis_id": "00-0036727",
     "pff_id": 35639,
+    "sleeper_id": 8025,
+    "yahoo_id": 33901,
     "espn_id": 3929914,
-    "yahoo_id": 33901
+    "espn_id_new": 3929914
   },
   {
     "mfl_id": 15651,
-    "sleeper_id": 6974,
     "gsis_id": "00-0035880",
     "pff_id": 49432,
+    "sleeper_id": 6974,
     "yahoo_id": 32958
   },
   {
     "mfl_id": 15653,
-    "sleeper_id": 7327,
     "gsis_id": "00-0035910",
     "pff_id": 36851,
-    "espn_id": 3916917,
+    "sleeper_id": 7327,
     "yahoo_id": 32991
   },
   {
     "mfl_id": 15654,
-    "sleeper_id": 7433,
     "gsis_id": "00-0036056",
     "pff_id": 34321,
-    "espn_id": 3912347,
+    "sleeper_id": 7433,
     "yahoo_id": 33283
   },
   {
     "mfl_id": 15655,
-    "sleeper_id": 7907,
-    "gsis_id": "00-0036792"
+    "gsis_id": "00-0036792",
+    "sleeper_id": 7907
   },
   {
     "mfl_id": 15656,
-    "sleeper_id": 7933,
     "gsis_id": "00-0036714",
+    "sleeper_id": 7933,
     "yahoo_id": 33677
   },
   {
     "mfl_id": 15657,
-    "sleeper_id": 7444,
     "gsis_id": "00-0036180",
     "pff_id": 28488,
-    "espn_id": 4038840,
+    "sleeper_id": 7444,
     "yahoo_id": 33346
   },
   {
     "mfl_id": 15661,
-    "sleeper_id": 7863,
     "gsis_id": "00-0036768",
     "pff_id": 143793,
+    "sleeper_id": 7863,
     "yahoo_id": 33707
   },
   {
     "mfl_id": 15662,
-    "sleeper_id": 5626,
     "gsis_id": "00-0034602",
     "pff_id": 48387,
-    "espn_id": 3060151,
+    "sleeper_id": 5626,
     "yahoo_id": 31666
   },
   {
     "mfl_id": 15666,
-    "sleeper_id": 7520,
     "gsis_id": "00-0036462",
-    "pff_id": 44443
+    "pff_id": 44443,
+    "sleeper_id": 7520
   },
   {
     "mfl_id": 15668,
-    "sleeper_id": 7215,
     "gsis_id": "00-0035821",
+    "sleeper_id": 7215,
+    "yahoo_id": 32942,
     "espn_id": 3125280,
-    "yahoo_id": 32942
+    "espn_id_new": 3125280
   },
   {
     "mfl_id": 15671,
-    "sleeper_id": 8076,
-    "pfr_id": "BandMi00",
     "gsis_id": "00-0036959",
-    "yahoo_id": 33928
+    "sleeper_id": 8076,
+    "yahoo_id": 33928,
+    "pfr_id": "BandMi00"
   },
   {
     "mfl_id": 15672,
-    "sleeper_id": 7499,
     "gsis_id": "00-0036453",
     "pff_id": 14811,
-    "espn_id": 2575891,
+    "sleeper_id": 7499,
     "yahoo_id": 33364
   },
   {
     "mfl_id": 15673,
-    "sleeper_id": 7876,
-    "pfr_id": "DwumMi00",
     "gsis_id": "00-0036507",
     "pff_id": 27376,
-    "yahoo_id": 33695
+    "sleeper_id": 7876,
+    "yahoo_id": 33695,
+    "pfr_id": "DwumMi00"
   },
   {
     "mfl_id": 15674,
-    "sleeper_id": 7456,
-    "pfr_id": "PotoBe00",
     "gsis_id": "00-0036050",
     "pff_id": 50195,
-    "espn_id": 3886826,
-    "yahoo_id": 33277
+    "sleeper_id": 7456,
+    "yahoo_id": 33277,
+    "pfr_id": "PotoBe00"
   },
   {
     "mfl_id": 15675,
-    "sleeper_id": 6986,
     "gsis_id": "00-0036127",
     "pff_id": 42930,
+    "sleeper_id": 6986,
     "yahoo_id": 33004
   },
   {
     "mfl_id": 15676,
-    "sleeper_id": 8000,
-    "pfr_id": "AndeZa02",
     "gsis_id": "00-0036677",
     "pff_id": 34622,
-    "yahoo_id": 33877
+    "sleeper_id": 8000,
+    "yahoo_id": 33877,
+    "pfr_id": "AndeZa02"
   },
   {
     "mfl_id": 15677,
-    "sleeper_id": 7903,
     "gsis_id": "00-0036696",
+    "sleeper_id": 7903,
     "yahoo_id": 33837
   },
   {
     "mfl_id": 15678,
-    "sleeper_id": 6602,
     "gsis_id": "00-0035518",
     "pff_id": 48665,
-    "espn_id": 3115492,
+    "sleeper_id": 6602,
     "yahoo_id": 32424
   },
   {
     "mfl_id": 15680,
-    "sleeper_id": 7942,
-    "pfr_id": "CoylTy00",
     "gsis_id": "00-0036764",
-    "pff_id": 42631
+    "pff_id": 42631,
+    "sleeper_id": 7942,
+    "pfr_id": "CoylTy00"
   },
   {
     "mfl_id": 15681,
-    "sleeper_id": 7921,
-    "pfr_id": "ElliCh00",
     "gsis_id": "00-0036813",
-    "yahoo_id": 33778
+    "sleeper_id": 7921,
+    "yahoo_id": 33778,
+    "espn_id": 4245273,
+    "pfr_id": "ElliCh00",
+    "espn_id_new": 4245273
   },
   {
     "mfl_id": 15682,
-    "sleeper_id": 7895,
-    "pfr_id": "McCaMa02",
     "gsis_id": "00-0036724",
-    "pff_id": 79072
+    "pff_id": 79072,
+    "sleeper_id": 7895,
+    "pfr_id": "McCaMa02"
   },
   {
     "mfl_id": 15683,
-    "sleeper_id": 8068,
-    "pfr_id": "SaunCJ00",
     "gsis_id": "00-0036910",
-    "yahoo_id": 33921
+    "sleeper_id": 8068,
+    "yahoo_id": 33921,
+    "pfr_id": "SaunCJ00"
   },
   {
     "mfl_id": 15684,
-    "sleeper_id": 6476,
     "gsis_id": "00-0034966",
     "pff_id": 27732,
-    "espn_id": 3139389,
+    "sleeper_id": 6476,
     "yahoo_id": 32223
   },
   {
     "mfl_id": 15691,
-    "sleeper_id": 8164,
-    "pfr_id": "CorrMa00",
     "gsis_id": "00-0038132",
+    "sleeper_id": 8164,
+    "yahoo_id": 34050,
     "espn_id": 4362874,
-    "yahoo_id": 34050
+    "pfr_id": "CorrMa00",
+    "espn_id_new": 4362874
   },
   {
     "mfl_id": 15692,
-    "sleeper_id": 8160,
-    "pfr_id": "PickKe00",
     "gsis_id": "00-0038102",
+    "sleeper_id": 8160,
+    "yahoo_id": 33975,
     "espn_id": 4240703,
-    "yahoo_id": 33975
+    "pfr_id": "PickKe00",
+    "espn_id_new": 4240703
   },
   {
     "mfl_id": 15693,
-    "sleeper_id": 8162,
-    "pfr_id": "HoweSa00",
     "gsis_id": "00-0037077",
+    "sleeper_id": 8162,
+    "yahoo_id": 34100,
     "espn_id": 4426875,
-    "yahoo_id": 34100
+    "pfr_id": "HoweSa00",
+    "espn_id_new": 4426875
   },
   {
     "mfl_id": 15694,
-    "sleeper_id": 8161,
-    "pfr_id": "WillMa12",
     "gsis_id": "00-0038128",
+    "sleeper_id": 8161,
+    "yahoo_id": 34042,
     "espn_id": 4242512,
-    "yahoo_id": 34042
+    "pfr_id": "WillMa12",
+    "espn_id_new": 4242512
   },
   {
     "mfl_id": 15695,
-    "sleeper_id": 8158,
     "gsis_id": "00-0037139",
+    "sleeper_id": 8158,
     "yahoo_id": 34385
   },
   {
     "mfl_id": 15696,
-    "sleeper_id": 8157,
-    "pfr_id": "ZappBa00",
     "gsis_id": "00-0038108",
-    "espn_id": 4250360,
-    "yahoo_id": 34093
+    "sleeper_id": 8157,
+    "yahoo_id": 34093,
+    "pfr_id": "ZappBa00"
   },
   {
     "mfl_id": 15697,
-    "sleeper_id": 8159,
-    "pfr_id": "RiddDe00",
     "gsis_id": "00-0038122",
-    "espn_id": 4239086,
-    "yahoo_id": 34030
+    "sleeper_id": 8159,
+    "yahoo_id": 34030,
+    "pfr_id": "RiddDe00"
   },
   {
     "mfl_id": 15698,
-    "sleeper_id": 8183,
-    "pfr_id": "PurdBr00",
     "gsis_id": "00-0037834",
+    "sleeper_id": 8183,
+    "yahoo_id": 34218,
     "espn_id": 4361741,
-    "yahoo_id": 34218
+    "pfr_id": "PurdBr00",
+    "espn_id_new": 4361741
   },
   {
     "mfl_id": 15699,
-    "sleeper_id": 8206,
-    "pfr_id": "ThomSk00",
     "gsis_id": "00-0037327",
-    "yahoo_id": 34203
+    "sleeper_id": 8206,
+    "yahoo_id": 34203,
+    "espn_id": 4036419,
+    "pfr_id": "ThomSk00",
+    "espn_id_new": 4036419
   },
   {
     "mfl_id": 15701,
-    "sleeper_id": 8431,
     "gsis_id": "00-0037507",
+    "sleeper_id": 8431,
     "yahoo_id": 34545
   },
   {
     "mfl_id": 15702,
-    "sleeper_id": 9230,
-    "pfr_id": "McKeTa01",
     "gsis_id": "00-0038400",
-    "yahoo_id": 40220
+    "sleeper_id": 9230,
+    "yahoo_id": 40220,
+    "espn_id": 4685201,
+    "pfr_id": "McKeTa01",
+    "espn_id_new": 4685201
   },
   {
     "mfl_id": 15703,
-    "sleeper_id": 8915,
     "gsis_id": "00-0038137",
+    "sleeper_id": 8915,
     "yahoo_id": 34707
   },
   {
     "mfl_id": 15704,
-    "sleeper_id": 8201,
     "gsis_id": "00-0037390",
+    "sleeper_id": 8201,
     "yahoo_id": 34481
   },
   {
     "mfl_id": 15705,
-    "sleeper_id": 8199,
     "gsis_id": "00-0037201",
+    "sleeper_id": 8199,
     "yahoo_id": 34425
   },
   {
     "mfl_id": 15706,
-    "sleeper_id": 8212,
     "gsis_id": "00-0037209",
+    "sleeper_id": 8212,
     "yahoo_id": 34433
   },
   {
@@ -11291,115 +11432,123 @@
   },
   {
     "mfl_id": 15708,
-    "sleeper_id": 8155,
-    "pfr_id": "HallBr03",
     "gsis_id": "00-0038120",
+    "sleeper_id": 8155,
+    "yahoo_id": 33991,
     "espn_id": 4427366,
-    "yahoo_id": 33991
+    "pfr_id": "HallBr03",
+    "espn_id_new": 4427366
   },
   {
     "mfl_id": 15709,
-    "sleeper_id": 8153,
-    "pfr_id": "SpilIs00",
     "gsis_id": "00-0038045",
-    "espn_id": 4426891,
-    "yahoo_id": 34079
+    "sleeper_id": 8153,
+    "yahoo_id": 34079,
+    "pfr_id": "SpilIs00"
   },
   {
     "mfl_id": 15710,
-    "sleeper_id": 8150,
-    "pfr_id": "WillKy02",
     "gsis_id": "00-0037840",
+    "sleeper_id": 8150,
+    "yahoo_id": 34120,
     "espn_id": 4430737,
-    "yahoo_id": 34120
+    "pfr_id": "WillKy02",
+    "espn_id_new": 4430737
   },
   {
     "mfl_id": 15711,
-    "sleeper_id": 8151,
-    "pfr_id": "WalkKe00",
     "gsis_id": "00-0038134",
+    "sleeper_id": 8151,
+    "yahoo_id": 33996,
     "espn_id": 4567048,
-    "yahoo_id": 33996
+    "pfr_id": "WalkKe00",
+    "espn_id_new": 4567048
   },
   {
     "mfl_id": 15712,
-    "sleeper_id": 8132,
-    "pfr_id": "AllgTy00",
     "gsis_id": "00-0037263",
+    "sleeper_id": 8132,
+    "yahoo_id": 34107,
     "espn_id": 4373626,
-    "yahoo_id": 34107
+    "pfr_id": "AllgTy00",
+    "espn_id_new": 4373626
   },
   {
     "mfl_id": 15713,
-    "sleeper_id": 8143,
-    "pfr_id": "FordJe00",
     "gsis_id": "00-0037267",
+    "sleeper_id": 8143,
+    "yahoo_id": 34112,
     "espn_id": 4372019,
-    "yahoo_id": 34112
+    "pfr_id": "FordJe00",
+    "espn_id_new": 4372019
   },
   {
     "mfl_id": 15714,
-    "sleeper_id": 8139,
-    "pfr_id": "WhitZa01",
     "gsis_id": "00-0038040",
+    "sleeper_id": 8139,
+    "yahoo_id": 34078,
     "espn_id": 4361777,
-    "yahoo_id": 34078
+    "pfr_id": "WhitZa01",
+    "espn_id_new": 4361777
   },
   {
     "mfl_id": 15715,
-    "sleeper_id": 8138,
-    "pfr_id": "CookJa01",
     "gsis_id": "00-0037248",
+    "sleeper_id": 8138,
+    "yahoo_id": 34019,
     "espn_id": 4379399,
-    "yahoo_id": 34019
+    "pfr_id": "CookJa01",
+    "espn_id_new": 4379399
   },
   {
     "mfl_id": 15716,
-    "sleeper_id": 8154,
-    "pfr_id": "RobiBr01",
     "gsis_id": "00-0037746",
+    "sleeper_id": 8154,
+    "yahoo_id": 34054,
     "espn_id": 4241474,
-    "yahoo_id": 34054
+    "pfr_id": "RobiBr01",
+    "espn_id_new": 4241474
   },
   {
     "mfl_id": 15717,
-    "sleeper_id": 8129,
-    "pfr_id": "PierDa01",
     "gsis_id": "00-0037258",
+    "sleeper_id": 8129,
+    "yahoo_id": 34063,
     "espn_id": 4360238,
-    "yahoo_id": 34063
+    "pfr_id": "PierDa01",
+    "espn_id_new": 4360238
   },
   {
     "mfl_id": 15718,
-    "sleeper_id": 8208,
-    "pfr_id": "BadiTy00",
     "gsis_id": "00-0037085",
-    "espn_id": 4362748,
-    "yahoo_id": 34152
+    "sleeper_id": 8208,
+    "yahoo_id": 34152,
+    "pfr_id": "BadiTy00"
   },
   {
     "mfl_id": 15719,
-    "sleeper_id": 8174,
-    "pfr_id": "HarrKe01",
     "gsis_id": "00-0037286",
-    "espn_id": 4570674,
-    "yahoo_id": 34139
+    "sleeper_id": 8174,
+    "yahoo_id": 34139,
+    "pfr_id": "HarrKe01"
   },
   {
     "mfl_id": 15720,
-    "sleeper_id": 8123,
-    "pfr_id": "HaskHa00",
     "gsis_id": "00-0037617",
+    "sleeper_id": 8123,
+    "yahoo_id": 34087,
     "espn_id": 4372071,
-    "yahoo_id": 34087
+    "pfr_id": "HaskHa00",
+    "espn_id_new": 4372071
   },
   {
     "mfl_id": 15721,
-    "sleeper_id": 8136,
-    "pfr_id": "WhitRa01",
     "gsis_id": "00-0037256",
+    "sleeper_id": 8136,
+    "yahoo_id": 34047,
     "espn_id": 4697815,
-    "yahoo_id": 34047
+    "pfr_id": "WhitRa01",
+    "espn_id_new": 4697815
   },
   {
     "mfl_id": 15722,
@@ -11408,101 +11557,112 @@
   },
   {
     "mfl_id": 15723,
-    "sleeper_id": 8230,
-    "pfr_id": "ChanTy01",
     "gsis_id": "00-0037276",
+    "sleeper_id": 8230,
+    "yahoo_id": 34125,
     "espn_id": 4242431,
-    "yahoo_id": 34125
+    "pfr_id": "ChanTy01",
+    "espn_id_new": 4242431
   },
   {
     "mfl_id": 15724,
-    "sleeper_id": 8217,
     "gsis_id": "00-0037466",
+    "sleeper_id": 8217,
     "yahoo_id": 34628
   },
   {
     "mfl_id": 15725,
-    "sleeper_id": 8179,
-    "pfr_id": "ConnSn00",
     "gsis_id": "00-0037265",
+    "sleeper_id": 8179,
+    "yahoo_id": 34110,
     "espn_id": 4567246,
-    "yahoo_id": 34110
+    "pfr_id": "ConnSn00",
+    "espn_id_new": 4567246
   },
   {
     "mfl_id": 15726,
-    "sleeper_id": 8195,
-    "pfr_id": "RiveRo01",
     "gsis_id": "00-0037557",
-    "yahoo_id": 34310
+    "sleeper_id": 8195,
+    "yahoo_id": 34310,
+    "espn_id": 4243003,
+    "pfr_id": "RiveRo01",
+    "espn_id_new": 4243003
   },
   {
     "mfl_id": 15727,
-    "sleeper_id": 8122,
-    "pfr_id": "KnigZo00",
     "gsis_id": "00-0037157",
+    "sleeper_id": 8122,
+    "yahoo_id": 34357,
     "espn_id": 4427728,
-    "yahoo_id": 34357
+    "pfr_id": "KnigZo00",
+    "espn_id_new": 4427728
   },
   {
     "mfl_id": 15728,
-    "sleeper_id": 8190,
     "gsis_id": "00-0037546",
-    "espn_id": 4241224,
+    "sleeper_id": 8190,
     "yahoo_id": 34660
   },
   {
     "mfl_id": 15729,
-    "sleeper_id": 8194,
     "gsis_id": "00-0037410",
-    "yahoo_id": 34665
+    "sleeper_id": 8194,
+    "yahoo_id": 34665,
+    "espn_id": 4372519,
+    "espn_id_new": 4372519
   },
   {
     "mfl_id": 15730,
-    "sleeper_id": 8207,
     "gsis_id": "00-0037120",
-    "yahoo_id": 34261
+    "sleeper_id": 8207,
+    "yahoo_id": 34261,
+    "espn_id": 4429676,
+    "espn_id_new": 4429676
   },
   {
     "mfl_id": 15731,
-    "sleeper_id": 8149,
     "gsis_id": "00-0037111",
+    "sleeper_id": 8149,
     "yahoo_id": 34373
   },
   {
     "mfl_id": 15733,
-    "sleeper_id": 8116,
-    "pfr_id": "StroPi00",
     "gsis_id": "00-0038098",
+    "sleeper_id": 8116,
+    "yahoo_id": 34083,
     "espn_id": 4249836,
-    "yahoo_id": 34083
+    "pfr_id": "StroPi00",
+    "espn_id_new": 4249836
   },
   {
     "mfl_id": 15734,
-    "sleeper_id": 8221,
-    "pfr_id": "IngrKe01",
     "gsis_id": "00-0037299",
+    "sleeper_id": 8221,
+    "yahoo_id": 34157,
     "espn_id": 4362087,
-    "yahoo_id": 34157
+    "pfr_id": "IngrKe01",
+    "espn_id_new": 4362087
   },
   {
     "mfl_id": 15735,
-    "sleeper_id": 8218,
     "gsis_id": "00-0037389",
+    "sleeper_id": 8218,
     "yahoo_id": 34479
   },
   {
     "mfl_id": 15736,
-    "sleeper_id": 8152,
     "gsis_id": "00-0037131",
+    "sleeper_id": 8152,
     "yahoo_id": 34377
   },
   {
     "mfl_id": 15738,
-    "sleeper_id": 8800,
-    "pfr_id": "DaviMa02",
     "gsis_id": "00-0037563",
+    "sleeper_id": 8800,
+    "yahoo_id": 34610,
     "espn_id": 4240603,
-    "yahoo_id": 34610
+    "pfr_id": "DaviMa02",
+    "espn_id_new": 4240603
   },
   {
     "mfl_id": 15739,
@@ -11511,28 +11671,29 @@
   },
   {
     "mfl_id": 15740,
-    "sleeper_id": 8239,
     "gsis_id": "00-0037182",
+    "sleeper_id": 8239,
     "yahoo_id": 34402
   },
   {
     "mfl_id": 15742,
-    "sleeper_id": 8228,
-    "pfr_id": "WarrJa01",
     "gsis_id": "00-0037228",
+    "sleeper_id": 8228,
+    "yahoo_id": 34447,
     "espn_id": 4569987,
-    "yahoo_id": 34447
+    "pfr_id": "WarrJa01",
+    "espn_id_new": 4569987
   },
   {
     "mfl_id": 15743,
-    "sleeper_id": 8220,
     "gsis_id": "00-0037509",
+    "sleeper_id": 8220,
     "yahoo_id": 34551
   },
   {
     "mfl_id": 15744,
-    "sleeper_id": 8184,
     "gsis_id": "00-0037400",
+    "sleeper_id": 8184,
     "yahoo_id": 34521
   },
   {
@@ -11542,11 +11703,10 @@
   },
   {
     "mfl_id": 15746,
-    "sleeper_id": 8211,
-    "pfr_id": "DaviTy03",
     "gsis_id": "00-0037827",
-    "espn_id": 4426475,
-    "yahoo_id": 34049
+    "sleeper_id": 8211,
+    "yahoo_id": 34049,
+    "pfr_id": "DaviTy03"
   },
   {
     "mfl_id": 15747,
@@ -11554,19 +11714,21 @@
   },
   {
     "mfl_id": 15748,
-    "sleeper_id": 8189,
-    "pfr_id": "EbneTr00",
     "gsis_id": "00-0037087",
+    "sleeper_id": 8189,
+    "yahoo_id": 34159,
     "espn_id": 4259169,
-    "yahoo_id": 34159
+    "pfr_id": "EbneTr00",
+    "espn_id_new": 4259169
   },
   {
     "mfl_id": 15749,
-    "sleeper_id": 8205,
-    "pfr_id": "PachIs00",
     "gsis_id": "00-0037197",
+    "sleeper_id": 8205,
+    "yahoo_id": 34207,
     "espn_id": 4361529,
-    "yahoo_id": 34207
+    "pfr_id": "PachIs00",
+    "espn_id_new": 4361529
   },
   {
     "mfl_id": 15750,
@@ -11575,140 +11737,155 @@
   },
   {
     "mfl_id": 15751,
-    "sleeper_id": 8112,
-    "pfr_id": "LondDr00",
     "gsis_id": "00-0037238",
+    "sleeper_id": 8112,
+    "yahoo_id": 33963,
     "espn_id": 4426502,
-    "yahoo_id": 33963
+    "pfr_id": "LondDr00",
+    "espn_id_new": 4426502
   },
   {
     "mfl_id": 15752,
-    "sleeper_id": 8135,
-    "pfr_id": "BurkTr00",
     "gsis_id": "00-0037742",
+    "sleeper_id": 8135,
+    "yahoo_id": 33973,
     "espn_id": 4567156,
-    "yahoo_id": 33973
+    "pfr_id": "BurkTr00",
+    "espn_id_new": 4567156
   },
   {
     "mfl_id": 15753,
-    "sleeper_id": 8146,
-    "pfr_id": "WilsGa00",
     "gsis_id": "00-0037740",
+    "sleeper_id": 8146,
+    "yahoo_id": 33965,
     "espn_id": 4569618,
-    "yahoo_id": 33965
+    "pfr_id": "WilsGa00",
+    "espn_id_new": 4569618
   },
   {
     "mfl_id": 15754,
-    "sleeper_id": 8144,
-    "pfr_id": "OlavCh00",
     "gsis_id": "00-0037239",
+    "sleeper_id": 8144,
+    "yahoo_id": 33966,
     "espn_id": 4361370,
-    "yahoo_id": 33966
+    "pfr_id": "OlavCh00",
+    "espn_id_new": 4361370
   },
   {
     "mfl_id": 15755,
-    "sleeper_id": 8119,
-    "pfr_id": "DotsJa00",
     "gsis_id": "00-0037741",
+    "sleeper_id": 8119,
+    "yahoo_id": 33971,
     "espn_id": 4361409,
-    "yahoo_id": 33971
+    "pfr_id": "DotsJa00",
+    "espn_id_new": 4361409
   },
   {
     "mfl_id": 15756,
-    "sleeper_id": 8148,
-    "pfr_id": "WillJa11",
     "gsis_id": "00-0037240",
+    "sleeper_id": 8148,
+    "yahoo_id": 33967,
     "espn_id": 4426388,
-    "yahoo_id": 33967
+    "pfr_id": "WillJa11",
+    "espn_id_new": 4426388
   },
   {
     "mfl_id": 15757,
-    "sleeper_id": 8126,
-    "pfr_id": "RobiWa01",
     "gsis_id": "00-0038117",
+    "sleeper_id": 8126,
+    "yahoo_id": 33998,
     "espn_id": 4569587,
-    "yahoo_id": 33998
+    "pfr_id": "RobiWa01",
+    "espn_id_new": 4569587
   },
   {
     "mfl_id": 15758,
-    "sleeper_id": 8118,
-    "pfr_id": "BellDa02",
     "gsis_id": "00-0037257",
+    "sleeper_id": 8118,
+    "yahoo_id": 34055,
     "espn_id": 4570409,
-    "yahoo_id": 34055
+    "pfr_id": "BellDa02",
+    "espn_id_new": 4570409
   },
   {
     "mfl_id": 15759,
-    "sleeper_id": 8147,
-    "pfr_id": "MetcJo00",
     "gsis_id": "00-0037614",
+    "sleeper_id": 8147,
+    "yahoo_id": 33999,
     "espn_id": 4567096,
-    "yahoo_id": 33999
+    "pfr_id": "MetcJo00",
+    "espn_id_new": 4567096
   },
   {
     "mfl_id": 15760,
-    "sleeper_id": 8191,
     "gsis_id": "00-0037173",
+    "sleeper_id": 8191,
     "yahoo_id": 34442
   },
   {
     "mfl_id": 15761,
-    "sleeper_id": 8134,
-    "pfr_id": "ShakKh00",
     "gsis_id": "00-0037261",
+    "sleeper_id": 8134,
+    "yahoo_id": 34104,
     "espn_id": 4373678,
-    "yahoo_id": 34104
+    "pfr_id": "ShakKh00",
+    "espn_id_new": 4373678
   },
   {
     "mfl_id": 15762,
-    "sleeper_id": 8137,
-    "pfr_id": "PickGe00",
     "gsis_id": "00-0037247",
+    "sleeper_id": 8137,
+    "yahoo_id": 34007,
     "espn_id": 4426354,
-    "yahoo_id": 34007
+    "pfr_id": "PickGe00",
+    "espn_id_new": 4426354
   },
   {
     "mfl_id": 15763,
-    "sleeper_id": 8140,
-    "pfr_id": "RossJu00",
     "gsis_id": "00-0037216",
+    "sleeper_id": 8140,
+    "yahoo_id": 34440,
     "espn_id": 4360306,
-    "yahoo_id": 34440
+    "pfr_id": "RossJu00",
+    "espn_id_new": 4360306
   },
   {
     "mfl_id": 15765,
-    "sleeper_id": 8200,
     "gsis_id": "00-0037231",
+    "sleeper_id": 8200,
     "yahoo_id": 34242
   },
   {
     "mfl_id": 15766,
-    "sleeper_id": 8168,
-    "pfr_id": "MoorSk01",
     "gsis_id": "00-0038090",
+    "sleeper_id": 8168,
+    "yahoo_id": 34009,
     "espn_id": 4430191,
-    "yahoo_id": 34009
+    "pfr_id": "MoorSk01",
+    "espn_id_new": 4430191
   },
   {
     "mfl_id": 15767,
-    "sleeper_id": 8223,
-    "pfr_id": "JoneVe00",
     "gsis_id": "00-0037745",
+    "sleeper_id": 8223,
+    "yahoo_id": 34027,
     "espn_id": 4035693,
-    "yahoo_id": 34027
+    "pfr_id": "JoneVe00",
+    "espn_id_new": 4035693
   },
   {
     "mfl_id": 15768,
-    "sleeper_id": 8142,
-    "pfr_id": "PierAl00",
     "gsis_id": "00-0037664",
+    "sleeper_id": 8142,
+    "yahoo_id": 34008,
     "espn_id": 4360078,
-    "yahoo_id": 34008
+    "pfr_id": "PierAl00",
+    "espn_id_new": 4360078
   },
   {
     "mfl_id": 15769,
-    "sleeper_id": 8175,
-    "gsis_id": "00-0037604"
+    "gsis_id": "00-0037604",
+    "sleeper_id": 8175
   },
   {
     "mfl_id": 15770,
@@ -11717,94 +11894,105 @@
   },
   {
     "mfl_id": 15771,
-    "sleeper_id": 8250,
-    "pfr_id": "MartTa00",
     "gsis_id": "00-0037524",
-    "yahoo_id": 34319
+    "sleeper_id": 8250,
+    "yahoo_id": 34319,
+    "espn_id": 4245144,
+    "pfr_id": "MartTa00",
+    "espn_id_new": 4245144
   },
   {
     "mfl_id": 15772,
-    "sleeper_id": 8414,
-    "pfr_id": "CoveBr00",
     "gsis_id": "00-0037132",
+    "sleeper_id": 8414,
+    "yahoo_id": 34378,
     "espn_id": 3926231,
-    "yahoo_id": 34378
+    "pfr_id": "CoveBr00",
+    "espn_id_new": 3926231
   },
   {
     "mfl_id": 15773,
-    "sleeper_id": 8209,
     "gsis_id": "00-0037183",
+    "sleeper_id": 8209,
     "yahoo_id": 34403
   },
   {
     "mfl_id": 15774,
-    "sleeper_id": 8166,
     "gsis_id": "00-0037564",
+    "sleeper_id": 8166,
     "yahoo_id": 34608
   },
   {
     "mfl_id": 15775,
-    "sleeper_id": 8178,
-    "pfr_id": "SandBr00",
     "gsis_id": "00-0037355",
-    "yahoo_id": 34534
+    "sleeper_id": 8178,
+    "yahoo_id": 34534,
+    "espn_id": 4259908,
+    "pfr_id": "SandBr00",
+    "espn_id_new": 4259908
   },
   {
     "mfl_id": 15776,
-    "sleeper_id": 8198,
     "gsis_id": "00-0037366",
+    "sleeper_id": 8198,
     "yahoo_id": 34229
   },
   {
     "mfl_id": 15777,
-    "sleeper_id": 8125,
-    "pfr_id": "AustCa00",
     "gsis_id": "00-0037837",
+    "sleeper_id": 8125,
+    "yahoo_id": 34094,
     "espn_id": 4243389,
-    "yahoo_id": 34094
+    "pfr_id": "AustCa00",
+    "espn_id_new": 4243389
   },
   {
     "mfl_id": 15778,
-    "sleeper_id": 8213,
     "gsis_id": "00-0037042",
+    "sleeper_id": 8213,
     "yahoo_id": 34297
   },
   {
     "mfl_id": 15779,
-    "sleeper_id": 8121,
-    "pfr_id": "DoubRo00",
     "gsis_id": "00-0037816",
+    "sleeper_id": 8121,
+    "yahoo_id": 34088,
     "espn_id": 4361432,
-    "yahoo_id": 34088
+    "pfr_id": "DoubRo00",
+    "espn_id_new": 4361432
   },
   {
     "mfl_id": 15780,
-    "sleeper_id": 8114,
-    "pfr_id": "EzukEr00",
     "gsis_id": "00-0038092",
+    "sleeper_id": 8114,
+    "yahoo_id": 34081,
     "espn_id": 4362186,
-    "yahoo_id": 34081
+    "pfr_id": "EzukEr00",
+    "espn_id_new": 4362186
   },
   {
     "mfl_id": 15781,
-    "sleeper_id": 8196,
     "gsis_id": "00-0037566",
+    "sleeper_id": 8196,
     "yahoo_id": 34609
   },
   {
     "mfl_id": 15782,
-    "sleeper_id": 8176,
-    "pfr_id": "GrayDa02",
     "gsis_id": "00-0037828",
+    "sleeper_id": 8176,
+    "yahoo_id": 34061,
     "espn_id": 4689546,
-    "yahoo_id": 34061
+    "pfr_id": "GrayDa02",
+    "espn_id_new": 4689546
   },
   {
     "mfl_id": 15783,
-    "sleeper_id": 8185,
-    "pfr_id": "JohnJo12",
     "gsis_id": "00-0037460",
-    "yahoo_id": 34601
+    "sleeper_id": 8185,
+    "yahoo_id": 34601,
+    "espn_id": 4242504,
+    "pfr_id": "JohnJo12",
+    "espn_id_new": 4242504
   },
   {
     "mfl_id": 15784,
@@ -11813,792 +12001,881 @@
   },
   {
     "mfl_id": 15785,
-    "sleeper_id": 8204,
-    "pfr_id": "MeltBo00",
     "gsis_id": "00-0037091",
+    "sleeper_id": 8204,
+    "yahoo_id": 34185,
     "espn_id": 4259305,
-    "yahoo_id": 34185
+    "pfr_id": "MeltBo00",
+    "espn_id_new": 4259305
   },
   {
     "mfl_id": 15786,
-    "sleeper_id": 8180,
-    "pfr_id": "NailJa00",
     "gsis_id": "00-0037291",
+    "sleeper_id": 8180,
+    "yahoo_id": 34147,
     "espn_id": 4382466,
-    "yahoo_id": 34147
+    "pfr_id": "NailJa00",
+    "espn_id_new": 4382466
   },
   {
     "mfl_id": 15787,
-    "sleeper_id": 8188,
-    "pfr_id": "ThorTy00",
     "gsis_id": "00-0038104",
+    "sleeper_id": 8188,
+    "yahoo_id": 34005,
     "espn_id": 4362921,
-    "yahoo_id": 34005
+    "pfr_id": "ThorTy00",
+    "espn_id_new": 4362921
   },
   {
     "mfl_id": 15788,
-    "sleeper_id": 8117,
-    "pfr_id": "TolbJa00",
     "gsis_id": "00-0037666",
+    "sleeper_id": 8117,
+    "yahoo_id": 34044,
     "espn_id": 4249417,
-    "yahoo_id": 34044
+    "pfr_id": "TolbJa00",
+    "espn_id_new": 4249417
   },
   {
     "mfl_id": 15789,
-    "sleeper_id": 8167,
-    "pfr_id": "WatsCh00",
     "gsis_id": "00-0038124",
+    "sleeper_id": 8167,
+    "yahoo_id": 33989,
     "espn_id": 4248528,
-    "yahoo_id": 33989
+    "pfr_id": "WatsCh00",
+    "espn_id_new": 4248528
   },
   {
     "mfl_id": 15790,
-    "sleeper_id": 8229,
     "gsis_id": "00-0037343",
+    "sleeper_id": 8229,
     "yahoo_id": 34494
   },
   {
     "mfl_id": 15791,
-    "sleeper_id": 8186,
     "gsis_id": "00-0037187",
+    "sleeper_id": 8186,
     "yahoo_id": 34412
   },
   {
     "mfl_id": 15792,
     "sleeper_id": 8202,
-    "pfr_id": "WoodMi00",
-    "espn_id": 4360174,
-    "yahoo_id": 34158
+    "yahoo_id": 34158,
+    "pfr_id": "WoodMi00"
   },
   {
     "mfl_id": 15793,
-    "sleeper_id": 8115,
     "gsis_id": "00-0037436",
+    "sleeper_id": 8115,
     "yahoo_id": 34623
   },
   {
     "mfl_id": 15794,
-    "sleeper_id": 8130,
-    "pfr_id": "McBrTr01",
     "gsis_id": "00-0037744",
+    "sleeper_id": 8130,
+    "yahoo_id": 34010,
     "espn_id": 4361307,
-    "yahoo_id": 34010
+    "pfr_id": "McBrTr01",
+    "espn_id_new": 4361307
   },
   {
     "mfl_id": 15795,
-    "sleeper_id": 8127,
-    "pfr_id": "KolaCh00",
     "gsis_id": "00-0038046",
+    "sleeper_id": 8127,
+    "yahoo_id": 34084,
     "espn_id": 4241263,
-    "yahoo_id": 34084
+    "pfr_id": "KolaCh00",
+    "espn_id_new": 4241263
   },
   {
     "mfl_id": 15796,
-    "sleeper_id": 8145,
-    "pfr_id": "RuckJe00",
     "gsis_id": "00-0037805",
+    "sleeper_id": 8145,
+    "yahoo_id": 34057,
     "espn_id": 4361372,
-    "yahoo_id": 34057
+    "pfr_id": "RuckJe00",
+    "espn_id_new": 4361372
   },
   {
     "mfl_id": 15797,
-    "sleeper_id": 8172,
-    "pfr_id": "DulcGr00",
     "gsis_id": "00-0037252",
+    "sleeper_id": 8172,
+    "yahoo_id": 34036,
     "espn_id": 4367209,
-    "yahoo_id": 34036
+    "pfr_id": "DulcGr00",
+    "espn_id_new": 4367209
   },
   {
     "mfl_id": 15798,
-    "sleeper_id": 8131,
-    "pfr_id": "LikeIs00",
     "gsis_id": "00-0037838",
+    "sleeper_id": 8131,
+    "yahoo_id": 34095,
     "espn_id": 4361050,
-    "yahoo_id": 34095
+    "pfr_id": "LikeIs00",
+    "espn_id_new": 4361050
   },
   {
     "mfl_id": 15799,
-    "sleeper_id": 8110,
-    "pfr_id": "FergJa00",
     "gsis_id": "00-0038041",
+    "sleeper_id": 8110,
+    "yahoo_id": 34085,
     "espn_id": 4242355,
-    "yahoo_id": 34085
+    "pfr_id": "FergJa00",
+    "espn_id_new": 4242355
   },
   {
     "mfl_id": 15800,
-    "sleeper_id": 8181,
-    "pfr_id": "HeywCo00",
     "gsis_id": "00-0037304",
+    "sleeper_id": 8181,
+    "yahoo_id": 34163,
     "espn_id": 4241961,
-    "yahoo_id": 34163
+    "pfr_id": "HeywCo00",
+    "espn_id_new": 4241961
   },
   {
     "mfl_id": 15801,
-    "sleeper_id": 8215,
     "gsis_id": "00-0037369",
+    "sleeper_id": 8215,
     "yahoo_id": 34664
   },
   {
     "mfl_id": 15802,
-    "sleeper_id": 8111,
-    "pfr_id": "OttoCa00",
     "gsis_id": "00-0038129",
+    "sleeper_id": 8111,
+    "yahoo_id": 34062,
     "espn_id": 4243331,
-    "yahoo_id": 34062
+    "pfr_id": "OttoCa00",
+    "espn_id_new": 4243331
   },
   {
     "mfl_id": 15803,
-    "sleeper_id": 8214,
-    "pfr_id": "TurnCo00",
     "gsis_id": "00-0037078",
+    "sleeper_id": 8214,
+    "yahoo_id": 34105,
     "espn_id": 4361438,
-    "yahoo_id": 34105
+    "pfr_id": "TurnCo00",
+    "espn_id_new": 4361438
   },
   {
     "mfl_id": 15804,
-    "sleeper_id": 8177,
-    "pfr_id": "CalcGr00",
     "gsis_id": "00-0037086",
+    "sleeper_id": 8177,
+    "yahoo_id": 34154,
     "espn_id": 4241374,
-    "yahoo_id": 34154
+    "pfr_id": "CalcGr00",
+    "espn_id_new": 4241374
   },
   {
     "mfl_id": 15805,
-    "sleeper_id": 8289,
-    "pfr_id": "HutcAi00",
     "gsis_id": "00-0037236",
+    "sleeper_id": 8289,
+    "yahoo_id": 33957,
     "espn_id": 4372099,
-    "yahoo_id": 33957
+    "pfr_id": "HutcAi00",
+    "espn_id_new": 4372099
   },
   {
     "mfl_id": 15806,
-    "sleeper_id": 8355,
-    "pfr_id": "ThibKa00",
     "gsis_id": "00-0037611",
+    "sleeper_id": 8355,
+    "yahoo_id": 33960,
     "espn_id": 4426326,
-    "yahoo_id": 33960
+    "pfr_id": "ThibKa00",
+    "espn_id_new": 4426326
   },
   {
     "mfl_id": 15807,
-    "sleeper_id": 8287,
-    "pfr_id": "OjabDa00",
     "gsis_id": "00-0038142",
+    "sleeper_id": 8287,
+    "yahoo_id": 34000,
     "espn_id": 4426507,
-    "yahoo_id": 34000
+    "pfr_id": "OjabDa00",
+    "espn_id_new": 4426507
   },
   {
     "mfl_id": 15808,
-    "sleeper_id": 8385,
-    "pfr_id": "KarlGe00",
     "gsis_id": "00-0037192",
+    "sleeper_id": 8385,
+    "yahoo_id": 33985,
     "espn_id": 4426659,
-    "yahoo_id": 33985
+    "pfr_id": "KarlGe00",
+    "espn_id_new": 4426659
   },
   {
     "mfl_id": 15809,
-    "sleeper_id": 8398,
-    "pfr_id": "JohnJe07",
     "gsis_id": "00-0037663",
+    "sleeper_id": 8398,
+    "yahoo_id": 33981,
     "espn_id": 4567962,
-    "yahoo_id": 33981
+    "pfr_id": "JohnJe07",
+    "espn_id_new": 4567962
   },
   {
     "mfl_id": 15810,
-    "sleeper_id": 8291,
-    "pfr_id": "SandMy00",
     "gsis_id": "00-0037751",
+    "sleeper_id": 8291,
+    "yahoo_id": 34056,
     "espn_id": 4360080,
-    "yahoo_id": 34056
+    "pfr_id": "SandMy00",
+    "espn_id_new": 4360080
   },
   {
     "mfl_id": 15811,
-    "sleeper_id": 8351,
-    "pfr_id": "JackDr01",
     "gsis_id": "00-0037826",
+    "sleeper_id": 8351,
+    "yahoo_id": 34017,
     "espn_id": 4569511,
-    "yahoo_id": 34017
+    "pfr_id": "JackDr01",
+    "espn_id_new": 4569511
   },
   {
     "mfl_id": 15812,
     "sleeper_id": 8360,
-    "pfr_id": "HallLo00",
+    "yahoo_id": 33988,
     "espn_id": 4360189,
-    "yahoo_id": 33988
+    "pfr_id": "HallLo00",
+    "espn_id_new": 4360189
   },
   {
     "mfl_id": 15813,
-    "sleeper_id": 8382,
-    "pfr_id": "EnagKi00",
     "gsis_id": "00-0037083",
+    "sleeper_id": 8382,
+    "yahoo_id": 34135,
     "espn_id": 4362840,
-    "yahoo_id": 34135
+    "pfr_id": "EnagKi00",
+    "espn_id_new": 4362840
   },
   {
     "mfl_id": 15814,
-    "sleeper_id": 8383,
-    "pfr_id": "ThomCa03",
     "gsis_id": "00-0037815",
+    "sleeper_id": 8383,
+    "yahoo_id": 34043,
     "espn_id": 4361510,
-    "yahoo_id": 34043
+    "pfr_id": "ThomCa03",
+    "espn_id_new": 4361510
   },
   {
     "mfl_id": 15815,
-    "sleeper_id": 8265,
-    "pfr_id": "WalkTr03",
     "gsis_id": "00-0037235",
+    "sleeper_id": 8265,
+    "yahoo_id": 33956,
     "espn_id": 4426349,
-    "yahoo_id": 33956
+    "pfr_id": "WalkTr03",
+    "espn_id_new": 4426349
   },
   {
     "mfl_id": 15816,
-    "sleeper_id": 8279,
-    "pfr_id": "WinfPe00",
     "gsis_id": "00-0038126",
+    "sleeper_id": 8279,
+    "yahoo_id": 34064,
     "espn_id": 4686470,
-    "yahoo_id": 34064
+    "pfr_id": "WinfPe00",
+    "espn_id_new": 4686470
   },
   {
     "mfl_id": 15817,
-    "sleeper_id": 8269,
-    "pfr_id": "DaviJo03",
     "gsis_id": "00-0037073",
+    "sleeper_id": 8269,
+    "yahoo_id": 33968,
     "espn_id": 4381558,
-    "yahoo_id": 33968
+    "pfr_id": "DaviJo03",
+    "espn_id_new": 4381558
   },
   {
     "mfl_id": 15818,
     "sleeper_id": 8319,
-    "pfr_id": "LealDe00",
+    "yahoo_id": 34040,
     "espn_id": 4426359,
-    "yahoo_id": 34040
+    "pfr_id": "LealDe00",
+    "espn_id_new": 4426359
   },
   {
     "mfl_id": 15819,
-    "sleeper_id": 8270,
-    "pfr_id": "WyatDe00",
     "gsis_id": "00-0037075",
+    "sleeper_id": 8270,
+    "yahoo_id": 33983,
     "espn_id": 4361791,
-    "yahoo_id": 33983
+    "pfr_id": "WyatDe00",
+    "espn_id_new": 4361791
   },
   {
     "mfl_id": 15820,
-    "sleeper_id": 8273,
-    "pfr_id": "MathPh00",
     "gsis_id": "00-0038099",
+    "sleeper_id": 8273,
+    "yahoo_id": 34002,
     "espn_id": 4241468,
-    "yahoo_id": 34002
+    "pfr_id": "MathPh00",
+    "espn_id_new": 4241468
   },
   {
     "mfl_id": 15821,
-    "sleeper_id": 8267,
-    "pfr_id": "DeanNa00",
     "gsis_id": "00-0037615",
+    "sleeper_id": 8267,
+    "yahoo_id": 34039,
     "espn_id": 4426340,
-    "yahoo_id": 34039
+    "pfr_id": "DeanNa00",
+    "espn_id_new": 4426340
   },
   {
     "mfl_id": 15822,
-    "sleeper_id": 8329,
-    "pfr_id": "LloyDe00",
     "gsis_id": "00-0037244",
+    "sleeper_id": 8329,
+    "yahoo_id": 33982,
     "espn_id": 4243256,
-    "yahoo_id": 33982
+    "pfr_id": "LloyDe00",
+    "espn_id_new": 4243256
   },
   {
     "mfl_id": 15823,
-    "sleeper_id": 8278,
-    "pfr_id": "HarrCh06",
     "gsis_id": "00-0037823",
+    "sleeper_id": 8278,
+    "yahoo_id": 34031,
     "espn_id": 4567099,
-    "yahoo_id": 34031
+    "pfr_id": "HarrCh06",
+    "espn_id_new": 4567099
   },
   {
     "mfl_id": 15824,
-    "sleeper_id": 8272,
-    "pfr_id": "TindCh00",
     "gsis_id": "00-0037813",
+    "sleeper_id": 8272,
+    "yahoo_id": 34058,
     "espn_id": 4379414,
-    "yahoo_id": 34058
+    "pfr_id": "TindCh00",
+    "espn_id_new": 4379414
   },
   {
     "mfl_id": 15825,
-    "sleeper_id": 8292,
-    "pfr_id": "BeavDa00",
     "gsis_id": "00-0037285",
-    "espn_id": 4239121,
-    "yahoo_id": 34138
+    "sleeper_id": 8292,
+    "yahoo_id": 34138,
+    "pfr_id": "BeavDa00"
   },
   {
     "mfl_id": 15826,
-    "sleeper_id": 8309,
-    "pfr_id": "ClarDa02",
     "gsis_id": "00-0037281",
+    "sleeper_id": 8309,
+    "yahoo_id": 34132,
     "espn_id": 4362636,
-    "yahoo_id": 34132
+    "pfr_id": "ClarDa02",
+    "espn_id_new": 4362636
   },
   {
     "mfl_id": 15827,
-    "sleeper_id": 8340,
-    "pfr_id": "DomaJo00",
     "gsis_id": "00-0037393",
-    "yahoo_id": 34490
+    "sleeper_id": 8340,
+    "yahoo_id": 34490,
+    "pfr_id": "DomaJo00"
   },
   {
     "mfl_id": 15828,
-    "sleeper_id": 8324,
-    "pfr_id": "SmitBr08",
     "gsis_id": "00-0038113",
-    "espn_id": 4575416,
-    "yahoo_id": 34076
+    "sleeper_id": 8324,
+    "yahoo_id": 34076,
+    "pfr_id": "SmitBr08"
   },
   {
     "mfl_id": 15829,
-    "sleeper_id": 8283,
-    "pfr_id": "AsamBr00",
     "gsis_id": "00-0037822",
+    "sleeper_id": 8283,
+    "yahoo_id": 34022,
     "espn_id": 4360255,
-    "yahoo_id": 34022
+    "pfr_id": "AsamBr00",
+    "espn_id_new": 4360255
   },
   {
     "mfl_id": 15830,
-    "sleeper_id": 8371,
-    "pfr_id": "MumaCh00",
     "gsis_id": "00-0037811",
+    "sleeper_id": 8371,
+    "yahoo_id": 34026,
     "espn_id": 4361707,
-    "yahoo_id": 34026
+    "pfr_id": "MumaCh00",
+    "espn_id_new": 4361707
   },
   {
     "mfl_id": 15831,
-    "sleeper_id": 8362,
-    "pfr_id": "ChenLe00",
     "gsis_id": "00-0037819",
+    "sleeper_id": 8362,
+    "yahoo_id": 34059,
     "espn_id": 4426901,
-    "yahoo_id": 34059
+    "pfr_id": "ChenLe00",
+    "espn_id_new": 4426901
   },
   {
     "mfl_id": 15832,
-    "sleeper_id": 8308,
-    "pfr_id": "StinDe00",
     "gsis_id": "00-0037237",
+    "sleeper_id": 8308,
+    "yahoo_id": 33958,
     "espn_id": 4426434,
-    "yahoo_id": 33958
+    "pfr_id": "StinDe00",
+    "espn_id_new": 4426434
   },
   {
     "mfl_id": 15833,
-    "sleeper_id": 8290,
-    "pfr_id": "GardSa00",
     "gsis_id": "00-0037190",
-    "yahoo_id": 33959
+    "sleeper_id": 8290,
+    "yahoo_id": 33959,
+    "espn_id": 4427250,
+    "pfr_id": "GardSa00",
+    "espn_id_new": 4427250
   },
   {
     "mfl_id": 15834,
-    "sleeper_id": 8339,
-    "pfr_id": "HamiKy00",
     "gsis_id": "00-0038038",
+    "sleeper_id": 8339,
+    "yahoo_id": 33969,
     "espn_id": 4575517,
-    "yahoo_id": 33969
+    "pfr_id": "HamiKy00",
+    "espn_id_new": 4575517
   },
   {
     "mfl_id": 15835,
-    "sleeper_id": 8323,
-    "pfr_id": "BrisJa01",
     "gsis_id": "00-0038135",
+    "sleeper_id": 8323,
+    "yahoo_id": 34003,
     "espn_id": 4570044,
-    "yahoo_id": 34003
+    "pfr_id": "BrisJa01",
+    "espn_id_new": 4570044
   },
   {
     "mfl_id": 15836,
-    "sleeper_id": 8286,
-    "pfr_id": "HillDa04",
     "gsis_id": "00-0037743",
-    "yahoo_id": 33986
+    "sleeper_id": 8286,
+    "yahoo_id": 33986,
+    "espn_id": 4426422,
+    "pfr_id": "HillDa04",
+    "espn_id_new": 4426422
   },
   {
     "mfl_id": 15837,
-    "sleeper_id": 8268,
-    "pfr_id": "CineLe00",
     "gsis_id": "00-0037245",
+    "sleeper_id": 8268,
+    "yahoo_id": 33987,
     "espn_id": 4426536,
-    "yahoo_id": 33987
+    "pfr_id": "CineLe00",
+    "espn_id_new": 4426536
   },
   {
     "mfl_id": 15838,
-    "sleeper_id": 8353,
-    "pfr_id": "McKiVe00",
     "gsis_id": "00-0037354",
-    "yahoo_id": 34532
+    "sleeper_id": 8353,
+    "yahoo_id": 34532,
+    "espn_id": 4360692,
+    "pfr_id": "McKiVe00",
+    "espn_id_new": 4360692
   },
   {
     "mfl_id": 15839,
-    "sleeper_id": 8392,
-    "pfr_id": "CrosNi00",
     "gsis_id": "00-0037616",
+    "sleeper_id": 8392,
+    "yahoo_id": 34052,
     "espn_id": 4426403,
-    "yahoo_id": 34052
+    "pfr_id": "CrosNi00",
+    "espn_id_new": 4426403
   },
   {
     "mfl_id": 15840,
-    "sleeper_id": 8219,
-    "pfr_id": "WoodJe01",
     "gsis_id": "00-0037755",
+    "sleeper_id": 8219,
+    "yahoo_id": 34029,
     "espn_id": 4241410,
-    "yahoo_id": 34029
+    "pfr_id": "WoodJe01",
+    "espn_id_new": 4241410
   },
   {
     "mfl_id": 15841,
-    "sleeper_id": 8235,
-    "pfr_id": "TourSa00",
     "gsis_id": "00-0037098",
-    "espn_id": 4027873,
-    "yahoo_id": 34214
+    "sleeper_id": 8235,
+    "yahoo_id": 34214,
+    "pfr_id": "TourSa00"
   },
   {
     "mfl_id": 15842,
-    "sleeper_id": 7984,
     "gsis_id": "00-0036729",
-    "espn_id": 4040607
+    "sleeper_id": 7984
   },
   {
     "mfl_id": 15843,
-    "sleeper_id": 8061,
     "gsis_id": "00-0036746",
+    "sleeper_id": 8061,
     "yahoo_id": 33766
   },
   {
     "mfl_id": 15844,
-    "sleeper_id": 8411,
     "gsis_id": "00-0037039",
-    "yahoo_id": 33953
+    "sleeper_id": 8411,
+    "yahoo_id": 33953,
+    "espn_id": 3052083,
+    "espn_id_new": 3052083
   },
   {
     "mfl_id": 15845,
-    "sleeper_id": 8364,
-    "pfr_id": "McDuTr00",
     "gsis_id": "00-0037191",
+    "sleeper_id": 8364,
+    "yahoo_id": 33976,
     "espn_id": 4426405,
-    "yahoo_id": 33976
+    "pfr_id": "McDuTr00",
+    "espn_id_new": 4426405
   },
   {
     "mfl_id": 15846,
-    "sleeper_id": 8266,
-    "pfr_id": "WalkQu00",
     "gsis_id": "00-0037074",
+    "sleeper_id": 8266,
+    "yahoo_id": 33977,
     "espn_id": 4379416,
-    "yahoo_id": 33977
+    "pfr_id": "WalkQu00",
+    "espn_id_new": 4379416
   },
   {
     "mfl_id": 15847,
-    "sleeper_id": 8296,
-    "pfr_id": "ElamKa00",
     "gsis_id": "00-0037242",
+    "sleeper_id": 8296,
+    "yahoo_id": 33978,
     "espn_id": 4567399,
-    "yahoo_id": 33978
+    "pfr_id": "ElamKa00",
+    "espn_id_new": 4567399
   },
   {
     "mfl_id": 15849,
-    "sleeper_id": 8303,
-    "pfr_id": "McCrRo01",
     "gsis_id": "00-0038125",
+    "sleeper_id": 8303,
+    "yahoo_id": 33990,
     "espn_id": 4371973,
-    "yahoo_id": 33990
+    "pfr_id": "McCrRo01",
+    "espn_id_new": 4371973
   },
   {
     "mfl_id": 15850,
-    "sleeper_id": 8314,
-    "pfr_id": "PitrJa00",
     "gsis_id": "00-0037246",
+    "sleeper_id": 8314,
+    "yahoo_id": 33992,
     "espn_id": 4241223,
-    "yahoo_id": 33992
+    "pfr_id": "PitrJa00",
+    "espn_id_new": 4241223
   },
   {
     "mfl_id": 15851,
-    "sleeper_id": 8325,
-    "pfr_id": "EbikAr00",
     "gsis_id": "00-0038116",
+    "sleeper_id": 8325,
+    "yahoo_id": 33993,
     "espn_id": 4257591,
-    "yahoo_id": 33993
+    "pfr_id": "EbikAr00",
+    "espn_id_new": 4257591
   },
   {
     "mfl_id": 15852,
-    "sleeper_id": 8365,
-    "pfr_id": "GordKy00",
     "gsis_id": "00-0038111",
+    "sleeper_id": 8365,
+    "yahoo_id": 33994,
     "espn_id": 4361093,
-    "yahoo_id": 33994
+    "pfr_id": "GordKy00",
+    "espn_id_new": 4361093
   },
   {
     "mfl_id": 15853,
-    "sleeper_id": 8343,
-    "pfr_id": "MafeBo00",
     "gsis_id": "00-0038133",
+    "sleeper_id": 8343,
+    "yahoo_id": 33995,
     "espn_id": 4240754,
-    "yahoo_id": 33995
+    "pfr_id": "MafeBo00",
+    "espn_id_new": 4240754
   },
   {
     "mfl_id": 15854,
-    "sleeper_id": 8300,
-    "pfr_id": "BootAn00",
     "gsis_id": "00-0038130",
+    "sleeper_id": 8300,
+    "yahoo_id": 33997,
     "espn_id": 4426344,
-    "yahoo_id": 33997
+    "pfr_id": "BootAn00",
+    "espn_id_new": 4426344
   },
   {
     "mfl_id": 15855,
-    "sleeper_id": 8358,
-    "pfr_id": "PascJo00",
     "gsis_id": "00-0038096",
+    "sleeper_id": 8358,
+    "yahoo_id": 34001,
     "espn_id": 4259994,
-    "yahoo_id": 34001
+    "pfr_id": "PascJo00",
+    "espn_id_new": 4259994
   },
   {
     "mfl_id": 15856,
-    "sleeper_id": 8333,
-    "pfr_id": "TaylAl01",
     "gsis_id": "00-0038121",
+    "sleeper_id": 8333,
+    "yahoo_id": 34004,
     "espn_id": 4369835,
-    "yahoo_id": 34004
+    "pfr_id": "TaylAl01",
+    "espn_id_new": 4369835
   },
   {
     "mfl_id": 15857,
-    "sleeper_id": 8368,
-    "pfr_id": "WillSa00",
     "gsis_id": "00-0037665",
+    "sleeper_id": 8368,
+    "yahoo_id": 34011,
     "espn_id": 4567242,
-    "yahoo_id": 34011
+    "pfr_id": "WillSa00",
+    "espn_id_new": 4567242
   },
   {
     "mfl_id": 15858,
-    "sleeper_id": 8388,
-    "pfr_id": "AndeTr00",
     "gsis_id": "00-0037810",
+    "sleeper_id": 8388,
+    "yahoo_id": 34015,
     "espn_id": 4247807,
-    "yahoo_id": 34015
+    "pfr_id": "AndeTr00",
+    "espn_id_new": 4247807
   },
   {
     "mfl_id": 15859,
-    "sleeper_id": 8341,
-    "pfr_id": "TaylCa01",
     "gsis_id": "00-0037753",
+    "sleeper_id": 8341,
+    "yahoo_id": 34016,
     "espn_id": 4361196,
-    "yahoo_id": 34016
+    "pfr_id": "TaylCa01",
+    "espn_id_new": 4361196
   },
   {
     "mfl_id": 15860,
-    "sleeper_id": 8294,
-    "pfr_id": "CookBr02",
     "gsis_id": "00-0037193",
+    "sleeper_id": 8294,
+    "yahoo_id": 34018,
     "espn_id": 4247726,
-    "yahoo_id": 34018
+    "pfr_id": "CookBr02",
+    "espn_id_new": 4247726
   },
   {
     "mfl_id": 15861,
-    "sleeper_id": 8280,
-    "pfr_id": "BoniNi00",
     "gsis_id": "00-0037249",
+    "sleeper_id": 8280,
+    "yahoo_id": 34020,
     "espn_id": 4360259,
-    "yahoo_id": 34020
+    "pfr_id": "BoniNi00",
+    "espn_id_new": 4360259
   },
   {
     "mfl_id": 15862,
-    "sleeper_id": 8390,
-    "pfr_id": "EmerMa00",
     "gsis_id": "00-0037250",
+    "sleeper_id": 8390,
+    "yahoo_id": 34024,
     "espn_id": 4429568,
-    "yahoo_id": 34024
+    "pfr_id": "EmerMa00",
+    "espn_id_new": 4429568
   },
   {
     "mfl_id": 15863,
-    "sleeper_id": 8400,
-    "pfr_id": "JoneTr00",
     "gsis_id": "00-0037756",
+    "sleeper_id": 8400,
+    "yahoo_id": 34032,
     "espn_id": 4362139,
-    "yahoo_id": 34032
+    "pfr_id": "JoneTr00",
+    "espn_id_new": 4362139
   },
   {
     "mfl_id": 15864,
-    "sleeper_id": 8376,
-    "pfr_id": "WrigAl01",
     "gsis_id": "00-0037251",
+    "sleeper_id": 8376,
+    "yahoo_id": 34034,
     "espn_id": 4570119,
-    "yahoo_id": 34034
+    "pfr_id": "WrigAl01",
+    "espn_id_new": 4570119
   },
   {
     "mfl_id": 15865,
-    "sleeper_id": 8313,
-    "pfr_id": "WoodJT00",
     "gsis_id": "00-0038091",
+    "sleeper_id": 8313,
+    "yahoo_id": 34035,
     "espn_id": 4362917,
-    "yahoo_id": 34035
+    "pfr_id": "WoodJT00",
+    "espn_id_new": 4362917
   },
   {
     "mfl_id": 15866,
-    "sleeper_id": 8310,
-    "pfr_id": "FlotCo00",
     "gsis_id": "00-0037758",
-    "yahoo_id": 34037
+    "sleeper_id": 8310,
+    "yahoo_id": 34037,
+    "pfr_id": "FlotCo00"
   },
   {
     "mfl_id": 15867,
-    "sleeper_id": 8372,
-    "pfr_id": "MaloDe00",
     "gsis_id": "00-0037808",
+    "sleeper_id": 8372,
+    "yahoo_id": 34038,
     "espn_id": 4243457,
-    "yahoo_id": 34038
+    "pfr_id": "MaloDe00",
+    "espn_id_new": 4243457
   },
   {
     "mfl_id": 15868,
-    "sleeper_id": 8359,
-    "pfr_id": "JoneMa06",
     "gsis_id": "00-0037253",
+    "sleeper_id": 8359,
+    "yahoo_id": 34041,
     "espn_id": 4241720,
-    "yahoo_id": 34041
+    "pfr_id": "JoneMa06",
+    "espn_id_new": 4241720
   },
   {
     "mfl_id": 15869,
-    "sleeper_id": 8311,
-    "pfr_id": "BernTe00",
     "gsis_id": "00-0037254",
+    "sleeper_id": 8311,
+    "yahoo_id": 34045,
     "espn_id": 4259166,
-    "yahoo_id": 34045
+    "pfr_id": "BernTe00",
+    "espn_id_new": 4259166
   },
   {
     "mfl_id": 15870,
-    "sleeper_id": 8295,
-    "pfr_id": "CartZa00",
     "gsis_id": "00-0037804",
+    "sleeper_id": 8295,
+    "yahoo_id": 34051,
     "espn_id": 4240619,
-    "yahoo_id": 34051
+    "pfr_id": "CartZa00",
+    "espn_id_new": 4240619
   },
   {
     "mfl_id": 15871,
-    "sleeper_id": 8348,
-    "pfr_id": "JoseKe03",
     "gsis_id": "00-0037667",
+    "sleeper_id": 8348,
+    "yahoo_id": 34053,
     "espn_id": 4360383,
-    "yahoo_id": 34053
+    "pfr_id": "JoseKe03",
+    "espn_id_new": 4360383
   },
   {
     "mfl_id": 15872,
-    "sleeper_id": 8293,
-    "pfr_id": "BryaCo01",
     "gsis_id": "00-0038136",
+    "sleeper_id": 8293,
+    "yahoo_id": 34065,
     "espn_id": 4239094,
-    "yahoo_id": 34065
+    "pfr_id": "BryaCo01",
+    "espn_id_new": 4239094
   },
   {
     "mfl_id": 15873,
-    "sleeper_id": 8225,
-    "pfr_id": "BellDa00",
     "gsis_id": "00-0038115",
+    "sleeper_id": 8225,
+    "yahoo_id": 34068,
     "espn_id": 4361516,
-    "yahoo_id": 34068
+    "pfr_id": "BellDa00",
+    "espn_id_new": 4361516
   },
   {
     "mfl_id": 15874,
-    "sleeper_id": 8394,
-    "pfr_id": "ButlPe00",
     "gsis_id": "00-0038100",
+    "sleeper_id": 8394,
+    "yahoo_id": 34069,
     "espn_id": 4363097,
-    "yahoo_id": 34069
+    "pfr_id": "ButlPe00",
+    "espn_id_new": 4363097
   },
   {
     "mfl_id": 15875,
-    "sleeper_id": 8395,
-    "pfr_id": "BeltDa00",
     "gsis_id": "00-0038123",
+    "sleeper_id": 8395,
+    "yahoo_id": 34070,
     "espn_id": 4426686,
-    "yahoo_id": 34070
+    "pfr_id": "BeltDa00",
+    "espn_id_new": 4426686
   },
   {
     "mfl_id": 15876,
-    "sleeper_id": 8386,
-    "pfr_id": "MathDa00",
     "gsis_id": "00-0038105",
+    "sleeper_id": 8386,
+    "yahoo_id": 34071,
     "espn_id": 4240707,
-    "yahoo_id": 34071
+    "pfr_id": "MathDa00",
+    "espn_id_new": 4240707
   },
   {
     "mfl_id": 15877,
     "sleeper_id": 8347,
-    "pfr_id": "UwazEy00",
+    "yahoo_id": 34072,
     "espn_id": 4066109,
-    "yahoo_id": 34072
+    "pfr_id": "UwazEy00",
+    "espn_id_new": 4066109
   },
   {
     "mfl_id": 15878,
-    "sleeper_id": 8316,
-    "pfr_id": "ClemMi03",
     "gsis_id": "00-0038107",
+    "sleeper_id": 8316,
+    "yahoo_id": 34073,
     "espn_id": 4240896,
-    "yahoo_id": 34073
+    "pfr_id": "ClemMi03",
+    "espn_id_new": 4240896
   },
   {
     "mfl_id": 15879,
-    "sleeper_id": 8276,
-    "pfr_id": "ArmoJa00",
     "gsis_id": "00-0038119",
+    "sleeper_id": 8276,
+    "yahoo_id": 34075,
     "espn_id": 4372017,
-    "yahoo_id": 34075
+    "pfr_id": "ArmoJa00",
+    "espn_id_new": 4372017
   },
   {
     "mfl_id": 15880,
-    "sleeper_id": 8389,
-    "pfr_id": "EvanAk00",
     "gsis_id": "00-0038101",
+    "sleeper_id": 8389,
+    "yahoo_id": 34074,
     "espn_id": 4244607,
-    "yahoo_id": 34074
+    "pfr_id": "EvanAk00",
+    "espn_id_new": 4244607
   },
   {
     "mfl_id": 15881,
-    "sleeper_id": 8261,
-    "pfr_id": "JoneJa10",
     "gsis_id": "00-0038039",
+    "sleeper_id": 8261,
+    "yahoo_id": 34077,
     "espn_id": 4035686,
-    "yahoo_id": 34077
+    "pfr_id": "JoneJa10",
+    "espn_id_new": 4035686
   },
   {
     "mfl_id": 15882,
-    "sleeper_id": 8258,
-    "pfr_id": "YorkCa00",
     "gsis_id": "00-0038097",
+    "sleeper_id": 8258,
+    "yahoo_id": 34080,
     "espn_id": 4428963,
-    "yahoo_id": 34080
+    "pfr_id": "YorkCa00",
+    "espn_id_new": 4428963
   },
   {
     "mfl_id": 15883,
-    "sleeper_id": 8307,
-    "pfr_id": "FarrNe00",
     "gsis_id": "00-0038093",
+    "sleeper_id": 8307,
+    "yahoo_id": 34082,
     "espn_id": 4242234,
-    "yahoo_id": 34082
+    "pfr_id": "FarrNe00",
+    "espn_id_new": 4242234
   },
   {
     "mfl_id": 15884,
     "sleeper_id": 8467,
+    "espn_id": 4260224,
     "pfr_id": "StouJo00",
-    "espn_id": 4260224
+    "espn_id_new": 4260224
   },
   {
     "mfl_id": 15885,
-    "sleeper_id": 8470,
-    "pfr_id": "WillJo03",
     "gsis_id": "00-0038043",
+    "sleeper_id": 8470,
+    "yahoo_id": 34091,
     "espn_id": 4917635,
-    "yahoo_id": 34091
+    "pfr_id": "WillJo03",
+    "espn_id_new": 4917635
   },
   {
     "mfl_id": 15886,
-    "sleeper_id": 8361,
-    "pfr_id": "WillDa15",
     "gsis_id": "00-0037984",
+    "sleeper_id": 8361,
+    "yahoo_id": 34097,
     "espn_id": 4567480,
-    "yahoo_id": 34097
+    "pfr_id": "WillDa15",
+    "espn_id_new": 4567480
   },
   {
     "mfl_id": 15887,
     "sleeper_id": 8466,
+    "espn_id": 4379396,
     "pfr_id": "CamaJa00",
-    "espn_id": 4379396
+    "espn_id_new": 4379396
   },
   {
     "mfl_id": 15888,
@@ -12606,540 +12883,610 @@
   },
   {
     "mfl_id": 15889,
-    "sleeper_id": 8210,
-    "pfr_id": "OkonCh00",
     "gsis_id": "00-0037809",
+    "sleeper_id": 8210,
+    "yahoo_id": 34099,
     "espn_id": 4360635,
-    "yahoo_id": 34099
+    "pfr_id": "OkonCh00",
+    "espn_id_new": 4360635
   },
   {
     "mfl_id": 15890,
-    "sleeper_id": 8396,
-    "pfr_id": "McFaMi01",
     "gsis_id": "00-0037259",
+    "sleeper_id": 8396,
+    "yahoo_id": 34102,
     "espn_id": 4371961,
-    "yahoo_id": 34102
+    "pfr_id": "McFaMi01",
+    "espn_id_new": 4371961
   },
   {
     "mfl_id": 15891,
-    "sleeper_id": 8262,
-    "pfr_id": "DaviDJ00",
     "gsis_id": "00-0037260",
+    "sleeper_id": 8262,
+    "yahoo_id": 34103,
     "espn_id": 4242899,
-    "yahoo_id": 34103
+    "pfr_id": "DaviDJ00",
+    "espn_id_new": 4242899
   },
   {
     "mfl_id": 15892,
     "sleeper_id": 8380,
-    "pfr_id": "BookTh00",
-    "espn_id": 4360749,
-    "yahoo_id": 34106
+    "yahoo_id": 34106,
+    "pfr_id": "BookTh00"
   },
   {
     "mfl_id": 15893,
-    "sleeper_id": 8282,
-    "pfr_id": "TurnDe02",
     "gsis_id": "00-0037264",
+    "sleeper_id": 8282,
+    "yahoo_id": 34108,
     "espn_id": 4360287,
-    "yahoo_id": 34108
+    "pfr_id": "TurnDe02",
+    "espn_id_new": 4360287
   },
   {
     "mfl_id": 15894,
-    "sleeper_id": 8374,
-    "pfr_id": "WoolTa00",
     "gsis_id": "00-0037079",
+    "sleeper_id": 8374,
+    "yahoo_id": 34109,
     "espn_id": 4245185,
-    "yahoo_id": 34109
+    "pfr_id": "WoolTa00",
+    "espn_id_new": 4245185
   },
   {
     "mfl_id": 15895,
-    "sleeper_id": 8384,
-    "pfr_id": "McCoZy02",
     "gsis_id": "00-0037268",
+    "sleeper_id": 8384,
+    "yahoo_id": 34113,
     "espn_id": 4250392,
-    "yahoo_id": 34113
+    "pfr_id": "McCoZy02",
+    "espn_id_new": 4250392
   },
   {
     "mfl_id": 15896,
     "sleeper_id": 8336,
-    "pfr_id": "SmitTy03",
+    "yahoo_id": 34114,
     "espn_id": 4361340,
-    "yahoo_id": 34114
+    "pfr_id": "SmitTy03",
+    "espn_id_new": 4361340
   },
   {
     "mfl_id": 15897,
-    "sleeper_id": 8473,
-    "pfr_id": "JohnEr01",
     "gsis_id": "00-0037269",
+    "sleeper_id": 8473,
+    "yahoo_id": 34115,
     "espn_id": 4050971,
-    "yahoo_id": 34115
+    "pfr_id": "JohnEr01",
+    "espn_id_new": 4050971
   },
   {
     "mfl_id": 15898,
-    "sleeper_id": 8331,
-    "pfr_id": "OgboOt00",
     "gsis_id": "00-0037270",
+    "sleeper_id": 8331,
+    "yahoo_id": 34116,
     "espn_id": 4367210,
-    "yahoo_id": 34116
+    "pfr_id": "OgboOt00",
+    "espn_id_new": 4367210
   },
   {
     "mfl_id": 15899,
-    "sleeper_id": 8367,
-    "pfr_id": "JackDM00",
     "gsis_id": "00-0037271",
-    "yahoo_id": 34117
+    "sleeper_id": 8367,
+    "yahoo_id": 34117,
+    "espn_id": 4241007,
+    "pfr_id": "JackDM00",
+    "espn_id_new": 4241007
   },
   {
     "mfl_id": 15900,
-    "sleeper_id": 8475,
-    "pfr_id": "WashMo00",
     "gsis_id": "00-0037272",
+    "sleeper_id": 8475,
+    "yahoo_id": 34118,
     "espn_id": 4248822,
-    "yahoo_id": 34118
+    "pfr_id": "WashMo00",
+    "espn_id_new": 4248822
   },
   {
     "mfl_id": 15901,
-    "sleeper_id": 8171,
-    "pfr_id": "PhilKy01",
     "gsis_id": "00-0037273",
+    "sleeper_id": 8171,
+    "yahoo_id": 34119,
     "espn_id": 4367175,
-    "yahoo_id": 34119
+    "pfr_id": "PhilKy01",
+    "espn_id_new": 4367175
   },
   {
     "mfl_id": 15902,
     "sleeper_id": 8342,
-    "pfr_id": "OtomEs00",
+    "yahoo_id": 34121,
     "espn_id": 4240759,
-    "yahoo_id": 34121
+    "pfr_id": "OtomEs00",
+    "espn_id_new": 4240759
   },
   {
     "mfl_id": 15903,
     "sleeper_id": 8377,
-    "pfr_id": "AndeTy00",
+    "yahoo_id": 34122,
     "espn_id": 4257240,
-    "yahoo_id": 34122
+    "pfr_id": "AndeTy00",
+    "espn_id_new": 4257240
   },
   {
     "mfl_id": 15904,
-    "sleeper_id": 8476,
-    "pfr_id": "BlanDa00",
     "gsis_id": "00-0037275",
+    "sleeper_id": 8476,
+    "yahoo_id": 34123,
     "espn_id": 4248911,
-    "yahoo_id": 34123
+    "pfr_id": "BlanDa00",
+    "espn_id_new": 4248911
   },
   {
     "mfl_id": 15905,
-    "sleeper_id": 8227,
-    "pfr_id": "QuitTe00",
     "gsis_id": "00-0037277",
+    "sleeper_id": 8227,
+    "yahoo_id": 34126,
     "espn_id": 4374045,
-    "yahoo_id": 34126
+    "pfr_id": "QuitTe00",
+    "espn_id_new": 4374045
   },
   {
     "mfl_id": 15906,
-    "sleeper_id": 8478,
-    "pfr_id": "WomaSa00",
     "gsis_id": "00-0037830",
+    "sleeper_id": 8478,
+    "yahoo_id": 34128,
     "espn_id": 4280416,
-    "yahoo_id": 34128
+    "pfr_id": "WomaSa00",
+    "espn_id_new": 4280416
   },
   {
     "mfl_id": 15907,
-    "sleeper_id": 8391,
-    "pfr_id": "RobiDo00",
     "gsis_id": "00-0037082",
+    "sleeper_id": 8391,
+    "yahoo_id": 34130,
     "espn_id": 4244300,
-    "yahoo_id": 34130
+    "pfr_id": "RobiDo00",
+    "espn_id_new": 4244300
   },
   {
     "mfl_id": 15908,
-    "sleeper_id": 8332,
-    "pfr_id": "ButlMa02",
     "gsis_id": "00-0037280",
-    "espn_id": 4242457,
-    "yahoo_id": 34131
+    "sleeper_id": 8332,
+    "yahoo_id": 34131,
+    "pfr_id": "ButlMa02"
   },
   {
     "mfl_id": 15909,
-    "sleeper_id": 8170,
-    "pfr_id": "MitcJa00",
     "gsis_id": "00-0037282",
-    "espn_id": 4361988,
-    "yahoo_id": 34133
+    "sleeper_id": 8170,
+    "yahoo_id": 34133,
+    "pfr_id": "MitcJa00"
   },
   {
     "mfl_id": 15910,
-    "sleeper_id": 8306,
-    "pfr_id": "RidgJo00",
     "gsis_id": "00-0037283",
+    "sleeper_id": 8306,
+    "yahoo_id": 34134,
     "espn_id": 4248047,
-    "yahoo_id": 34134
+    "pfr_id": "RidgJo00",
+    "espn_id_new": 4248047
   },
   {
     "mfl_id": 15911,
     "sleeper_id": 8486,
+    "espn_id": 4361496,
     "pfr_id": "AraiMa00",
-    "espn_id": 4361496
+    "espn_id_new": 4361496
   },
   {
     "mfl_id": 15912,
-    "sleeper_id": 8483,
-    "pfr_id": "JohnKy02",
     "gsis_id": "00-0037084",
-    "yahoo_id": 34137
+    "sleeper_id": 8483,
+    "yahoo_id": 34137,
+    "espn_id": 4241302,
+    "pfr_id": "JohnKy02",
+    "espn_id_new": 4241302
   },
   {
     "mfl_id": 15913,
-    "sleeper_id": 8487,
-    "pfr_id": "BenfCh00",
     "gsis_id": "00-0037288",
-    "yahoo_id": 34141
+    "sleeper_id": 8487,
+    "yahoo_id": 34141,
+    "espn_id": 4379778,
+    "pfr_id": "BenfCh00",
+    "espn_id_new": 4379778
   },
   {
     "mfl_id": 15914,
-    "sleeper_id": 8334,
-    "pfr_id": "RodrMa00",
     "gsis_id": "00-0037289",
+    "sleeper_id": 8334,
+    "yahoo_id": 34144,
     "espn_id": 4241411,
-    "yahoo_id": 34144
+    "pfr_id": "RodrMa00",
+    "espn_id_new": 4241411
   },
   {
     "mfl_id": 15915,
-    "sleeper_id": 8327,
-    "pfr_id": "BarnAm00",
     "gsis_id": "00-0037043",
+    "sleeper_id": 8327,
+    "yahoo_id": 34145,
     "espn_id": 4568439,
-    "yahoo_id": 34145
+    "pfr_id": "BarnAm00",
+    "espn_id_new": 4568439
   },
   {
     "mfl_id": 15916,
-    "sleeper_id": 8489,
-    "pfr_id": "OgleAn00",
     "gsis_id": "00-0037292",
-    "yahoo_id": 34148
+    "sleeper_id": 8489,
+    "yahoo_id": 34148,
+    "espn_id": 4722908,
+    "pfr_id": "OgleAn00",
+    "espn_id_new": 4722908
   },
   {
     "mfl_id": 15917,
-    "sleeper_id": 8498,
-    "pfr_id": "HarpDe00",
     "gsis_id": "00-0037293",
-    "yahoo_id": 34149
+    "sleeper_id": 8498,
+    "yahoo_id": 34149,
+    "pfr_id": "HarpDe00"
   },
   {
     "mfl_id": 15918,
     "sleeper_id": 8370,
-    "pfr_id": "JackJo06",
-    "espn_id": 4261090,
-    "yahoo_id": 34150
+    "yahoo_id": 34150,
+    "pfr_id": "JackJo06"
   },
   {
     "mfl_id": 15919,
-    "sleeper_id": 8503,
-    "pfr_id": "JuniGr00",
     "gsis_id": "00-0037296",
-    "yahoo_id": 34153
+    "sleeper_id": 8503,
+    "yahoo_id": 34153,
+    "espn_id": 4400960,
+    "pfr_id": "JuniGr00",
+    "espn_id_new": 4400960
   },
   {
     "mfl_id": 15920,
-    "sleeper_id": 8492,
-    "pfr_id": "RobeSa00",
     "gsis_id": "00-0037298",
+    "sleeper_id": 8492,
+    "yahoo_id": 34156,
     "espn_id": 4077786,
-    "yahoo_id": 34156
+    "pfr_id": "RobeSa00",
+    "espn_id_new": 4077786
   },
   {
     "mfl_id": 15921,
-    "sleeper_id": 8496,
-    "pfr_id": "JackTh00",
     "gsis_id": "00-0037301",
-    "yahoo_id": 34164
+    "sleeper_id": 8496,
+    "yahoo_id": 34164,
+    "espn_id": 4242436,
+    "pfr_id": "JackTh00",
+    "espn_id_new": 4242436
   },
   {
     "mfl_id": 15922,
     "sleeper_id": 8495,
-    "pfr_id": "HennMa01",
-    "espn_id": 4242358,
-    "yahoo_id": 34161
+    "yahoo_id": 34161,
+    "pfr_id": "HennMa01"
   },
   {
     "mfl_id": 15923,
-    "sleeper_id": 8330,
-    "pfr_id": "LakeQu00",
     "gsis_id": "00-0037841",
+    "sleeper_id": 8330,
+    "yahoo_id": 34167,
     "espn_id": 4249128,
-    "yahoo_id": 34167
+    "pfr_id": "LakeQu00",
+    "espn_id_new": 4249128
   },
   {
     "mfl_id": 15924,
-    "sleeper_id": 8271,
-    "pfr_id": "KendDe00",
     "gsis_id": "00-0037842",
-    "yahoo_id": 34168
+    "sleeper_id": 8271,
+    "yahoo_id": 34168,
+    "espn_id": 4360307,
+    "pfr_id": "KendDe00",
+    "espn_id_new": 4360307
   },
   {
     "mfl_id": 15925,
-    "sleeper_id": 8500,
-    "pfr_id": "FitzJo00",
     "gsis_id": "00-0037306",
+    "sleeper_id": 8500,
+    "yahoo_id": 34169,
     "espn_id": 4379401,
-    "yahoo_id": 34169
+    "pfr_id": "FitzJo00",
+    "espn_id_new": 4379401
   },
   {
     "mfl_id": 15926,
     "sleeper_id": 8481,
-    "pfr_id": "TaylJa04",
+    "yahoo_id": 34170,
     "espn_id": 4240434,
-    "yahoo_id": 34170
+    "pfr_id": "TaylJa04",
+    "espn_id_new": 4240434
   },
   {
     "mfl_id": 15927,
-    "sleeper_id": 8490,
-    "pfr_id": "BrooCu00",
     "gsis_id": "00-0037309",
-    "espn_id": 4037474,
-    "yahoo_id": 34172
+    "sleeper_id": 8490,
+    "yahoo_id": 34172,
+    "pfr_id": "BrooCu00"
   },
   {
     "mfl_id": 15928,
-    "sleeper_id": 8494,
-    "pfr_id": "HousJa01",
     "gsis_id": "00-0037310",
+    "sleeper_id": 8494,
+    "yahoo_id": 34173,
     "espn_id": 4240608,
-    "yahoo_id": 34173
+    "pfr_id": "HousJa01",
+    "espn_id_new": 4240608
   },
   {
     "mfl_id": 15929,
-    "sleeper_id": 8484,
-    "pfr_id": "KiefKo00",
     "gsis_id": "00-0037311",
+    "sleeper_id": 8484,
+    "yahoo_id": 34174,
     "espn_id": 4034779,
-    "yahoo_id": 34174
+    "pfr_id": "KiefKo00",
+    "espn_id_new": 4034779
   },
   {
     "mfl_id": 15930,
-    "sleeper_id": 8369,
-    "pfr_id": "CampCh02",
     "gsis_id": "00-0037312",
-    "yahoo_id": 34175
+    "sleeper_id": 8369,
+    "yahoo_id": 34175,
+    "espn_id": 4372051,
+    "pfr_id": "CampCh02",
+    "espn_id_new": 4372051
   },
   {
     "mfl_id": 15931,
-    "sleeper_id": 8375,
-    "pfr_id": "DaviKa01",
     "gsis_id": "00-0037832",
-    "yahoo_id": 34176
+    "sleeper_id": 8375,
+    "yahoo_id": 34176,
+    "espn_id": 4243541,
+    "pfr_id": "DaviKa01",
+    "espn_id_new": 4243541
   },
   {
     "mfl_id": 15932,
-    "sleeper_id": 8321,
-    "pfr_id": "CastTa00",
     "gsis_id": "00-0037833",
-    "yahoo_id": 34177
+    "sleeper_id": 8321,
+    "yahoo_id": 34177,
+    "espn_id": 4259590,
+    "pfr_id": "CastTa00",
+    "espn_id_new": 4259590
   },
   {
     "mfl_id": 15933,
-    "sleeper_id": 8305,
-    "pfr_id": "BrowMo00",
     "gsis_id": "00-0037313",
-    "yahoo_id": 34178
+    "sleeper_id": 8305,
+    "yahoo_id": 34178,
+    "espn_id": 4242149,
+    "pfr_id": "BrowMo00",
+    "espn_id_new": 4242149
   },
   {
     "mfl_id": 15934,
-    "sleeper_id": 8281,
-    "pfr_id": "ThomIs01",
     "gsis_id": "00-0037314",
+    "sleeper_id": 8281,
+    "yahoo_id": 34179,
     "espn_id": 4241404,
-    "yahoo_id": 34179
+    "pfr_id": "ThomIs01",
+    "espn_id_new": 4241404
   },
   {
     "mfl_id": 15935,
-    "sleeper_id": 8526,
-    "pfr_id": "GoodCa00",
     "gsis_id": "00-0037315",
-    "yahoo_id": 34180
+    "sleeper_id": 8526,
+    "yahoo_id": 34180,
+    "espn_id": 4035857,
+    "pfr_id": "GoodCa00",
+    "espn_id_new": 4035857
   },
   {
     "mfl_id": 15936,
-    "sleeper_id": 8525,
-    "pfr_id": "RobiMa03",
     "gsis_id": "00-0037316",
+    "sleeper_id": 8525,
+    "yahoo_id": 34181,
     "espn_id": 4249342,
-    "yahoo_id": 34181
+    "pfr_id": "RobiMa03",
+    "espn_id_new": 4249342
   },
   {
     "mfl_id": 15937,
-    "sleeper_id": 8523,
-    "pfr_id": "MuseNi00",
     "gsis_id": "00-0037317",
+    "sleeper_id": 8523,
+    "yahoo_id": 34183,
     "espn_id": 4249624,
-    "yahoo_id": 34183
+    "pfr_id": "MuseNi00",
+    "espn_id_new": 4249624
   },
   {
     "mfl_id": 15938,
     "sleeper_id": 8405,
+    "espn_id": 4240486,
     "pfr_id": "CarpTa00",
-    "espn_id": 4240486
+    "espn_id_new": 4240486
   },
   {
     "mfl_id": 15939,
-    "sleeper_id": 8299,
-    "pfr_id": "SpecBa00",
     "gsis_id": "00-0037318",
-    "yahoo_id": 34187
+    "sleeper_id": 8299,
+    "yahoo_id": 34187,
+    "espn_id": 4239997,
+    "pfr_id": "SpecBa00",
+    "espn_id_new": 4239997
   },
   {
     "mfl_id": 15940,
-    "sleeper_id": 8521,
-    "pfr_id": "HickFa00",
     "gsis_id": "00-0037319",
-    "yahoo_id": 34188
+    "sleeper_id": 8521,
+    "yahoo_id": 34188,
+    "pfr_id": "HickFa00"
   },
   {
     "mfl_id": 15941,
-    "sleeper_id": 8527,
-    "pfr_id": "YounDa02",
     "gsis_id": "00-0037093",
+    "sleeper_id": 8527,
+    "yahoo_id": 34189,
     "espn_id": 4401805,
-    "yahoo_id": 34189
+    "pfr_id": "YounDa02",
+    "espn_id_new": 4401805
   },
   {
     "mfl_id": 15942,
-    "sleeper_id": 8344,
-    "pfr_id": "FordJo00",
     "gsis_id": "00-0037094",
-    "yahoo_id": 34190
+    "sleeper_id": 8344,
+    "yahoo_id": 34190,
+    "pfr_id": "FordJo00"
   },
   {
     "mfl_id": 15943,
-    "sleeper_id": 8520,
-    "pfr_id": "HardDa01",
     "gsis_id": "00-0037843",
-    "espn_id": 4365629,
-    "yahoo_id": 34191
+    "sleeper_id": 8520,
+    "yahoo_id": 34191,
+    "pfr_id": "HardDa01"
   },
   {
     "mfl_id": 15944,
+    "gsis_id": "00-0037320",
     "sleeper_id": 8519,
+    "espn_id": 4690171,
     "pfr_id": "LeonDe00",
-    "gsis_id": "00-0037320"
+    "espn_id_new": 4690171
   },
   {
     "mfl_id": 15945,
-    "sleeper_id": 8264,
-    "pfr_id": "LucaCh01",
     "gsis_id": "00-0037321",
-    "yahoo_id": 34193
+    "sleeper_id": 8264,
+    "yahoo_id": 34193,
+    "espn_id": 4047846,
+    "pfr_id": "LucaCh01",
+    "espn_id_new": 4047846
   },
   {
     "mfl_id": 15946,
-    "sleeper_id": 8517,
-    "pfr_id": "ThomRo07",
     "gsis_id": "00-0037323",
+    "sleeper_id": 8517,
+    "yahoo_id": 34195,
     "espn_id": 4248455,
-    "yahoo_id": 34195
+    "pfr_id": "ThomRo07",
+    "espn_id_new": 4248455
   },
   {
     "mfl_id": 15947,
-    "sleeper_id": 8516,
-    "pfr_id": "HolmCh00",
     "gsis_id": "00-0037095",
+    "sleeper_id": 8516,
+    "yahoo_id": 34196,
     "espn_id": 4035105,
-    "yahoo_id": 34196
+    "pfr_id": "HolmCh00",
+    "espn_id_new": 4035105
   },
   {
     "mfl_id": 15948,
-    "sleeper_id": 8413,
-    "pfr_id": "OladCh00",
     "gsis_id": "00-0037324",
-    "yahoo_id": 34197
+    "sleeper_id": 8413,
+    "yahoo_id": 34197,
+    "pfr_id": "OladCh00"
   },
   {
     "mfl_id": 15949,
-    "sleeper_id": 8312,
-    "pfr_id": "BarnKa00",
     "gsis_id": "00-0037325",
-    "espn_id": 4373017
+    "sleeper_id": 8312,
+    "pfr_id": "BarnKa00"
   },
   {
     "mfl_id": 15950,
-    "sleeper_id": 8373,
-    "pfr_id": "WatsJa02",
     "gsis_id": "00-0037195",
+    "sleeper_id": 8373,
+    "yahoo_id": 34199,
     "espn_id": 4697639,
-    "yahoo_id": 34199
+    "pfr_id": "WatsJa02",
+    "espn_id_new": 4697639
   },
   {
     "mfl_id": 15951,
+    "gsis_id": "00-0037747",
     "sleeper_id": 8515,
+    "espn_id": 4911023,
     "pfr_id": "MattCh01",
-    "gsis_id": "00-0037747"
+    "espn_id_new": 4911023
   },
   {
     "mfl_id": 15952,
-    "sleeper_id": 8512,
-    "pfr_id": "AnthAn00",
     "gsis_id": "00-0037328",
-    "yahoo_id": 34204
+    "sleeper_id": 8512,
+    "yahoo_id": 34204,
+    "pfr_id": "AnthAn00"
   },
   {
     "mfl_id": 15953,
-    "sleeper_id": 8423,
-    "pfr_id": "BrowBr06",
     "gsis_id": "00-0037329",
-    "yahoo_id": 34206
+    "sleeper_id": 8423,
+    "yahoo_id": 34206,
+    "espn_id": 4036032,
+    "pfr_id": "BrowBr06",
+    "espn_id_new": 4036032
   },
   {
     "mfl_id": 15954,
     "sleeper_id": 8402,
-    "yahoo_id": 34208
+    "yahoo_id": 34208,
+    "espn_id": 4241089,
+    "espn_id_new": 4241089
   },
   {
     "mfl_id": 15955,
-    "sleeper_id": 8510,
-    "pfr_id": "YeasRu00",
     "gsis_id": "00-0037844",
-    "yahoo_id": 34209
+    "sleeper_id": 8510,
+    "yahoo_id": 34209,
+    "espn_id": 4240071,
+    "pfr_id": "YeasRu00",
+    "espn_id_new": 4240071
   },
   {
     "mfl_id": 15956,
-    "sleeper_id": 8509,
-    "pfr_id": "HickEl00",
     "gsis_id": "00-0037096",
-    "yahoo_id": 34210
+    "sleeper_id": 8509,
+    "yahoo_id": 34210,
+    "espn_id": 4242402,
+    "pfr_id": "HickEl00",
+    "espn_id_new": 4242402
   },
   {
     "mfl_id": 15957,
     "sleeper_id": 8508,
+    "espn_id": 4240128,
     "pfr_id": "GillTr01",
-    "espn_id": 4240128
+    "espn_id_new": 4240128
   },
   {
     "mfl_id": 15958,
-    "sleeper_id": 8322,
-    "pfr_id": "LukeJe00",
     "gsis_id": "00-0037330",
-    "yahoo_id": 34212
+    "sleeper_id": 8322,
+    "yahoo_id": 34212,
+    "espn_id": 4361419,
+    "pfr_id": "LukeJe00",
+    "espn_id_new": 4361419
   },
   {
     "mfl_id": 15959,
-    "sleeper_id": 8506,
-    "pfr_id": "JohnNa01",
     "gsis_id": "00-0037198",
+    "sleeper_id": 8506,
+    "yahoo_id": 34215,
     "espn_id": 4043625,
-    "yahoo_id": 34215
+    "pfr_id": "JohnNa01",
+    "espn_id_new": 4043625
   },
   {
     "mfl_id": 15960,
-    "sleeper_id": 8428,
-    "pfr_id": "HorvZa00",
     "gsis_id": "00-0037331",
-    "espn_id": 4260406,
-    "yahoo_id": 34216
+    "sleeper_id": 8428,
+    "yahoo_id": 34216,
+    "pfr_id": "HorvZa00"
   },
   {
     "mfl_id": 15961,
-    "sleeper_id": 7202,
     "gsis_id": "00-0036156",
+    "sleeper_id": 7202,
     "yahoo_id": 33000
   },
   {
@@ -13149,8 +13496,8 @@
   },
   {
     "mfl_id": 15963,
-    "sleeper_id": 8224,
     "gsis_id": "00-0037165",
+    "sleeper_id": 8224,
     "yahoo_id": 34275
   },
   {
@@ -13160,16 +13507,17 @@
   },
   {
     "mfl_id": 15965,
-    "sleeper_id": 8254,
-    "pfr_id": "ChesJu00",
     "gsis_id": "00-0037594",
+    "sleeper_id": 8254,
+    "yahoo_id": 34451,
     "espn_id": 4367567,
-    "yahoo_id": 34451
+    "pfr_id": "ChesJu00",
+    "espn_id_new": 4367567
   },
   {
     "mfl_id": 15966,
-    "sleeper_id": 8233,
     "gsis_id": "00-0037226",
+    "sleeper_id": 8233,
     "yahoo_id": 34445
   },
   {
@@ -13179,43 +13527,47 @@
   },
   {
     "mfl_id": 15968,
-    "sleeper_id": 8247,
     "gsis_id": "00-0037233",
+    "sleeper_id": 8247,
     "yahoo_id": 34252
   },
   {
     "mfl_id": 15969,
-    "sleeper_id": 8301,
-    "gsis_id": "00-0037178"
+    "gsis_id": "00-0037178",
+    "sleeper_id": 8301
   },
   {
     "mfl_id": 15970,
-    "sleeper_id": 8249,
-    "pfr_id": "KrulLu00",
     "gsis_id": "00-0037539",
-    "yahoo_id": 34654
+    "sleeper_id": 8249,
+    "yahoo_id": 34654,
+    "espn_id": 4360231,
+    "pfr_id": "KrulLu00",
+    "espn_id_new": 4360231
   },
   {
     "mfl_id": 15971,
-    "sleeper_id": 8236,
     "gsis_id": "00-0037486",
+    "sleeper_id": 8236,
     "yahoo_id": 34516
   },
   {
     "mfl_id": 15972,
-    "sleeper_id": 8408,
-    "pfr_id": "MasoJo00",
     "gsis_id": "00-0037525",
+    "sleeper_id": 8408,
+    "yahoo_id": 34320,
     "espn_id": 4360569,
-    "yahoo_id": 34320
+    "pfr_id": "MasoJo00",
+    "espn_id_new": 4360569
   },
   {
     "mfl_id": 15973,
-    "sleeper_id": 8255,
-    "pfr_id": "BlacRa00",
     "gsis_id": "00-0037429",
+    "sleeper_id": 8255,
+    "yahoo_id": 34617,
     "espn_id": 4259308,
-    "yahoo_id": 34617
+    "pfr_id": "BlacRa00",
+    "espn_id_new": 4259308
   },
   {
     "mfl_id": 15974,
@@ -13224,25 +13576,27 @@
   },
   {
     "mfl_id": 15975,
-    "sleeper_id": 8363,
-    "pfr_id": "SanbJa00",
     "gsis_id": "00-0037109",
+    "sleeper_id": 8363,
+    "yahoo_id": 34370,
     "espn_id": 4372576,
-    "yahoo_id": 34370
+    "pfr_id": "SanbJa00",
+    "espn_id_new": 4372576
   },
   {
     "mfl_id": 15976,
-    "sleeper_id": 8246,
     "gsis_id": "00-0037495",
+    "sleeper_id": 8246,
     "yahoo_id": 34234
   },
   {
     "mfl_id": 15977,
-    "sleeper_id": 8253,
-    "pfr_id": "ThomDe07",
     "gsis_id": "00-0037487",
+    "sleeper_id": 8253,
+    "yahoo_id": 34520,
     "espn_id": 4374187,
-    "yahoo_id": 34520
+    "pfr_id": "ThomDe07",
+    "espn_id_new": 4374187
   },
   {
     "mfl_id": 15978,
@@ -13250,127 +13604,142 @@
   },
   {
     "mfl_id": 15979,
-    "sleeper_id": 8259,
     "gsis_id": "00-0037224",
-    "yahoo_id": 34344
+    "sleeper_id": 8259,
+    "yahoo_id": 34344,
+    "espn_id": 4362081,
+    "espn_id_new": 4362081
   },
   {
     "mfl_id": 15980,
-    "sleeper_id": 8650,
     "gsis_id": "00-0037071",
+    "sleeper_id": 8650,
     "yahoo_id": 34255
   },
   {
     "mfl_id": 15981,
-    "sleeper_id": 8917,
     "gsis_id": "00-0037801",
+    "sleeper_id": 8917,
+    "yahoo_id": 34709,
     "espn_id": 3676833,
-    "yahoo_id": 34709
+    "espn_id_new": 3676833
   },
   {
     "mfl_id": 15982,
-    "sleeper_id": 8263,
-    "pfr_id": "ButlDa00",
     "gsis_id": "00-0037503",
-    "espn_id": 4360466,
-    "yahoo_id": 34536
+    "sleeper_id": 8263,
+    "yahoo_id": 34536,
+    "pfr_id": "ButlDa00"
   },
   {
     "mfl_id": 15983,
-    "sleeper_id": 8801,
-    "pfr_id": "HousDe01",
     "gsis_id": "00-0037570",
-    "yahoo_id": 34592
+    "sleeper_id": 8801,
+    "yahoo_id": 34592,
+    "espn_id": 4572786,
+    "pfr_id": "HousDe01",
+    "espn_id_new": 4572786
   },
   {
     "mfl_id": 15984,
-    "sleeper_id": 8861,
     "gsis_id": "00-0037156",
-    "yahoo_id": 34356
+    "sleeper_id": 8861,
+    "yahoo_id": 34356,
+    "espn_id": 3929636,
+    "espn_id_new": 3929636
   },
   {
     "mfl_id": 15985,
+    "gsis_id": "00-0037561",
     "sleeper_id": 8399,
+    "espn_id": 4241921,
     "pfr_id": "BellMa01",
-    "gsis_id": "00-0037561"
+    "espn_id_new": 4241921
   },
   {
     "mfl_id": 15986,
-    "sleeper_id": 8056,
     "gsis_id": "00-0036873",
+    "sleeper_id": 8056,
     "yahoo_id": 33918
   },
   {
     "mfl_id": 15987,
-    "sleeper_id": 8756,
-    "pfr_id": "JohnBr23",
     "gsis_id": "00-0037382",
-    "yahoo_id": 34571
+    "sleeper_id": 8756,
+    "yahoo_id": 34571,
+    "pfr_id": "JohnBr23"
   },
   {
     "mfl_id": 15988,
-    "sleeper_id": 8731,
     "gsis_id": "00-0037174",
+    "sleeper_id": 8731,
     "yahoo_id": 34387
   },
   {
     "mfl_id": 15989,
-    "sleeper_id": 8275,
-    "pfr_id": "JobeJo00",
     "gsis_id": "00-0037137",
-    "yahoo_id": 34383
+    "sleeper_id": 8275,
+    "yahoo_id": 34383,
+    "pfr_id": "JobeJo00"
   },
   {
     "mfl_id": 15990,
-    "sleeper_id": 8665,
-    "pfr_id": "RogeAr00",
     "gsis_id": "00-0037168",
-    "yahoo_id": 34278
+    "sleeper_id": 8665,
+    "yahoo_id": 34278,
+    "espn_id": 4056052,
+    "pfr_id": "RogeAr00",
+    "espn_id_new": 4056052
   },
   {
     "mfl_id": 15991,
     "sleeper_id": 8849,
-    "yahoo_id": 34513
+    "yahoo_id": 34513,
+    "espn_id": 4047422,
+    "espn_id_new": 4047422
   },
   {
     "mfl_id": 15992,
-    "sleeper_id": 8240,
     "gsis_id": "00-0037115",
+    "sleeper_id": 8240,
     "yahoo_id": 34256
   },
   {
     "mfl_id": 15993,
-    "sleeper_id": 8745,
-    "pfr_id": "McCuLa01",
     "gsis_id": "00-0037055",
+    "sleeper_id": 8745,
+    "yahoo_id": 34330,
     "espn_id": 4247812,
-    "yahoo_id": 34330
+    "pfr_id": "McCuLa01",
+    "espn_id_new": 4247812
   },
   {
     "mfl_id": 15994,
-    "sleeper_id": 8403,
-    "pfr_id": "WeatSt01",
     "gsis_id": "00-0037406",
-    "yahoo_id": 34531
+    "sleeper_id": 8403,
+    "yahoo_id": 34531,
+    "pfr_id": "WeatSt01"
   },
   {
     "mfl_id": 15995,
-    "sleeper_id": 7989,
     "gsis_id": "00-0036527",
     "pff_id": 47663,
-    "yahoo_id": 33813
+    "sleeper_id": 7989,
+    "yahoo_id": 33813,
+    "espn_id": 4036211,
+    "espn_id_new": 4036211
   },
   {
     "mfl_id": 15996,
-    "sleeper_id": 8416,
-    "pfr_id": "VirgJa00",
     "gsis_id": "00-0037387",
-    "yahoo_id": 34579
+    "sleeper_id": 8416,
+    "yahoo_id": 34579,
+    "pfr_id": "VirgJa00"
   },
   {
     "mfl_id": 15997,
-    "sleeper_id": 8602,
     "gsis_id": "00-0037119",
+    "sleeper_id": 8602,
     "yahoo_id": 34260
   },
   {
@@ -13380,135 +13749,152 @@
   },
   {
     "mfl_id": 16000,
-    "sleeper_id": 8197,
-    "pfr_id": "HendPe01",
     "gsis_id": "00-0037569",
-    "espn_id": 4258248,
-    "yahoo_id": 34607
+    "sleeper_id": 8197,
+    "yahoo_id": 34607,
+    "pfr_id": "HendPe01"
   },
   {
     "mfl_id": 16001,
-    "sleeper_id": 8663,
-    "pfr_id": "BernJa00",
     "gsis_id": "00-0037580",
-    "yahoo_id": 34284
+    "sleeper_id": 8663,
+    "yahoo_id": 34284,
+    "pfr_id": "BernJa00"
   },
   {
     "mfl_id": 16002,
-    "sleeper_id": 8577,
     "gsis_id": "00-0037471",
+    "sleeper_id": 8577,
     "yahoo_id": 34633
   },
   {
     "mfl_id": 16003,
-    "sleeper_id": 8530,
     "gsis_id": "00-0037499",
-    "espn_id": 4258210
+    "sleeper_id": 8530
   },
   {
     "mfl_id": 16004,
-    "sleeper_id": 8839,
-    "pfr_id": "MastLu00",
     "gsis_id": "00-0037517",
+    "sleeper_id": 8839,
+    "yahoo_id": 34549,
     "espn_id": 4037212,
-    "yahoo_id": 34549
+    "pfr_id": "MastLu00",
+    "espn_id_new": 4037212
   },
   {
     "mfl_id": 16005,
-    "sleeper_id": 8013,
     "gsis_id": "00-0036497",
+    "sleeper_id": 8013,
+    "yahoo_id": 33649,
     "espn_id": 4245131,
-    "yahoo_id": 33649
+    "espn_id_new": 4245131
   },
   {
     "mfl_id": 16006,
-    "sleeper_id": 8870,
-    "pfr_id": "FatuOl00",
     "gsis_id": "00-0037481",
-    "yahoo_id": 34502
+    "sleeper_id": 8870,
+    "yahoo_id": 34502,
+    "pfr_id": "FatuOl00"
   },
   {
     "mfl_id": 16007,
+    "gsis_id": "00-0037459",
     "sleeper_id": 8547,
+    "espn_id": 4258594,
     "pfr_id": "HiniKu00",
-    "gsis_id": "00-0037459"
+    "espn_id_new": 4258594
   },
   {
     "mfl_id": 16008,
+    "gsis_id": "00-0037184",
     "sleeper_id": 8285,
-    "pfr_id": "RossJo01",
-    "gsis_id": "00-0037184"
+    "pfr_id": "RossJo01"
   },
   {
     "mfl_id": 16009,
-    "sleeper_id": 8680,
-    "pfr_id": "GibbJa00",
     "gsis_id": "00-0037596",
+    "sleeper_id": 8680,
+    "yahoo_id": 34454,
     "espn_id": 4249739,
-    "yahoo_id": 34454
+    "pfr_id": "GibbJa00",
+    "espn_id_new": 4249739
   },
   {
     "mfl_id": 16010,
-    "sleeper_id": 8528
+    "sleeper_id": 8528,
+    "espn_id": 4361823,
+    "espn_id_new": 4361823
   },
   {
     "mfl_id": 16011,
-    "sleeper_id": 8538
+    "sleeper_id": 8538,
+    "espn_id": 4256051,
+    "espn_id_new": 4256051
   },
   {
     "mfl_id": 16013,
-    "sleeper_id": 8659,
-    "pfr_id": "LandNa01",
     "gsis_id": "00-0037587",
-    "yahoo_id": 34291
+    "sleeper_id": 8659,
+    "yahoo_id": 34291,
+    "espn_id": 4243181,
+    "pfr_id": "LandNa01",
+    "espn_id_new": 4243181
   },
   {
     "mfl_id": 16014,
-    "sleeper_id": 8860,
-    "pfr_id": "AdamTo03",
     "gsis_id": "00-0037155",
-    "yahoo_id": 34355
+    "sleeper_id": 8860,
+    "yahoo_id": 34355,
+    "espn_id": 4240532,
+    "pfr_id": "AdamTo03",
+    "espn_id_new": 4240532
   },
   {
     "mfl_id": 16015,
-    "sleeper_id": 8783,
     "gsis_id": "00-0037422",
+    "sleeper_id": 8783,
     "yahoo_id": 34476
   },
   {
     "mfl_id": 16016,
-    "sleeper_id": 8857,
-    "pfr_id": "KohoKa00",
     "gsis_id": "00-0037353",
-    "yahoo_id": 34529
+    "sleeper_id": 8857,
+    "yahoo_id": 34529,
+    "espn_id": 4291489,
+    "pfr_id": "KohoKa00",
+    "espn_id_new": 4291489
   },
   {
     "mfl_id": 16017,
-    "sleeper_id": 8733,
-    "pfr_id": "HummJa00",
     "gsis_id": "00-0037633",
-    "yahoo_id": 34342
+    "sleeper_id": 8733,
+    "yahoo_id": 34342,
+    "pfr_id": "HummJa00"
   },
   {
     "mfl_id": 16018,
-    "sleeper_id": 8406,
-    "pfr_id": "BlanRe00",
     "gsis_id": "00-0037130",
-    "yahoo_id": 34376
+    "sleeper_id": 8406,
+    "yahoo_id": 34376,
+    "espn_id": 4243956,
+    "pfr_id": "BlanRe00",
+    "espn_id_new": 4243956
   },
   {
     "mfl_id": 16019,
+    "gsis_id": "00-0037457",
     "sleeper_id": 8349,
+    "espn_id": 4033812,
     "pfr_id": "HansJa01",
-    "gsis_id": "00-0037457"
+    "espn_id_new": 4033812
   },
   {
     "mfl_id": 16020,
-    "sleeper_id": 7878,
-    "pfr_id": "EiflMi00",
     "gsis_id": "00-0036511",
     "pff_id": 43421,
-    "yahoo_id": 33696
+    "sleeper_id": 7878,
+    "yahoo_id": 33696,
+    "pfr_id": "EiflMi00"
   },
   {
     "mfl_id": 16021,
@@ -13516,77 +13902,94 @@
   },
   {
     "mfl_id": 16022,
-    "sleeper_id": 8241,
-    "pfr_id": "BrowAn06",
     "gsis_id": "00-0037175",
-    "yahoo_id": 34389
+    "sleeper_id": 8241,
+    "yahoo_id": 34389,
+    "espn_id": 4035312,
+    "pfr_id": "BrowAn06",
+    "espn_id_new": 4035312
   },
   {
     "mfl_id": 16023,
-    "sleeper_id": 8795,
-    "pfr_id": "BellDA03",
     "gsis_id": "00-0037332",
-    "yahoo_id": 34475
+    "sleeper_id": 8795,
+    "yahoo_id": 34475,
+    "espn_id": 4608386,
+    "pfr_id": "BellDA03",
+    "espn_id_new": 4608386
   },
   {
     "mfl_id": 16024,
+    "gsis_id": "00-0037585",
     "sleeper_id": 8654,
+    "espn_id": 4045701,
     "pfr_id": "HornTi00",
-    "gsis_id": "00-0037585"
+    "espn_id_new": 4045701
   },
   {
     "mfl_id": 16025,
-    "sleeper_id": 8820,
-    "pfr_id": "HairTr00",
     "gsis_id": "00-0037456",
+    "sleeper_id": 8820,
+    "yahoo_id": 34597,
     "espn_id": 4274040,
-    "yahoo_id": 34597
+    "pfr_id": "HairTr00",
+    "espn_id_new": 4274040
   },
   {
     "mfl_id": 16026,
+    "gsis_id": "00-0037106",
     "sleeper_id": 8702,
+    "espn_id": 4047655,
     "pfr_id": "JoneJa12",
-    "gsis_id": "00-0037106"
+    "espn_id_new": 4047655
   },
   {
     "mfl_id": 16029,
+    "gsis_id": "00-0037593",
     "sleeper_id": 8925,
+    "espn_id": 4259300,
     "pfr_id": "AverTr01",
-    "gsis_id": "00-0037593"
+    "espn_id_new": 4259300
   },
   {
     "mfl_id": 16030,
-    "sleeper_id": 8854,
-    "pfr_id": "FoxxTo00",
     "gsis_id": "00-0037447",
-    "espn_id": 4037520
+    "sleeper_id": 8854,
+    "espn_id": 4037520,
+    "pfr_id": "FoxxTo00",
+    "espn_id_new": 4037520
   },
   {
     "mfl_id": 16036,
-    "sleeper_id": 8698,
-    "pfr_id": "TongJa00",
     "gsis_id": "00-0037112",
-    "yahoo_id": 34374
+    "sleeper_id": 8698,
+    "yahoo_id": 34374,
+    "pfr_id": "TongJa00"
   },
   {
     "mfl_id": 16037,
-    "sleeper_id": 7233,
     "gsis_id": "00-0035876",
     "pff_id": 47901,
+    "sleeper_id": 7233,
+    "yahoo_id": 32943,
     "espn_id": 3886809,
-    "yahoo_id": 32943
+    "espn_id_new": 3886809
   },
   {
     "mfl_id": 16043,
-    "sleeper_id": 8932,
     "gsis_id": "00-0038152",
-    "yahoo_id": 34720
+    "sleeper_id": 8932,
+    "yahoo_id": 34720,
+    "espn_id": 4245661,
+    "espn_id_new": 4245661
   },
   {
     "mfl_id": 16045,
+    "gsis_id": "00-0037205",
     "sleeper_id": 8726,
+    "espn_id": 4047941,
     "pfr_id": "SchoBr00",
-    "gsis_id": "00-0037205"
+    "espn_id_new": 4047941
   },
   {
     "mfl_id": 16049,
@@ -13594,40 +13997,47 @@
   },
   {
     "mfl_id": 16050,
-    "sleeper_id": 8732,
-    "pfr_id": "WebbRa02",
     "gsis_id": "00-0037185",
-    "yahoo_id": 34407
+    "sleeper_id": 8732,
+    "yahoo_id": 34407,
+    "espn_id": 4032247,
+    "pfr_id": "WebbRa02",
+    "espn_id_new": 4032247
   },
   {
     "mfl_id": 16052,
+    "gsis_id": "00-0037516",
     "sleeper_id": 8844,
-    "pfr_id": "WebbSa00",
-    "gsis_id": "00-0037516"
+    "pfr_id": "WebbSa00"
   },
   {
     "mfl_id": 16054,
+    "gsis_id": "00-0037129",
     "sleeper_id": 8714,
+    "espn_id": 4240459,
     "pfr_id": "BlacJo00",
-    "gsis_id": "00-0037129"
+    "espn_id_new": 4240459
   },
   {
     "mfl_id": 16055,
+    "gsis_id": "00-0037431",
     "sleeper_id": 8776,
+    "espn_id": 4240405,
     "pfr_id": "JonaKi00",
-    "gsis_id": "00-0037431"
+    "espn_id_new": 4240405
   },
   {
     "mfl_id": 16056,
+    "gsis_id": "00-0037662",
     "sleeper_id": 8898,
-    "pfr_id": "BrewCJ00",
-    "gsis_id": "00-0037662"
+    "pfr_id": "BrewCJ00"
   },
   {
     "mfl_id": 16058,
-    "sleeper_id": 8001,
     "gsis_id": "00-0036682",
-    "espn_id": 4259547
+    "sleeper_id": 8001,
+    "espn_id": 4259547,
+    "espn_id_new": 4259547
   },
   {
     "mfl_id": 16059,
@@ -13635,60 +14045,67 @@
   },
   {
     "mfl_id": 16063,
-    "sleeper_id": 8618,
-    "gsis_id": "00-0037526"
+    "gsis_id": "00-0037526",
+    "sleeper_id": 8618
   },
   {
     "mfl_id": 16064,
-    "sleeper_id": 8833,
-    "pfr_id": "FlowDa00",
     "gsis_id": "00-0037395",
-    "yahoo_id": 34503
+    "sleeper_id": 8833,
+    "yahoo_id": 34503,
+    "espn_id": 4917592,
+    "pfr_id": "FlowDa00",
+    "espn_id_new": 4917592
   },
   {
     "mfl_id": 16066,
-    "sleeper_id": 8921,
     "gsis_id": "00-0037708",
+    "sleeper_id": 8921,
     "yahoo_id": 34712
   },
   {
     "mfl_id": 16068,
+    "gsis_id": "00-0037660",
     "sleeper_id": 8899,
-    "pfr_id": "EmilPr00",
-    "gsis_id": "00-0037660"
+    "pfr_id": "EmilPr00"
   },
   {
     "mfl_id": 16072,
+    "gsis_id": "00-0037208",
     "sleeper_id": 8710,
+    "espn_id": 4249766,
     "pfr_id": "CochJa00",
-    "gsis_id": "00-0037208"
+    "espn_id_new": 4249766
   },
   {
     "mfl_id": 16075,
-    "sleeper_id": 8683,
-    "pfr_id": "BlouJo00",
     "gsis_id": "00-0037141",
-    "yahoo_id": 34388
+    "sleeper_id": 8683,
+    "yahoo_id": 34388,
+    "espn_id": 4240824,
+    "pfr_id": "BlouJo00",
+    "espn_id_new": 4240824
   },
   {
     "mfl_id": 16077,
+    "gsis_id": "00-0037602",
     "sleeper_id": 8540,
-    "pfr_id": "OkuaSa00",
-    "gsis_id": "00-0037602"
+    "pfr_id": "OkuaSa00"
   },
   {
     "mfl_id": 16080,
-    "sleeper_id": 8676,
-    "pfr_id": "ShahRa00",
     "gsis_id": "00-0037545",
+    "sleeper_id": 8676,
+    "yahoo_id": 34659,
     "espn_id": 4032473,
-    "yahoo_id": 34659
+    "pfr_id": "ShahRa00",
+    "espn_id_new": 4032473
   },
   {
     "mfl_id": 16082,
+    "gsis_id": "00-0037364",
     "sleeper_id": 8569,
-    "pfr_id": "MosbAr00",
-    "gsis_id": "00-0037364"
+    "pfr_id": "MosbAr00"
   },
   {
     "mfl_id": 16086,
@@ -13697,9 +14114,11 @@
   },
   {
     "mfl_id": 16087,
+    "gsis_id": "00-0037621",
     "sleeper_id": 8874,
+    "espn_id": 4242430,
     "pfr_id": "AndeRy01",
-    "gsis_id": "00-0037621"
+    "espn_id_new": 4242430
   },
   {
     "mfl_id": 16088,
@@ -13707,9 +14126,11 @@
   },
   {
     "mfl_id": 16091,
+    "gsis_id": "00-0037356",
     "sleeper_id": 8850,
+    "espn_id": 4034861,
     "pfr_id": "StilBe00",
-    "gsis_id": "00-0037356"
+    "espn_id_new": 4034861
   },
   {
     "mfl_id": 16093,
@@ -13718,9 +14139,11 @@
   },
   {
     "mfl_id": 16094,
+    "gsis_id": "00-0037491",
     "sleeper_id": 8869,
+    "espn_id": 4243366,
     "pfr_id": "RussJJ00",
-    "gsis_id": "00-0037491"
+    "espn_id_new": 4243366
   },
   {
     "mfl_id": 16095,
@@ -13729,28 +14152,30 @@
   },
   {
     "mfl_id": 16096,
-    "sleeper_id": 8419,
-    "pfr_id": "BerrSt00",
     "gsis_id": "00-0037581",
-    "yahoo_id": 34285
+    "sleeper_id": 8419,
+    "yahoo_id": 34285,
+    "pfr_id": "BerrSt00"
   },
   {
     "mfl_id": 16097,
-    "sleeper_id": 8595,
     "gsis_id": "00-0037172",
+    "sleeper_id": 8595,
     "yahoo_id": 34276
   },
   {
     "mfl_id": 16098,
-    "sleeper_id": 7390,
     "gsis_id": "00-0036148",
+    "sleeper_id": 7390,
     "yahoo_id": 33332
   },
   {
     "mfl_id": 16099,
+    "gsis_id": "00-0037560",
     "sleeper_id": 8635,
+    "espn_id": 4242515,
     "pfr_id": "WootCh00",
-    "gsis_id": "00-0037560"
+    "espn_id_new": 4242515
   },
   {
     "mfl_id": 16101,
@@ -13758,29 +14183,32 @@
   },
   {
     "mfl_id": 16102,
+    "gsis_id": "00-0037512",
     "sleeper_id": 8838,
+    "espn_id": 4259632,
     "pfr_id": "PolaIs00",
-    "gsis_id": "00-0037512"
+    "espn_id_new": 4259632
   },
   {
     "mfl_id": 16103,
+    "gsis_id": "00-0037341",
     "sleeper_id": 8794,
-    "pfr_id": "PerrRo01",
-    "gsis_id": "00-0037341"
+    "pfr_id": "PerrRo01"
   },
   {
     "mfl_id": 16113,
-    "sleeper_id": 8583,
-    "pfr_id": "SmarSt00",
     "gsis_id": "00-0037475",
+    "sleeper_id": 8583,
+    "yahoo_id": 34637,
     "espn_id": 4250764,
-    "yahoo_id": 34637
+    "pfr_id": "SmarSt00",
+    "espn_id_new": 4250764
   },
   {
     "mfl_id": 16114,
+    "gsis_id": "00-0037153",
     "sleeper_id": 8691,
-    "pfr_id": "JoneVi00",
-    "gsis_id": "00-0037153"
+    "pfr_id": "JoneVi00"
   },
   {
     "mfl_id": 16115,
@@ -13789,60 +14217,65 @@
   },
   {
     "mfl_id": 16116,
-    "sleeper_id": 8765,
-    "gsis_id": "00-0037373"
+    "gsis_id": "00-0037373",
+    "sleeper_id": 8765
   },
   {
     "mfl_id": 16117,
+    "gsis_id": "00-0037222",
     "sleeper_id": 8719,
-    "pfr_id": "ThomAJ00",
-    "gsis_id": "00-0037222"
+    "pfr_id": "ThomAJ00"
   },
   {
     "mfl_id": 16118,
-    "sleeper_id": 8532,
-    "pfr_id": "BrowMi02",
     "gsis_id": "00-0037493",
-    "yahoo_id": 34232
+    "sleeper_id": 8532,
+    "yahoo_id": 34232,
+    "espn_id": 4244310,
+    "pfr_id": "BrowMi02",
+    "espn_id_new": 4244310
   },
   {
     "mfl_id": 16119,
-    "sleeper_id": 8546,
-    "gsis_id": "00-0037464"
+    "gsis_id": "00-0037464",
+    "sleeper_id": 8546
   },
   {
     "mfl_id": 16120,
-    "sleeper_id": 7746,
-    "pfr_id": "TramAu00",
     "gsis_id": "00-0036841",
     "pff_id": 52195,
-    "yahoo_id": 33745
+    "sleeper_id": 7746,
+    "yahoo_id": 33745,
+    "espn_id": 4244856,
+    "pfr_id": "TramAu00",
+    "espn_id_new": 4244856
   },
   {
     "mfl_id": 16121,
-    "sleeper_id": 8739,
     "gsis_id": "00-0037057",
-    "espn_id": 4038843
+    "sleeper_id": 8739,
+    "espn_id": 4038843,
+    "espn_id_new": 4038843
   },
   {
     "mfl_id": 16122,
-    "sleeper_id": 8871,
-    "pfr_id": "TurnNo00",
     "gsis_id": "00-0037488",
-    "yahoo_id": 34517
+    "sleeper_id": 8871,
+    "yahoo_id": 34517,
+    "pfr_id": "TurnNo00"
   },
   {
     "mfl_id": 16124,
+    "gsis_id": "00-0037401",
     "sleeper_id": 8836,
-    "pfr_id": "RhynFo00",
-    "gsis_id": "00-0037401"
+    "pfr_id": "RhynFo00"
   },
   {
     "mfl_id": 16125,
-    "sleeper_id": 8928,
-    "pfr_id": "BaldDa01",
     "gsis_id": "00-0038147",
-    "yahoo_id": 34713
+    "sleeper_id": 8928,
+    "yahoo_id": 34713,
+    "pfr_id": "BaldDa01"
   },
   {
     "mfl_id": 16127,
@@ -13850,20 +14283,22 @@
   },
   {
     "mfl_id": 16129,
-    "sleeper_id": 8788,
-    "gsis_id": "00-0037415"
+    "gsis_id": "00-0037415",
+    "sleeper_id": 8788
   },
   {
     "mfl_id": 16131,
+    "gsis_id": "00-0037375",
     "sleeper_id": 8288,
-    "pfr_id": "HintCh01",
-    "gsis_id": "00-0037375"
+    "pfr_id": "HintCh01"
   },
   {
     "mfl_id": 16132,
+    "gsis_id": "00-0037468",
     "sleeper_id": 8578,
+    "espn_id": 4258237,
     "pfr_id": "LaynRa00",
-    "gsis_id": "00-0037468"
+    "espn_id_new": 4258237
   },
   {
     "mfl_id": 16133,
@@ -13871,469 +14306,588 @@
   },
   {
     "mfl_id": 16135,
-    "sleeper_id": 8107,
-    "pfr_id": "KaliNi00",
     "gsis_id": "00-0037031",
-    "yahoo_id": 33950
+    "sleeper_id": 8107,
+    "yahoo_id": 33950,
+    "pfr_id": "KaliNi00"
   },
   {
     "mfl_id": 16136,
-    "sleeper_id": 7410,
     "gsis_id": "00-0036447",
     "pff_id": 117753,
-    "espn_id": 4686421,
+    "sleeper_id": 7410,
     "yahoo_id": 33185
   },
   {
     "mfl_id": 16137,
+    "gsis_id": "00-0037181",
     "sleeper_id": 8552,
-    "pfr_id": "NichRa00",
-    "gsis_id": "00-0037181"
+    "pfr_id": "NichRa00"
   },
   {
     "mfl_id": 16138,
+    "gsis_id": "00-0037527",
     "sleeper_id": 8620,
+    "espn_id": 4260703,
     "pfr_id": "OlubSe00",
-    "gsis_id": "00-0037527"
+    "espn_id_new": 4260703
   },
   {
     "mfl_id": 16139,
-    "sleeper_id": 8666,
     "gsis_id": "00-0037549",
-    "yahoo_id": 34302
+    "sleeper_id": 8666,
+    "yahoo_id": 34302,
+    "espn_id": 4036660,
+    "espn_id_new": 4036660
   },
   {
     "mfl_id": 16140,
+    "gsis_id": "00-0037639",
     "sleeper_id": 8889,
-    "pfr_id": "KwenWi00",
-    "gsis_id": "00-0037639"
+    "pfr_id": "KwenWi00"
   },
   {
     "mfl_id": 16144,
+    "gsis_id": "00-0037051",
     "sleeper_id": 8736,
-    "pfr_id": "GarcEl00",
-    "gsis_id": "00-0037051"
+    "pfr_id": "GarcEl00"
   },
   {
     "mfl_id": 16145,
     "sleeper_id": 8752,
-    "yahoo_id": 34574
+    "yahoo_id": 34574,
+    "espn_id": 4567462,
+    "espn_id_new": 4567462
   },
   {
     "mfl_id": 16148,
-    "sleeper_id": 9228,
-    "pfr_id": "YounBr01",
     "gsis_id": "00-0039150",
-    "yahoo_id": 40029
+    "sleeper_id": 9228,
+    "yahoo_id": 40029,
+    "espn_id": 4685720,
+    "pfr_id": "YounBr01",
+    "espn_id_new": 4685720
   },
   {
     "mfl_id": 16149,
-    "sleeper_id": 9999,
-    "pfr_id": "LeviWi00",
     "gsis_id": "00-0039152",
-    "yahoo_id": 40068
+    "sleeper_id": 9999,
+    "yahoo_id": 40068,
+    "espn_id": 4361418,
+    "pfr_id": "LeviWi00",
+    "espn_id_new": 4361418
   },
   {
     "mfl_id": 16150,
-    "sleeper_id": 9758,
-    "pfr_id": "StroCJ00",
     "gsis_id": "00-0039163",
-    "yahoo_id": 40030
+    "sleeper_id": 9758,
+    "yahoo_id": 40030,
+    "espn_id": 4432577,
+    "pfr_id": "StroCJ00",
+    "espn_id_new": 4432577
   },
   {
     "mfl_id": 16151,
-    "sleeper_id": 9998,
-    "pfr_id": "HookHe00",
     "gsis_id": "00-0038550",
-    "yahoo_id": 40096
+    "sleeper_id": 9998,
+    "yahoo_id": 40096,
+    "espn_id": 4240858,
+    "pfr_id": "HookHe00",
+    "espn_id_new": 4240858
   },
   {
     "mfl_id": 16152,
-    "sleeper_id": 9229,
-    "pfr_id": "RichAn03",
     "gsis_id": "00-0039164",
-    "yahoo_id": 40040
+    "sleeper_id": 9229,
+    "yahoo_id": 40040,
+    "espn_id": 4429084,
+    "pfr_id": "RichAn03",
+    "espn_id_new": 4429084
   },
   {
     "mfl_id": 16153,
-    "sleeper_id": 10857,
-    "pfr_id": "BennSt00",
     "gsis_id": "00-0039107",
-    "yahoo_id": 40153
+    "sleeper_id": 10857,
+    "yahoo_id": 40153,
+    "espn_id": 4259553,
+    "pfr_id": "BennSt00",
+    "espn_id_new": 4259553
   },
   {
     "mfl_id": 16154,
-    "sleeper_id": 9231,
-    "pfr_id": "HallJa00",
     "gsis_id": "00-0038598",
-    "yahoo_id": 40185
+    "sleeper_id": 9231,
+    "yahoo_id": 40185,
+    "espn_id": 4373632,
+    "pfr_id": "HallJa00",
+    "espn_id_new": 4373632
   },
   {
     "mfl_id": 16155,
-    "sleeper_id": 10233,
-    "pfr_id": "DuggMa00",
     "gsis_id": "00-0038637",
-    "yahoo_id": 40272
+    "sleeper_id": 10233,
+    "yahoo_id": 40272,
+    "espn_id": 4427105,
+    "pfr_id": "DuggMa00",
+    "espn_id_new": 4427105
   },
   {
     "mfl_id": 16156,
-    "sleeper_id": 10215,
-    "pfr_id": "HaenJa00",
     "gsis_id": "00-0038998",
-    "yahoo_id": 40144
+    "sleeper_id": 10215,
+    "yahoo_id": 40144,
+    "espn_id": 4243322,
+    "pfr_id": "HaenJa00",
+    "espn_id_new": 4243322
   },
   {
     "mfl_id": 16157,
-    "sleeper_id": 10860,
-    "pfr_id": "CunnMa00",
     "gsis_id": "00-0038911",
-    "yahoo_id": 40290
+    "sleeper_id": 10860,
+    "yahoo_id": 40290,
+    "espn_id": 4240069,
+    "pfr_id": "CunnMa00",
+    "espn_id_new": 4240069
   },
   {
     "mfl_id": 16158,
-    "sleeper_id": 10862,
-    "pfr_id": "ThomDo02",
     "gsis_id": "00-0038583",
-    "yahoo_id": 40195
+    "sleeper_id": 10862,
+    "yahoo_id": 40195,
+    "espn_id": 4367178,
+    "pfr_id": "ThomDo02",
+    "espn_id_new": 4367178
   },
   {
     "mfl_id": 16159,
-    "sleeper_id": 10866,
-    "pfr_id": "OConAi00",
     "gsis_id": "00-0038579",
-    "yahoo_id": 40138
+    "sleeper_id": 10866,
+    "yahoo_id": 40138,
+    "espn_id": 4260394,
+    "pfr_id": "OConAi00",
+    "espn_id_new": 4260394
   },
   {
     "mfl_id": 16160,
-    "sleeper_id": 10217,
-    "pfr_id": "TuneCl00",
     "gsis_id": "00-0038582",
-    "yahoo_id": 40188
+    "sleeper_id": 10217,
+    "yahoo_id": 40188,
+    "espn_id": 4360175,
+    "pfr_id": "TuneCl00",
+    "espn_id_new": 4360175
   },
   {
     "mfl_id": 16161,
-    "sleeper_id": 9509,
-    "pfr_id": "RobiBi01",
     "gsis_id": "00-0038542",
-    "yahoo_id": 40055
+    "sleeper_id": 9509,
+    "yahoo_id": 40055,
+    "espn_id": 4430807,
+    "pfr_id": "RobiBi01",
+    "espn_id_new": 4430807
   },
   {
     "mfl_id": 16162,
-    "sleeper_id": 9221,
-    "pfr_id": "GibbJa01",
     "gsis_id": "00-0039139",
-    "yahoo_id": 40059
+    "sleeper_id": 9221,
+    "yahoo_id": 40059,
+    "espn_id": 4429795,
+    "pfr_id": "GibbJa01",
+    "espn_id_new": 4429795
   },
   {
     "mfl_id": 16163,
-    "sleeper_id": 9222,
-    "pfr_id": "EvanZa00",
     "gsis_id": "00-0039136",
-    "yahoo_id": 40243
+    "sleeper_id": 9222,
+    "yahoo_id": 40243,
+    "espn_id": 4685035,
+    "pfr_id": "EvanZa00",
+    "espn_id_new": 4685035
   },
   {
     "mfl_id": 16164,
-    "sleeper_id": 9225,
-    "pfr_id": "BigsTa00",
     "gsis_id": "00-0038555",
-    "yahoo_id": 40095
+    "sleeper_id": 9225,
+    "yahoo_id": 40095,
+    "espn_id": 4429013,
+    "pfr_id": "BigsTa00",
+    "espn_id_new": 4429013
   },
   {
     "mfl_id": 16165,
-    "sleeper_id": 9508,
-    "pfr_id": "SpeaTy00",
     "gsis_id": "00-0039032",
-    "yahoo_id": 40119
+    "sleeper_id": 9508,
+    "yahoo_id": 40119,
+    "espn_id": 4428557,
+    "pfr_id": "SpeaTy00",
+    "espn_id_new": 4428557
   },
   {
     "mfl_id": 16166,
-    "sleeper_id": 9506,
-    "pfr_id": "TuckSe00",
     "gsis_id": "00-0038951",
-    "yahoo_id": 40742
+    "sleeper_id": 9506,
+    "yahoo_id": 40742,
+    "espn_id": 4430871,
+    "pfr_id": "TuckSe00",
+    "espn_id_new": 4430871
   },
   {
     "mfl_id": 16167,
-    "sleeper_id": 9226,
-    "pfr_id": "AchaDe00",
     "gsis_id": "00-0039040",
-    "yahoo_id": 40118
+    "sleeper_id": 9226,
+    "yahoo_id": 40118,
+    "espn_id": 4429160,
+    "pfr_id": "AchaDe00",
+    "espn_id_new": 4429160
   },
   {
     "mfl_id": 16168,
-    "sleeper_id": 9227,
-    "pfr_id": "AbanIs00",
     "gsis_id": "00-0038389",
-    "yahoo_id": 40165
+    "sleeper_id": 9227,
+    "yahoo_id": 40165,
+    "espn_id": 4429202,
+    "pfr_id": "AbanIs00",
+    "espn_id_new": 4429202
   },
   {
     "mfl_id": 16169,
-    "sleeper_id": 9753,
-    "pfr_id": "CharZa00",
     "gsis_id": "00-0039165",
-    "yahoo_id": 40075
+    "sleeper_id": 9753,
+    "yahoo_id": 40075,
+    "espn_id": 4426385,
+    "pfr_id": "CharZa00",
+    "espn_id_new": 4426385
   },
   {
     "mfl_id": 16170,
-    "sleeper_id": 10216,
-    "pfr_id": "McInKe00",
     "gsis_id": "00-0038636",
-    "yahoo_id": 40267
+    "sleeper_id": 10216,
+    "yahoo_id": 40267,
+    "espn_id": 4427391,
+    "pfr_id": "McInKe00",
+    "espn_id_new": 4427391
   },
   {
     "mfl_id": 16171,
-    "sleeper_id": 9757,
-    "pfr_id": "MillKe01",
     "gsis_id": "00-0038551",
-    "yahoo_id": 40108
+    "sleeper_id": 9757,
+    "yahoo_id": 40108,
+    "espn_id": 4599739,
+    "pfr_id": "MillKe01",
+    "espn_id_new": 4599739
   },
   {
     "mfl_id": 16172,
-    "sleeper_id": 10651,
-    "pfr_id": "IbraMo00",
     "gsis_id": "00-0038656",
-    "yahoo_id": 40586
+    "sleeper_id": 10651,
+    "yahoo_id": 40586,
+    "espn_id": 4240750,
+    "pfr_id": "IbraMo00",
+    "espn_id_new": 4240750
   },
   {
     "mfl_id": 16173,
-    "sleeper_id": 10223,
-    "pfr_id": "GrayEr01",
     "gsis_id": "00-0038396",
-    "yahoo_id": 40198
+    "sleeper_id": 10223,
+    "yahoo_id": 40198,
+    "espn_id": 4570561,
+    "pfr_id": "GrayEr01",
+    "espn_id_new": 4570561
   },
   {
     "mfl_id": 16174,
-    "sleeper_id": 10219,
-    "pfr_id": "RodrCh00",
     "gsis_id": "00-0038611",
-    "yahoo_id": 40231
+    "sleeper_id": 10219,
+    "yahoo_id": 40231,
+    "espn_id": 4362619,
+    "pfr_id": "RodrCh00",
+    "espn_id_new": 4362619
   },
   {
     "mfl_id": 16175,
-    "sleeper_id": 10235,
-    "pfr_id": "JohnRo07",
     "gsis_id": "00-0039021",
-    "yahoo_id": 40162
+    "sleeper_id": 10235,
+    "yahoo_id": 40162,
+    "espn_id": 4426386,
+    "pfr_id": "JohnRo07",
+    "espn_id_new": 4426386
   },
   {
     "mfl_id": 16176,
-    "sleeper_id": 9505,
-    "pfr_id": "VaugDe00",
     "gsis_id": "00-0038622",
-    "yahoo_id": 40240
+    "sleeper_id": 9505,
+    "yahoo_id": 40240,
+    "espn_id": 4431453,
+    "pfr_id": "VaugDe00",
+    "espn_id_new": 4431453
   },
   {
     "mfl_id": 16177,
-    "sleeper_id": 10865,
-    "gsis_id": "00-0038495"
+    "gsis_id": "00-0038495",
+    "sleeper_id": 10865
   },
   {
     "mfl_id": 16178,
-    "sleeper_id": 9511,
-    "pfr_id": "MitcKe01",
     "gsis_id": "00-0038454",
-    "yahoo_id": 40641
+    "sleeper_id": 9511,
+    "yahoo_id": 40641,
+    "espn_id": 4596334,
+    "pfr_id": "MitcKe01",
+    "espn_id_new": 4596334
   },
   {
     "mfl_id": 16179,
-    "sleeper_id": 9512,
-    "pfr_id": "McBrDe00",
     "gsis_id": "00-0039046",
-    "yahoo_id": 40285
+    "sleeper_id": 9512,
+    "yahoo_id": 40285,
+    "espn_id": 4430388,
+    "pfr_id": "McBrDe00",
+    "espn_id_new": 4430388
   },
   {
     "mfl_id": 16180,
-    "sleeper_id": 9220,
-    "pfr_id": "HullEv00",
     "gsis_id": "00-0038397",
-    "yahoo_id": 40169
+    "sleeper_id": 9220,
+    "yahoo_id": 40169,
+    "espn_id": 4569609,
+    "pfr_id": "HullEv00",
+    "espn_id_new": 4569609
   },
   {
     "mfl_id": 16181,
-    "sleeper_id": 9224,
-    "pfr_id": "BrowCh10",
     "gsis_id": "00-0038597",
-    "yahoo_id": 40196
+    "sleeper_id": 9224,
+    "yahoo_id": 40196,
+    "espn_id": 4362238,
+    "pfr_id": "BrowCh10",
+    "espn_id_new": 4362238
   },
   {
     "mfl_id": 16182,
-    "sleeper_id": 10211,
     "gsis_id": "00-0038777",
+    "sleeper_id": 10211,
     "yahoo_id": 40587
   },
   {
     "mfl_id": 16183,
-    "sleeper_id": 9497,
-    "pfr_id": "HyatJa00",
     "gsis_id": "00-0038938",
-    "yahoo_id": 40128
+    "sleeper_id": 9497,
+    "yahoo_id": 40128,
+    "espn_id": 4692590,
+    "pfr_id": "HyatJa00",
+    "espn_id_new": 4692590
   },
   {
     "mfl_id": 16184,
-    "sleeper_id": 10222,
-    "pfr_id": "ReedJa03",
     "gsis_id": "00-0039146",
-    "yahoo_id": 40063
+    "sleeper_id": 10222,
+    "yahoo_id": 40063,
+    "espn_id": 4362249,
+    "pfr_id": "ReedJa03",
+    "espn_id_new": 4362249
   },
   {
     "mfl_id": 16185,
-    "sleeper_id": 9488,
-    "pfr_id": "SmitJa06",
     "gsis_id": "00-0038543",
-    "yahoo_id": 40041
+    "sleeper_id": 9488,
+    "yahoo_id": 40041,
+    "espn_id": 4430878,
+    "pfr_id": "SmitJa06",
+    "espn_id_new": 4430878
   },
   {
     "mfl_id": 16186,
-    "sleeper_id": 9756,
-    "pfr_id": "AddiJo00",
     "gsis_id": "00-0038994",
-    "yahoo_id": 40042
+    "sleeper_id": 9756,
+    "yahoo_id": 40042,
+    "espn_id": 4429205,
+    "pfr_id": "AddiJo00",
+    "espn_id_new": 4429205
   },
   {
     "mfl_id": 16187,
-    "sleeper_id": 9500,
-    "pfr_id": "DownJo00",
     "gsis_id": "00-0038997",
-    "yahoo_id": 40126
+    "sleeper_id": 9500,
+    "yahoo_id": 40126,
+    "espn_id": 4688813,
+    "pfr_id": "DownJo00",
+    "espn_id_new": 4688813
   },
   {
     "mfl_id": 16188,
-    "sleeper_id": 9754,
-    "pfr_id": "JohnQu02",
     "gsis_id": "00-0038544",
-    "yahoo_id": 40051
+    "sleeper_id": 9754,
+    "yahoo_id": 40051,
+    "espn_id": 4429025,
+    "pfr_id": "JohnQu02",
+    "espn_id_new": 4429025
   },
   {
     "mfl_id": 16189,
-    "sleeper_id": 9494,
-    "pfr_id": "MimsMa00",
     "gsis_id": "00-0038976",
-    "yahoo_id": 40090
+    "sleeper_id": 9494,
+    "yahoo_id": 40090,
+    "espn_id": 4686472,
+    "pfr_id": "MimsMa00",
+    "espn_id_new": 4686472
   },
   {
     "mfl_id": 16190,
-    "sleeper_id": 9997,
-    "pfr_id": "FlowZa00",
     "gsis_id": "00-0039064",
-    "yahoo_id": 40039
+    "sleeper_id": 9997,
+    "yahoo_id": 40039,
+    "espn_id": 4429615,
+    "pfr_id": "FlowZa00",
+    "espn_id_new": 4429615
   },
   {
     "mfl_id": 16191,
-    "sleeper_id": 10444,
-    "pfr_id": "TillCe01",
     "gsis_id": "00-0038979",
-    "yahoo_id": 40093
+    "sleeper_id": 10444,
+    "yahoo_id": 40093,
+    "espn_id": 4369863,
+    "pfr_id": "TillCe01",
+    "espn_id_new": 4369863
   },
   {
     "mfl_id": 16192,
-    "sleeper_id": 9487,
-    "pfr_id": "WashPa01",
     "gsis_id": "00-0038606",
-    "yahoo_id": 40234
+    "sleeper_id": 9487,
+    "yahoo_id": 40234,
+    "espn_id": 4432620,
+    "pfr_id": "WashPa01",
+    "espn_id_new": 4432620
   },
   {
     "mfl_id": 16193,
-    "sleeper_id": 9504,
-    "pfr_id": "BoutKa00",
     "gsis_id": "00-0038608",
-    "yahoo_id": 40224
+    "sleeper_id": 9504,
+    "yahoo_id": 40224,
+    "espn_id": 4429022,
+    "pfr_id": "BoutKa00",
+    "espn_id_new": 4429022
   },
   {
     "mfl_id": 16194,
-    "sleeper_id": 10229,
-    "pfr_id": "RiceRa01",
     "gsis_id": "00-0039067",
-    "yahoo_id": 40084
+    "sleeper_id": 10229,
+    "yahoo_id": 40084,
+    "espn_id": 4428331,
+    "pfr_id": "RiceRa01",
+    "espn_id_new": 4428331
   },
   {
     "mfl_id": 16195,
-    "sleeper_id": 9486,
-    "pfr_id": "WickDo00",
     "gsis_id": "00-0038393",
-    "yahoo_id": 40201
+    "sleeper_id": 9486,
+    "yahoo_id": 40201,
+    "espn_id": 4428850,
+    "pfr_id": "WickDo00",
+    "espn_id_new": 4428850
   },
   {
     "mfl_id": 16196,
-    "sleeper_id": 10863,
-    "pfr_id": "PerrAT00",
     "gsis_id": "00-0038612",
-    "yahoo_id": 40242
+    "sleeper_id": 10863,
+    "yahoo_id": 40242,
+    "espn_id": 4362019,
+    "pfr_id": "PerrAT00",
+    "espn_id_new": 4362019
   },
   {
     "mfl_id": 16197,
-    "sleeper_id": 10225,
-    "pfr_id": "MingJo00",
     "gsis_id": "00-0039062",
-    "yahoo_id": 40073
+    "sleeper_id": 10225,
+    "yahoo_id": 40073,
+    "espn_id": 4426485,
+    "pfr_id": "MingJo00",
+    "espn_id_new": 4426485
   },
   {
     "mfl_id": 16198,
-    "sleeper_id": 9495,
-    "pfr_id": "JarrRa00",
     "gsis_id": "00-0038821",
-    "yahoo_id": 40671
+    "sleeper_id": 9495,
+    "yahoo_id": 40671,
+    "espn_id": 4429006,
+    "pfr_id": "JarrRa00",
+    "espn_id_new": 4429006
   },
   {
     "mfl_id": 16199,
-    "sleeper_id": 9492,
-    "pfr_id": "PalmTr00",
     "gsis_id": "00-0039052",
-    "yahoo_id": 40223
+    "sleeper_id": 9492,
+    "yahoo_id": 40223,
+    "espn_id": 4426407,
+    "pfr_id": "PalmTr00",
+    "espn_id_new": 4426407
   },
   {
     "mfl_id": 16200,
-    "sleeper_id": 11382,
     "gsis_id": "00-0038447",
+    "sleeper_id": 11382,
     "yahoo_id": 40642
   },
   {
     "mfl_id": 16201,
-    "sleeper_id": 10218,
-    "pfr_id": "HutcXa00",
     "gsis_id": "00-0038618",
-    "yahoo_id": 40232
+    "sleeper_id": 10218,
+    "yahoo_id": 40232,
+    "espn_id": 4686422,
+    "pfr_id": "HutcXa00",
+    "espn_id_new": 4686422
   },
   {
     "mfl_id": 16202,
-    "sleeper_id": 10221,
-    "pfr_id": "BellRo01",
     "gsis_id": "00-0038647",
-    "yahoo_id": 40279
+    "sleeper_id": 10221,
+    "yahoo_id": 40279,
+    "espn_id": 4372063,
+    "pfr_id": "BellRo01",
+    "espn_id_new": 4372063
   },
   {
     "mfl_id": 16203,
-    "sleeper_id": 10228,
-    "pfr_id": "JoneCh11",
     "gsis_id": "00-0038576",
-    "yahoo_id": 40158
+    "sleeper_id": 10228,
+    "yahoo_id": 40158,
+    "espn_id": 4257188,
+    "pfr_id": "JoneCh11",
+    "espn_id_new": 4257188
   },
   {
     "mfl_id": 16204,
-    "sleeper_id": 9502,
-    "pfr_id": "DellNa00",
     "gsis_id": "00-0038977",
-    "yahoo_id": 40097
+    "sleeper_id": 9502,
+    "yahoo_id": 40097,
+    "espn_id": 4366031,
+    "pfr_id": "DellNa00",
+    "espn_id_new": 4366031
   },
   {
     "mfl_id": 16205,
-    "sleeper_id": 9490,
-    "pfr_id": "ScotTy00",
     "gsis_id": "00-0038941",
-    "yahoo_id": 40141
+    "sleeper_id": 9490,
+    "yahoo_id": 40141,
+    "espn_id": 4565908,
+    "pfr_id": "ScotTy00",
+    "espn_id_new": 4565908
   },
   {
     "mfl_id": 16206,
-    "sleeper_id": 10232,
-    "pfr_id": "WilsMi02",
     "gsis_id": "00-0038559",
-    "yahoo_id": 40121
+    "sleeper_id": 10232,
+    "yahoo_id": 40121,
+    "espn_id": 4360761,
+    "pfr_id": "WilsMi02",
+    "espn_id_new": 4360761
   },
   {
     "mfl_id": 16207,
-    "sleeper_id": 10226,
-    "pfr_id": "IosiAn00",
     "gsis_id": "00-0038619",
-    "yahoo_id": 40211
+    "sleeper_id": 10226,
+    "yahoo_id": 40211,
+    "espn_id": 4368003,
+    "pfr_id": "IosiAn00",
+    "espn_id_new": 4368003
   },
   {
     "mfl_id": 16208,
@@ -14341,866 +14895,1110 @@
   },
   {
     "mfl_id": 16209,
-    "sleeper_id": 9498,
     "gsis_id": "00-0038483",
+    "sleeper_id": 9498,
     "yahoo_id": 40515
   },
   {
     "mfl_id": 16210,
-    "sleeper_id": 9489,
-    "pfr_id": "ShorJu00",
     "gsis_id": "00-0038590",
-    "yahoo_id": 40167
+    "sleeper_id": 9489,
+    "yahoo_id": 40167,
+    "espn_id": 4361426,
+    "pfr_id": "ShorJu00",
+    "espn_id_new": 4361426
   },
   {
     "mfl_id": 16211,
-    "sleeper_id": 9493,
-    "pfr_id": "NacuPu00",
     "gsis_id": "00-0039075",
-    "yahoo_id": 40168
+    "sleeper_id": 9493,
+    "yahoo_id": 40168,
+    "espn_id": 4426515,
+    "pfr_id": "NacuPu00",
+    "espn_id_new": 4426515
   },
   {
     "mfl_id": 16212,
-    "sleeper_id": 9482,
-    "pfr_id": "MayeMi00",
     "gsis_id": "00-0039066",
-    "yahoo_id": 40065
+    "sleeper_id": 9482,
+    "yahoo_id": 40065,
+    "espn_id": 4429086,
+    "pfr_id": "MayeMi00",
+    "espn_id_new": 4429086
   },
   {
     "mfl_id": 16213,
-    "sleeper_id": 10236,
-    "pfr_id": "KincDa00",
     "gsis_id": "00-0038933",
-    "yahoo_id": 40048
+    "sleeper_id": 10236,
+    "yahoo_id": 40048,
+    "espn_id": 4385690,
+    "pfr_id": "KincDa00",
+    "espn_id_new": 4385690
   },
   {
     "mfl_id": 16214,
-    "sleeper_id": 10859,
-    "pfr_id": "LaPoSa01",
     "gsis_id": "00-0039065",
-    "yahoo_id": 40064
+    "sleeper_id": 10859,
+    "yahoo_id": 40064,
+    "espn_id": 4430027,
+    "pfr_id": "LaPoSa01",
+    "espn_id_new": 4430027
   },
   {
     "mfl_id": 16215,
-    "sleeper_id": 9481,
-    "pfr_id": "MusgLu00",
     "gsis_id": "00-0039144",
-    "yahoo_id": 40074
+    "sleeper_id": 9481,
+    "yahoo_id": 40074,
+    "espn_id": 4428085,
+    "pfr_id": "MusgLu00",
+    "espn_id_new": 4428085
   },
   {
     "mfl_id": 16216,
-    "sleeper_id": 9479,
-    "pfr_id": "WashDa03",
     "gsis_id": "00-0038558",
-    "yahoo_id": 40094
+    "sleeper_id": 9479,
+    "yahoo_id": 40094,
+    "espn_id": 4430802,
+    "pfr_id": "WashDa03",
+    "espn_id_new": 4430802
   },
   {
     "mfl_id": 16217,
-    "sleeper_id": 10210,
-    "pfr_id": "LatuCa01",
     "gsis_id": "00-0038564",
-    "yahoo_id": 40101
+    "sleeper_id": 10210,
+    "yahoo_id": 40101,
+    "espn_id": 4372026,
+    "pfr_id": "LatuCa01",
+    "espn_id_new": 4372026
   },
   {
     "mfl_id": 16218,
-    "sleeper_id": 10227,
-    "pfr_id": "DurhPa00",
     "gsis_id": "00-0039050",
-    "yahoo_id": 40193
+    "sleeper_id": 10227,
+    "yahoo_id": 40193,
+    "espn_id": 4372505,
+    "pfr_id": "DurhPa00",
+    "espn_id_new": 4372505
   },
   {
     "mfl_id": 16219,
-    "sleeper_id": 10214,
-    "pfr_id": "AlleDa02",
     "gsis_id": "00-0039074",
-    "yahoo_id": 40164
+    "sleeper_id": 10214,
+    "yahoo_id": 40164,
+    "espn_id": 4426553,
+    "pfr_id": "AlleDa02",
+    "espn_id_new": 4426553
   },
   {
     "mfl_id": 16220,
-    "sleeper_id": 10220,
-    "pfr_id": "MallWi00",
     "gsis_id": "00-0038394",
-    "yahoo_id": 40180
+    "sleeper_id": 10220,
+    "yahoo_id": 40180,
+    "espn_id": 4362523,
+    "pfr_id": "MallWi00",
+    "espn_id_new": 4362523
   },
   {
     "mfl_id": 16221,
-    "sleeper_id": 10871,
-    "pfr_id": "SchoLu00",
     "gsis_id": "00-0038547",
-    "yahoo_id": 40061
+    "sleeper_id": 10871,
+    "yahoo_id": 40061,
+    "espn_id": 4372096,
+    "pfr_id": "SchoLu00",
+    "espn_id_new": 4372096
   },
   {
     "mfl_id": 16222,
-    "sleeper_id": 9484,
-    "pfr_id": "KrafTu00",
     "gsis_id": "00-0038996",
-    "yahoo_id": 40102
+    "sleeper_id": 9484,
+    "yahoo_id": 40102,
+    "espn_id": 4572680,
+    "pfr_id": "KrafTu00",
+    "espn_id_new": 4572680
   },
   {
     "mfl_id": 16223,
-    "sleeper_id": 10892,
-    "pfr_id": "AndeWi01",
     "gsis_id": "00-0039108",
-    "yahoo_id": 40031
+    "sleeper_id": 10892,
+    "yahoo_id": 40031,
+    "espn_id": 4685724,
+    "pfr_id": "AndeWi01",
+    "espn_id_new": 4685724
   },
   {
     "mfl_id": 16224,
-    "sleeper_id": 10875,
-    "pfr_id": "MurpMy00",
     "gsis_id": "00-0038546",
-    "yahoo_id": 40057
+    "sleeper_id": 10875,
+    "yahoo_id": 40057,
+    "espn_id": 4428985,
+    "pfr_id": "MurpMy00",
+    "espn_id_new": 4428985
   },
   {
     "mfl_id": 16225,
-    "sleeper_id": 10908,
-    "pfr_id": "OjulBJ00",
     "gsis_id": "00-0039155",
-    "yahoo_id": 40088
+    "sleeper_id": 10908,
+    "yahoo_id": 40088,
+    "espn_id": 4429111,
+    "pfr_id": "OjulBJ00",
+    "espn_id_new": 4429111
   },
   {
     "mfl_id": 16226,
-    "sleeper_id": 10889,
-    "pfr_id": "WilsTy01",
     "gsis_id": "00-0038541",
-    "yahoo_id": 40043
+    "sleeper_id": 10889,
+    "yahoo_id": 40043,
+    "espn_id": 4372533,
+    "pfr_id": "WilsTy01",
+    "espn_id_new": 4372533
   },
   {
     "mfl_id": 16227,
-    "sleeper_id": 10934,
-    "pfr_id": "HarrZa00",
     "gsis_id": "00-0038980",
-    "yahoo_id": 40115
+    "sleeper_id": 10934,
+    "yahoo_id": 40115,
+    "espn_id": 4426412,
+    "pfr_id": "HarrZa00",
+    "espn_id_new": 4426412
   },
   {
     "mfl_id": 16228,
-    "sleeper_id": 10873,
-    "pfr_id": "SmitNo02",
     "gsis_id": "00-0039013",
-    "yahoo_id": 40054
+    "sleeper_id": 10873,
+    "yahoo_id": 40054,
+    "espn_id": 4426331,
+    "pfr_id": "SmitNo02",
+    "espn_id_new": 4426331
   },
   {
     "mfl_id": 16229,
-    "sleeper_id": 11084
+    "sleeper_id": 11084,
+    "espn_id": 4577333,
+    "espn_id_new": 4577333
   },
   {
     "mfl_id": 16230,
-    "sleeper_id": 10885,
-    "pfr_id": "VanNLu00",
     "gsis_id": "00-0039112",
-    "yahoo_id": 40037
+    "sleeper_id": 10885,
+    "yahoo_id": 40037,
+    "espn_id": 4686906,
+    "pfr_id": "VanNLu00",
+    "espn_id_new": 4686906
   },
   {
     "mfl_id": 16231,
-    "sleeper_id": 10929,
-    "pfr_id": "SandDr00",
     "gsis_id": "00-0039003",
-    "yahoo_id": 40109
+    "sleeper_id": 10929,
+    "yahoo_id": 40109,
+    "espn_id": 4685721,
+    "pfr_id": "SandDr00",
+    "espn_id_new": 4685721
   },
   {
     "mfl_id": 16232,
     "sleeper_id": 10982,
-    "pfr_id": "MorrMi00"
+    "espn_id": 4572055,
+    "pfr_id": "MorrMi00",
+    "espn_id_new": 4572055
   },
   {
     "mfl_id": 16233,
-    "sleeper_id": 10888,
-    "pfr_id": "CartJa05",
     "gsis_id": "00-0038386",
-    "yahoo_id": 40035
+    "sleeper_id": 10888,
+    "yahoo_id": 40035,
+    "espn_id": 4685759,
+    "pfr_id": "CartJa05",
+    "espn_id_new": 4685759
   },
   {
     "mfl_id": 16234,
-    "sleeper_id": 10935,
-    "pfr_id": "SimpTr00",
     "gsis_id": "00-0038504",
-    "yahoo_id": 40116
+    "sleeper_id": 10935,
+    "yahoo_id": 40116,
+    "espn_id": 4430831,
+    "pfr_id": "SimpTr00",
+    "espn_id_new": 4430831
   },
   {
     "mfl_id": 16235,
     "sleeper_id": 10911,
+    "yahoo_id": 40070,
+    "espn_id": 4567226,
     "pfr_id": "HallDe04",
-    "yahoo_id": 40070
+    "espn_id_new": 4567226
   },
   {
     "mfl_id": 16236,
-    "sleeper_id": 10970,
-    "pfr_id": "TooTHe00",
     "gsis_id": "00-0038599",
-    "yahoo_id": 40189
+    "sleeper_id": 10970,
+    "yahoo_id": 40189,
+    "espn_id": 4426350,
+    "pfr_id": "TooTHe00",
+    "espn_id_new": 4426350
   },
   {
     "mfl_id": 16237,
-    "sleeper_id": 10969,
-    "pfr_id": "PappOw00",
     "gsis_id": "00-0038600",
-    "yahoo_id": 40200
+    "sleeper_id": 10969,
+    "yahoo_id": 40200,
+    "espn_id": 4567219,
+    "pfr_id": "PappOw00",
+    "espn_id_new": 4567219
   },
   {
     "mfl_id": 16238,
-    "sleeper_id": 10984,
-    "pfr_id": "SeweNo00",
     "gsis_id": "00-0038390",
-    "yahoo_id": 40172
+    "sleeper_id": 10984,
+    "yahoo_id": 40172,
+    "espn_id": 4430822,
+    "pfr_id": "SeweNo00",
+    "espn_id_new": 4430822
   },
   {
     "mfl_id": 16239,
-    "sleeper_id": 10880,
-    "pfr_id": "CampJa04",
     "gsis_id": "00-0039018",
-    "yahoo_id": 40036
+    "sleeper_id": 10880,
+    "yahoo_id": 40036,
+    "espn_id": 4569465,
+    "pfr_id": "CampJa04",
+    "espn_id_new": 4569465
   },
   {
     "mfl_id": 16240,
-    "sleeper_id": 10913,
-    "pfr_id": "PortJo02",
     "gsis_id": "00-0039167",
-    "yahoo_id": 40089
+    "sleeper_id": 10913,
+    "yahoo_id": 40089,
+    "espn_id": 4426506,
+    "pfr_id": "PortJo02",
+    "espn_id_new": 4426506
   },
   {
     "mfl_id": 16241,
-    "sleeper_id": 10891,
-    "pfr_id": "WithDe00",
     "gsis_id": "00-0039169",
-    "yahoo_id": 40056
+    "sleeper_id": 10891,
+    "yahoo_id": 40056,
+    "espn_id": 4575431,
+    "pfr_id": "WithDe00",
+    "espn_id_new": 4575431
   },
   {
     "mfl_id": 16242,
-    "sleeper_id": 10962,
-    "pfr_id": "RingKe00",
     "gsis_id": "00-0039140",
-    "yahoo_id": 40131
+    "sleeper_id": 10962,
+    "yahoo_id": 40131,
+    "espn_id": 4428992,
+    "pfr_id": "RingKe00",
+    "espn_id_new": 4428992
   },
   {
     "mfl_id": 16243,
-    "sleeper_id": 10900,
-    "pfr_id": "SmitCa02",
     "gsis_id": "00-0039133",
-    "yahoo_id": 40081
+    "sleeper_id": 10900,
+    "yahoo_id": 40081,
+    "espn_id": 4570672,
+    "pfr_id": "SmitCa02",
+    "espn_id_new": 4570672
   },
   {
     "mfl_id": 16244,
-    "sleeper_id": 10905,
-    "pfr_id": "BranBr00",
     "gsis_id": "00-0039141",
-    "yahoo_id": 40067
+    "sleeper_id": 10905,
+    "yahoo_id": 40067,
+    "espn_id": 4692025,
+    "pfr_id": "BranBr00",
+    "espn_id_new": 4692025
   },
   {
     "mfl_id": 16245,
-    "sleeper_id": 10927,
-    "pfr_id": "BattJo00",
     "gsis_id": "00-0038560",
-    "yahoo_id": 40117
+    "sleeper_id": 10927,
+    "yahoo_id": 40117,
+    "espn_id": 4567098,
+    "pfr_id": "BattJo00",
+    "espn_id_new": 4567098
   },
   {
     "mfl_id": 16246,
     "sleeper_id": 10974,
+    "yahoo_id": 40166,
+    "espn_id": 4429168,
     "pfr_id": "JohnAn07",
-    "yahoo_id": 40166
+    "espn_id_new": 4429168
   },
   {
     "mfl_id": 16247,
     "sleeper_id": 11011,
+    "yahoo_id": 40230,
+    "espn_id": 4428503,
     "pfr_id": "SkinJL00",
-    "yahoo_id": 40230
+    "espn_id_new": 4428503
   },
   {
     "mfl_id": 16249,
-    "sleeper_id": 9483,
-    "pfr_id": "KuntZa00",
     "gsis_id": "00-0038406",
-    "yahoo_id": 40255
+    "sleeper_id": 9483,
+    "yahoo_id": 40255,
+    "espn_id": 4361417,
+    "pfr_id": "KuntZa00",
+    "espn_id_new": 4361417
   },
   {
     "mfl_id": 16250,
-    "sleeper_id": 11276,
     "gsis_id": "00-0038484",
-    "yahoo_id": 40514
+    "sleeper_id": 11276,
+    "yahoo_id": 40514,
+    "espn_id": 4426426,
+    "espn_id_new": 4426426
   },
   {
     "mfl_id": 16251,
-    "sleeper_id": 10881,
-    "pfr_id": "GonzCh00",
     "gsis_id": "00-0039147",
-    "yahoo_id": 40052
+    "sleeper_id": 10881,
+    "yahoo_id": 40052,
+    "espn_id": 4686772,
+    "pfr_id": "GonzCh00",
+    "espn_id_new": 4686772
   },
   {
     "mfl_id": 16252,
-    "sleeper_id": 10883,
-    "pfr_id": "McDoWi00",
     "gsis_id": "00-0039142",
-    "yahoo_id": 40038
+    "sleeper_id": 10883,
+    "yahoo_id": 40038,
+    "espn_id": 4361767,
+    "pfr_id": "McDoWi00",
+    "espn_id_new": 4361767
   },
   {
     "mfl_id": 16253,
-    "sleeper_id": 10882,
-    "pfr_id": "ForbEm00",
     "gsis_id": "00-0039151",
-    "yahoo_id": 40033
+    "sleeper_id": 10882,
+    "yahoo_id": 40033,
+    "espn_id": 4429767,
+    "pfr_id": "ForbEm00",
+    "espn_id_new": 4429767
   },
   {
     "mfl_id": 16254,
-    "sleeper_id": 10879,
-    "pfr_id": "KancCa00",
     "gsis_id": "00-0039063",
-    "yahoo_id": 40049
+    "sleeper_id": 10879,
+    "yahoo_id": 40049,
+    "espn_id": 4427673,
+    "pfr_id": "KancCa00",
+    "espn_id_new": 4427673
   },
   {
     "mfl_id": 16255,
-    "sleeper_id": 10878,
-    "pfr_id": "BankDe00",
     "gsis_id": "00-0039000",
-    "yahoo_id": 40053
+    "sleeper_id": 10878,
+    "yahoo_id": 40053,
+    "espn_id": 4428328,
+    "pfr_id": "BankDe00",
+    "espn_id_new": 4428328
   },
   {
     "mfl_id": 16256,
-    "sleeper_id": 10874,
-    "pfr_id": "BresBr00",
     "gsis_id": "00-0038995",
-    "yahoo_id": 40045
+    "sleeper_id": 10874,
+    "yahoo_id": 40045,
+    "espn_id": 4428988,
+    "pfr_id": "BresBr00",
+    "espn_id_new": 4428988
   },
   {
     "mfl_id": 16257,
-    "sleeper_id": 10872,
-    "pfr_id": "AnudFe00",
     "gsis_id": "00-0039006",
-    "yahoo_id": 40034
+    "sleeper_id": 10872,
+    "yahoo_id": 40034,
+    "espn_id": 4612387,
+    "pfr_id": "AnudFe00",
+    "espn_id_new": 4612387
   },
   {
     "mfl_id": 16258,
-    "sleeper_id": 10877,
-    "pfr_id": "SmitMa06",
     "gsis_id": "00-0038545",
-    "yahoo_id": 40044
+    "sleeper_id": 10877,
+    "yahoo_id": 40044,
+    "espn_id": 4426347,
+    "pfr_id": "SmitMa06",
+    "espn_id_new": 4426347
   },
   {
     "mfl_id": 16259,
-    "sleeper_id": 10928,
-    "pfr_id": "MartBr00",
     "gsis_id": "00-0038939",
-    "yahoo_id": 40122
+    "sleeper_id": 10928,
+    "yahoo_id": 40122,
+    "espn_id": 4365457,
+    "pfr_id": "MartBr00",
+    "espn_id_new": 4365457
   },
   {
     "mfl_id": 16260,
-    "sleeper_id": 10909,
-    "pfr_id": "FoskIs00",
     "gsis_id": "00-0039143",
-    "yahoo_id": 40082
+    "sleeper_id": 10909,
+    "yahoo_id": 40082,
+    "espn_id": 4426457,
+    "pfr_id": "FoskIs00",
+    "espn_id_new": 4426457
   },
   {
     "mfl_id": 16261,
-    "sleeper_id": 10906,
-    "pfr_id": "BrenJu00",
     "gsis_id": "00-0039156",
-    "yahoo_id": 40062
+    "sleeper_id": 10906,
+    "yahoo_id": 40062,
+    "espn_id": 4360488,
+    "pfr_id": "BrenJu00",
+    "espn_id_new": 4360488
   },
   {
     "mfl_id": 16262,
     "sleeper_id": 10904,
+    "yahoo_id": 40080,
+    "espn_id": 4243493,
     "pfr_id": "WhitKe03",
-    "yahoo_id": 40080
+    "espn_id_new": 4243493
   },
   {
     "mfl_id": 16263,
     "sleeper_id": 10903,
+    "yahoo_id": 40087,
+    "espn_id": 4360378,
     "pfr_id": "MartJa04",
-    "yahoo_id": 40087
+    "espn_id_new": 4360378
   },
   {
     "mfl_id": 16264,
-    "sleeper_id": 10901,
-    "pfr_id": "BentKe00",
     "gsis_id": "00-0039110",
-    "yahoo_id": 40079
+    "sleeper_id": 10901,
+    "yahoo_id": 40079,
+    "espn_id": 4426694,
+    "pfr_id": "BentKe00",
+    "espn_id_new": 4426694
   },
   {
     "mfl_id": 16265,
+    "gsis_id": "00-0039070",
     "sleeper_id": 10899,
+    "espn_id": 4429014,
     "pfr_id": "DextGe00",
-    "gsis_id": "00-0039070"
+    "espn_id_new": 4429014
   },
   {
     "mfl_id": 16266,
-    "sleeper_id": 10898,
-    "pfr_id": "TuipTu00",
     "gsis_id": "00-0039111",
-    "yahoo_id": 40077
+    "sleeper_id": 10898,
+    "yahoo_id": 40077,
+    "espn_id": 4431442,
+    "pfr_id": "TuipTu00",
+    "espn_id_new": 4431442
   },
   {
     "mfl_id": 16267,
-    "sleeper_id": 10897,
-    "pfr_id": "StevTy01",
     "gsis_id": "00-0039071",
-    "yahoo_id": 40071
+    "sleeper_id": 10897,
+    "yahoo_id": 40071,
+    "espn_id": 4426374,
+    "pfr_id": "StevTy01",
+    "espn_id_new": 4426374
   },
   {
     "mfl_id": 16268,
-    "sleeper_id": 10894,
-    "pfr_id": "TurnDJ01",
     "gsis_id": "00-0038549",
-    "yahoo_id": 40076
+    "sleeper_id": 10894,
+    "yahoo_id": 40076,
+    "espn_id": 4572036,
+    "pfr_id": "TurnDJ01",
+    "espn_id_new": 4572036
   },
   {
     "mfl_id": 16269,
-    "sleeper_id": 9480,
-    "pfr_id": "StraBr00",
     "gsis_id": "00-0038935",
-    "yahoo_id": 40078
+    "sleeper_id": 9480,
+    "yahoo_id": 40078,
+    "espn_id": 4430539,
+    "pfr_id": "StraBr00",
+    "espn_id_new": 4430539
   },
   {
     "mfl_id": 16270,
-    "sleeper_id": 10924,
-    "pfr_id": "PickZa00",
     "gsis_id": "00-0038937",
-    "yahoo_id": 40111
+    "sleeper_id": 10924,
+    "yahoo_id": 40111,
+    "espn_id": 4426332,
+    "pfr_id": "PickZa00",
+    "espn_id_new": 4426332
   },
   {
     "mfl_id": 16271,
-    "sleeper_id": 10919,
-    "pfr_id": "BrowSy00",
     "gsis_id": "00-0039002",
-    "yahoo_id": 40123
+    "sleeper_id": 10919,
+    "yahoo_id": 40123,
+    "espn_id": 4360386,
+    "pfr_id": "BrowSy00",
+    "espn_id_new": 4360386
   },
   {
     "mfl_id": 16273,
-    "sleeper_id": 10925,
-    "pfr_id": "YounBy01",
     "gsis_id": "00-0038978",
-    "yahoo_id": 40125
+    "sleeper_id": 10925,
+    "yahoo_id": 40125,
+    "espn_id": 4567123,
+    "pfr_id": "YounBy01",
+    "espn_id_new": 4567123
   },
   {
     "mfl_id": 16274,
-    "sleeper_id": 10932,
-    "pfr_id": "WillGa00",
     "gsis_id": "00-0039007",
-    "yahoo_id": 40127
+    "sleeper_id": 10932,
+    "yahoo_id": 40127,
+    "espn_id": 4568506,
+    "pfr_id": "WillGa00",
+    "espn_id_new": 4568506
   },
   {
     "mfl_id": 16275,
-    "sleeper_id": 10926,
-    "pfr_id": "MapuMa00",
     "gsis_id": "00-0039054",
-    "yahoo_id": 40105
+    "sleeper_id": 10926,
+    "yahoo_id": 40105,
+    "espn_id": 4248899,
+    "pfr_id": "MapuMa00",
+    "espn_id_new": 4248899
   },
   {
     "mfl_id": 16276,
-    "sleeper_id": 10917,
-    "pfr_id": "YounBy01",
     "gsis_id": "00-0039137",
-    "yahoo_id": 40124
+    "sleeper_id": 10917,
+    "yahoo_id": 40124,
+    "espn_id": 4875196,
+    "pfr_id": "YounBy01",
+    "espn_id_new": 4875196
   },
   {
     "mfl_id": 16277,
     "sleeper_id": 10938,
-    "pfr_id": "JohnDJ00"
+    "espn_id": 4240623,
+    "pfr_id": "JohnDJ00",
+    "espn_id_new": 4240623
   },
   {
     "mfl_id": 16278,
-    "sleeper_id": 10921,
-    "pfr_id": "DiabYa00",
     "gsis_id": "00-0039068",
-    "yahoo_id": 40107
+    "sleeper_id": 10921,
+    "yahoo_id": 40107,
+    "espn_id": 4686334,
+    "pfr_id": "DiabYa00",
+    "espn_id_new": 4686334
   },
   {
     "mfl_id": 16279,
-    "sleeper_id": 10930,
-    "pfr_id": "MossRi00",
     "gsis_id": "00-0038552",
-    "yahoo_id": 40112
+    "sleeper_id": 10930,
+    "yahoo_id": 40112,
+    "espn_id": 4382401,
+    "pfr_id": "MossRi00",
+    "espn_id_new": 4382401
   },
   {
     "mfl_id": 16280,
-    "sleeper_id": 10914,
-    "pfr_id": "HenlDa00",
     "gsis_id": "00-0038553",
-    "yahoo_id": 40113
+    "sleeper_id": 10914,
+    "yahoo_id": 40113,
+    "espn_id": 4241597,
+    "pfr_id": "HenlDa00",
+    "espn_id_new": 4241597
   },
   {
     "mfl_id": 16281,
-    "sleeper_id": 10936,
-    "pfr_id": "BrowJi01",
     "gsis_id": "00-0038554",
-    "yahoo_id": 40106
+    "sleeper_id": 10936,
+    "yahoo_id": 40106,
+    "espn_id": 4693644,
+    "pfr_id": "BrowJi01",
+    "espn_id_new": 4693644
   },
   {
     "mfl_id": 16282,
-    "sleeper_id": 10916,
-    "pfr_id": "TurnKo00",
     "gsis_id": "00-0039138",
-    "yahoo_id": 40110
+    "sleeper_id": 10916,
+    "yahoo_id": 40110,
+    "espn_id": 4250621,
+    "pfr_id": "TurnKo00",
+    "espn_id_new": 4250621
   },
   {
     "mfl_id": 16283,
-    "sleeper_id": 10933,
-    "pfr_id": "OverDe00",
     "gsis_id": "00-0038556",
-    "yahoo_id": 40099
+    "sleeper_id": 10933,
+    "yahoo_id": 40099,
+    "espn_id": 4362088,
+    "pfr_id": "OverDe00",
+    "espn_id_new": 4362088
   },
   {
     "mfl_id": 16284,
-    "sleeper_id": 10923,
-    "pfr_id": "WillDo04",
     "gsis_id": "00-0038557",
-    "yahoo_id": 40098
+    "sleeper_id": 10923,
+    "yahoo_id": 40098,
+    "espn_id": 4568624,
+    "pfr_id": "WillDo04",
+    "espn_id_new": 4568624
   },
   {
     "mfl_id": 16285,
-    "sleeper_id": 10931,
-    "pfr_id": "IkaxSi00",
     "gsis_id": "00-0038561",
-    "yahoo_id": 40104
+    "sleeper_id": 10931,
+    "yahoo_id": 40104,
+    "pfr_id": "IkaxSi00"
   },
   {
     "mfl_id": 16286,
-    "sleeper_id": 10937,
-    "pfr_id": "MoodJa00",
     "gsis_id": "00-0038562",
-    "yahoo_id": 40129
+    "sleeper_id": 10937,
+    "yahoo_id": 40129,
+    "espn_id": 4372066,
+    "pfr_id": "MoodJa00",
+    "espn_id_new": 4372066
   },
   {
     "mfl_id": 16287,
-    "sleeper_id": 10213,
-    "pfr_id": "TuckTr00",
     "gsis_id": "00-0038563",
-    "yahoo_id": 40114
+    "sleeper_id": 10213,
+    "yahoo_id": 40114,
+    "espn_id": 4428718,
+    "pfr_id": "TuckTr00",
+    "espn_id_new": 4428718
   },
   {
     "mfl_id": 16288,
-    "sleeper_id": 10918,
-    "pfr_id": "BlacMe00",
     "gsis_id": "00-0038565",
-    "yahoo_id": 40103
+    "sleeper_id": 10918,
+    "yahoo_id": 40103,
+    "espn_id": 4360677,
+    "pfr_id": "BlacMe00",
+    "espn_id_new": 4360677
   },
   {
     "mfl_id": 16289,
-    "sleeper_id": 10963,
-    "pfr_id": "BennJa00",
     "gsis_id": "00-0039072",
-    "yahoo_id": 40148
+    "sleeper_id": 10963,
+    "yahoo_id": 40148,
+    "espn_id": 4686911,
+    "pfr_id": "BennJa00",
+    "espn_id_new": 4686911
   },
   {
     "mfl_id": 16290,
-    "sleeper_id": 10958,
-    "pfr_id": "HortDy00",
     "gsis_id": "00-0039009",
-    "yahoo_id": 40151
+    "sleeper_id": 10958,
+    "yahoo_id": 40151,
+    "espn_id": 4374066,
+    "pfr_id": "HortDy00",
+    "espn_id_new": 4374066
   },
   {
     "mfl_id": 16291,
-    "sleeper_id": 10957,
-    "pfr_id": "AdebAd00",
     "gsis_id": "00-0039031",
-    "yahoo_id": 40143
+    "sleeper_id": 10957,
+    "yahoo_id": 40143,
+    "espn_id": 4427635,
+    "pfr_id": "AdebAd00",
+    "espn_id_new": 4427635
   },
   {
     "mfl_id": 16292,
-    "sleeper_id": 10955,
-    "pfr_id": "RylaCh00",
     "gsis_id": "00-0038567",
-    "yahoo_id": 40159
+    "sleeper_id": 10955,
+    "yahoo_id": 40159,
+    "pfr_id": "RylaCh00"
   },
   {
     "mfl_id": 16293,
+    "gsis_id": "00-0038568",
     "sleeper_id": 10954,
+    "espn_id": 4429067,
     "pfr_id": "PhilCl00",
-    "gsis_id": "00-0038568"
+    "espn_id_new": 4429067
   },
   {
     "mfl_id": 16294,
-    "sleeper_id": 10952,
-    "pfr_id": "WoodCo01",
     "gsis_id": "00-0038387",
-    "yahoo_id": 40132
+    "sleeper_id": 10952,
+    "yahoo_id": 40132,
+    "espn_id": 4567224,
+    "pfr_id": "WoodCo01",
+    "espn_id_new": 4567224
   },
   {
     "mfl_id": 16295,
+    "gsis_id": "00-0038982",
     "sleeper_id": 10949,
+    "espn_id": 4361964,
     "pfr_id": "ConnCh01",
-    "gsis_id": "00-0038982"
+    "espn_id_new": 4361964
   },
   {
     "mfl_id": 16296,
-    "sleeper_id": 10947,
-    "pfr_id": "MillVe00",
     "gsis_id": "00-0038570",
-    "yahoo_id": 40155
+    "sleeper_id": 10947,
+    "yahoo_id": 40155,
+    "espn_id": 4240610,
+    "pfr_id": "MillVe00",
+    "espn_id_new": 4240610
   },
   {
     "mfl_id": 16297,
     "sleeper_id": 10945,
+    "yahoo_id": 40157,
+    "espn_id": 4362911,
     "pfr_id": "YounCa00",
-    "yahoo_id": 40157
+    "espn_id_new": 4362911
   },
   {
     "mfl_id": 16298,
     "sleeper_id": 10944,
+    "yahoo_id": 40135,
+    "espn_id": 4690179,
     "pfr_id": "RobiTa00",
-    "yahoo_id": 40135
+    "espn_id_new": 4690179
   },
   {
     "mfl_id": 16299,
-    "sleeper_id": 10234,
-    "pfr_id": "DaviDe02",
     "gsis_id": "00-0038573",
-    "yahoo_id": 40133
+    "sleeper_id": 10234,
+    "yahoo_id": 40133,
+    "espn_id": 4362477,
+    "pfr_id": "DaviDe02",
+    "espn_id_new": 4362477
   },
   {
     "mfl_id": 16300,
-    "sleeper_id": 10943,
-    "pfr_id": "McGuIs00",
     "gsis_id": "00-0038574",
-    "yahoo_id": 40150
+    "sleeper_id": 10943,
+    "yahoo_id": 40150,
+    "espn_id": 4427963,
+    "pfr_id": "McGuIs00",
+    "espn_id_new": 4427963
   },
   {
     "mfl_id": 16301,
-    "sleeper_id": 10942,
-    "pfr_id": "FehoVi00",
     "gsis_id": "00-0038575",
-    "yahoo_id": 40140
+    "sleeper_id": 10942,
+    "yahoo_id": 40140,
+    "espn_id": 4374148,
+    "pfr_id": "FehoVi00",
+    "espn_id_new": 4374148
   },
   {
     "mfl_id": 16302,
     "sleeper_id": 10941,
+    "yahoo_id": 40161,
+    "espn_id": 4361861,
     "pfr_id": "LacyTy00",
-    "yahoo_id": 40161
+    "espn_id_new": 4361861
   },
   {
     "mfl_id": 16303,
     "sleeper_id": 10940,
+    "yahoo_id": 40139,
+    "espn_id": 4429164,
     "pfr_id": "HerbNi00",
-    "yahoo_id": 40139
+    "espn_id_new": 4429164
   },
   {
     "mfl_id": 16304,
-    "sleeper_id": 10939,
-    "pfr_id": "WardJa00",
     "gsis_id": "00-0038578",
-    "yahoo_id": 40147
+    "sleeper_id": 10939,
+    "yahoo_id": 40147,
+    "espn_id": 4568007,
+    "pfr_id": "WardJa00",
+    "espn_id_new": 4568007
   },
   {
     "mfl_id": 16305,
+    "gsis_id": "00-0038580",
     "sleeper_id": 10992,
+    "espn_id": 4360807,
     "pfr_id": "AbduYa00",
-    "gsis_id": "00-0038580"
+    "espn_id_new": 4360807
   },
   {
     "mfl_id": 16306,
+    "gsis_id": "00-0038581",
     "sleeper_id": 10991,
-    "pfr_id": "HenrKJ00",
-    "gsis_id": "00-0038581"
+    "pfr_id": "HenrKJ00"
   },
   {
     "mfl_id": 16307,
-    "sleeper_id": 10990,
-    "pfr_id": "RushDa00",
     "gsis_id": "00-0038388",
-    "yahoo_id": 40170
+    "sleeper_id": 10990,
+    "yahoo_id": 40170,
+    "espn_id": 4362858,
+    "pfr_id": "RushDa00",
+    "espn_id_new": 4362858
   },
   {
     "mfl_id": 16308,
     "sleeper_id": 10989,
-    "pfr_id": "RoyxJa00"
+    "espn_id": 4429034,
+    "pfr_id": "RoyxJa00",
+    "espn_id_new": 4429034
   },
   {
     "mfl_id": 16309,
-    "sleeper_id": 10988,
-    "pfr_id": "MitcCa01",
     "gsis_id": "00-0038585",
-    "yahoo_id": 40184
+    "sleeper_id": 10988,
+    "yahoo_id": 40184,
+    "espn_id": 4569607,
+    "pfr_id": "MitcCa01",
+    "espn_id_new": 4569607
   },
   {
     "mfl_id": 16310,
-    "sleeper_id": 10986,
-    "pfr_id": "RobiJa03",
     "gsis_id": "00-0038587",
-    "yahoo_id": 40176
+    "sleeper_id": 10986,
+    "yahoo_id": 40176,
+    "espn_id": 4430411,
+    "pfr_id": "RobiJa03",
+    "espn_id_new": 4430411
   },
   {
     "mfl_id": 16311,
-    "sleeper_id": 10985,
-    "pfr_id": "HowdJo00",
     "gsis_id": "00-0038588",
-    "yahoo_id": 40199
+    "sleeper_id": 10985,
+    "yahoo_id": 40199,
+    "espn_id": 4360949,
+    "pfr_id": "HowdJo00",
+    "espn_id_new": 4360949
   },
   {
     "mfl_id": 16312,
-    "sleeper_id": 10212,
-    "pfr_id": "WhylJo01",
     "gsis_id": "00-0038589",
-    "yahoo_id": 40182
+    "sleeper_id": 10212,
+    "yahoo_id": 40182,
+    "espn_id": 4360086,
+    "pfr_id": "WhylJo01",
+    "espn_id_new": 4360086
   },
   {
     "mfl_id": 16313,
-    "sleeper_id": 10983,
-    "pfr_id": "ClifSe00",
     "gsis_id": "00-0038391",
-    "yahoo_id": 40173
+    "sleeper_id": 10983,
+    "yahoo_id": 40173,
+    "pfr_id": "ClifSe00"
   },
   {
     "mfl_id": 16314,
-    "sleeper_id": 10980,
-    "pfr_id": "DennSi00",
     "gsis_id": "00-0039049",
-    "yahoo_id": 40194
+    "sleeper_id": 10980,
+    "yahoo_id": 40194,
+    "espn_id": 4429511,
+    "pfr_id": "DennSi00",
+    "espn_id_new": 4429511
   },
   {
     "mfl_id": 16315,
-    "sleeper_id": 10978,
-    "pfr_id": "LuteDa00",
     "gsis_id": "00-0038594",
-    "yahoo_id": 40186
+    "sleeper_id": 10978,
+    "yahoo_id": 40186,
+    "espn_id": 4685978,
+    "pfr_id": "LuteDa00",
+    "espn_id_new": 4685978
   },
   {
     "mfl_id": 16316,
-    "sleeper_id": 10976,
-    "pfr_id": "BluxKy00",
     "gsis_id": "00-0038381",
-    "yahoo_id": 40187
+    "sleeper_id": 10976,
+    "yahoo_id": 40187,
+    "espn_id": 4427695,
+    "pfr_id": "BluxKy00",
+    "espn_id_new": 4427695
   },
   {
     "mfl_id": 16317,
     "sleeper_id": 10975,
+    "yahoo_id": 40205,
+    "espn_id": 4242415,
     "pfr_id": "ScotDa03",
-    "yahoo_id": 40205
+    "espn_id_new": 4242415
   },
   {
     "mfl_id": 16318,
+    "gsis_id": "00-0039076",
     "sleeper_id": 10973,
+    "espn_id": 4360773,
     "pfr_id": "HampNi00",
-    "gsis_id": "00-0039076"
+    "espn_id_new": 4360773
   },
   {
     "mfl_id": 16319,
-    "sleeper_id": 10972,
-    "pfr_id": "SmitTe05",
     "gsis_id": "00-0038395",
-    "yahoo_id": 40175
+    "sleeper_id": 10972,
+    "yahoo_id": 40175,
+    "espn_id": 4360935,
+    "pfr_id": "SmitTe05",
+    "espn_id_new": 4360935
   },
   {
     "mfl_id": 16320,
     "sleeper_id": 10971,
+    "yahoo_id": 40190,
+    "espn_id": 4691084,
     "pfr_id": "ThomBJ00",
-    "yahoo_id": 40190
+    "espn_id_new": 4691084
   },
   {
     "mfl_id": 16321,
     "sleeper_id": 10967,
-    "pfr_id": "SmitCh04",
-    "yahoo_id": 40178
+    "yahoo_id": 40178,
+    "pfr_id": "SmitCh04"
   },
   {
     "mfl_id": 16322,
-    "sleeper_id": 10966,
-    "pfr_id": "BealRo00",
     "gsis_id": "00-0038603",
-    "yahoo_id": 40181
+    "sleeper_id": 10966,
+    "yahoo_id": 40181,
+    "espn_id": 4259558,
+    "pfr_id": "BealRo00",
+    "espn_id_new": 4259558
   },
   {
     "mfl_id": 16323,
+    "gsis_id": "00-0038604",
     "sleeper_id": 11020,
+    "espn_id": 4248032,
     "pfr_id": "ScotEr00",
-    "gsis_id": "00-0038604"
+    "espn_id_new": 4248032
   },
   {
     "mfl_id": 16324,
+    "gsis_id": "00-0038398",
     "sleeper_id": 11009,
+    "espn_id": 4373423,
     "pfr_id": "BrooKa00",
-    "gsis_id": "00-0038398"
+    "espn_id_new": 4373423
   },
   {
     "mfl_id": 16325,
-    "sleeper_id": 11014,
-    "pfr_id": "ClarKe02",
     "gsis_id": "00-0038984",
-    "yahoo_id": 40229
+    "sleeper_id": 11014,
+    "yahoo_id": 40229,
+    "espn_id": 4426923,
+    "pfr_id": "ClarKe02",
+    "espn_id_new": 4426923
   },
   {
     "mfl_id": 16326,
+    "gsis_id": "00-0039051",
     "sleeper_id": 10999,
+    "espn_id": 4248533,
     "pfr_id": "HayeJo01",
-    "gsis_id": "00-0039051"
+    "espn_id_new": 4248533
   },
   {
     "mfl_id": 16327,
     "sleeper_id": 10995,
-    "yahoo_id": 40237
+    "yahoo_id": 40237,
+    "espn_id": 4427493,
+    "espn_id_new": 4427493
   },
   {
     "mfl_id": 16328,
-    "sleeper_id": 11000,
-    "pfr_id": "BarnZa00",
     "gsis_id": "00-0038399",
-    "yahoo_id": 40233
+    "sleeper_id": 11000,
+    "yahoo_id": 40233,
+    "espn_id": 4362234,
+    "pfr_id": "BarnZa00",
+    "espn_id_new": 4362234
   },
   {
     "mfl_id": 16329,
     "sleeper_id": 10996,
+    "yahoo_id": 40241,
+    "espn_id": 4362486,
     "pfr_id": "MathOc00",
-    "yahoo_id": 40241
+    "espn_id_new": 4362486
   },
   {
     "mfl_id": 16330,
     "sleeper_id": 11007,
-    "pfr_id": "BariBr00"
+    "espn_id": 4240545,
+    "pfr_id": "BariBr00",
+    "espn_id_new": 4240545
   },
   {
     "mfl_id": 16331,
     "sleeper_id": 11002,
-    "pfr_id": "CobuKe00"
+    "espn_id": 4362117,
+    "pfr_id": "CobuKe00",
+    "espn_id_new": 4362117
   },
   {
     "mfl_id": 16332,
     "sleeper_id": 10998,
+    "yahoo_id": 40215,
+    "espn_id": 4569068,
     "pfr_id": "RamiJo00",
-    "yahoo_id": 40215
+    "espn_id_new": 4569068
   },
   {
     "mfl_id": 16333,
-    "sleeper_id": 10231,
-    "pfr_id": "HiggEl00",
     "gsis_id": "00-0039041",
-    "yahoo_id": 40226
+    "sleeper_id": 10231,
+    "yahoo_id": 40226,
+    "espn_id": 4426844,
+    "pfr_id": "HiggEl00",
+    "espn_id_new": 4426844
   },
   {
     "mfl_id": 16334,
-    "sleeper_id": 10997,
-    "pfr_id": "ReedJe00",
     "gsis_id": "00-0038613",
-    "yahoo_id": 40239
+    "sleeper_id": 10997,
+    "yahoo_id": 40239,
+    "espn_id": 4570084,
+    "pfr_id": "ReedJe00",
+    "espn_id_new": 4570084
   },
   {
     "mfl_id": 16335,
-    "sleeper_id": 10994,
-    "pfr_id": "MatlSc00",
     "gsis_id": "00-0038614",
-    "yahoo_id": 40225
+    "sleeper_id": 10994,
+    "yahoo_id": 40225,
+    "espn_id": 4373684,
+    "pfr_id": "MatlSc00",
+    "espn_id_new": 4373684
   },
   {
     "mfl_id": 16336,
-    "sleeper_id": 11018,
-    "pfr_id": "BrasCh00",
     "gsis_id": "00-0038616",
-    "yahoo_id": 40208
+    "sleeper_id": 11018,
+    "yahoo_id": 40208,
+    "espn_id": 4257580,
+    "pfr_id": "BrasCh00",
+    "espn_id_new": 4257580
   },
   {
     "mfl_id": 16337,
-    "sleeper_id": 11003,
-    "pfr_id": "BurnAm00",
     "gsis_id": "00-0038617",
-    "yahoo_id": 40235
+    "sleeper_id": 11003,
+    "yahoo_id": 40235,
+    "espn_id": 4360239,
+    "pfr_id": "BurnAm00",
+    "espn_id_new": 4360239
   },
   {
     "mfl_id": 16338,
-    "sleeper_id": 11001,
-    "pfr_id": "BernJa01",
     "gsis_id": "00-0038401",
-    "yahoo_id": 40236
+    "sleeper_id": 11001,
+    "yahoo_id": 40236,
+    "espn_id": 4361834,
+    "pfr_id": "BernJa01",
+    "espn_id_new": 4361834
   },
   {
     "mfl_id": 16339,
-    "sleeper_id": 11008,
-    "pfr_id": "CarlAn00",
     "gsis_id": "00-0038402",
-    "yahoo_id": 40214
+    "sleeper_id": 11008,
+    "yahoo_id": 40214,
+    "pfr_id": "CarlAn00"
   },
   {
     "mfl_id": 16340,
@@ -15209,78 +16007,100 @@
   },
   {
     "mfl_id": 16341,
-    "sleeper_id": 10993,
-    "pfr_id": "HawkTr00",
     "gsis_id": "00-0038403",
-    "yahoo_id": 40228
+    "sleeper_id": 10993,
+    "yahoo_id": 40228,
+    "espn_id": 4686553,
+    "pfr_id": "HawkTr00",
+    "espn_id_new": 4686553
   },
   {
     "mfl_id": 16342,
-    "sleeper_id": 9501,
-    "pfr_id": "DougDe00",
     "gsis_id": "00-0038621",
-    "yahoo_id": 40222
+    "sleeper_id": 9501,
+    "yahoo_id": 40222,
+    "espn_id": 4427095,
+    "pfr_id": "DougDe00",
+    "espn_id_new": 4427095
   },
   {
     "mfl_id": 16343,
-    "sleeper_id": 11004,
-    "pfr_id": "LeoxTi00",
     "gsis_id": "00-0038404",
-    "yahoo_id": 40219
+    "sleeper_id": 11004,
+    "yahoo_id": 40219,
+    "espn_id": 4368468,
+    "pfr_id": "LeoxTi00",
+    "espn_id_new": 4368468
   },
   {
     "mfl_id": 16344,
     "sleeper_id": 11015,
+    "yahoo_id": 40244,
+    "espn_id": 4362225,
     "pfr_id": "StilDa01",
-    "yahoo_id": 40244
+    "espn_id_new": 4362225
   },
   {
     "mfl_id": 16345,
     "sleeper_id": 11006,
-    "pfr_id": "SpeeAm00"
+    "espn_id": 4259546,
+    "pfr_id": "SpeeAm00",
+    "espn_id_new": 4259546
   },
   {
     "mfl_id": 16346,
-    "sleeper_id": 11017,
-    "pfr_id": "WintDe00",
     "gsis_id": "00-0038625",
-    "yahoo_id": 40227
+    "sleeper_id": 11017,
+    "yahoo_id": 40227,
+    "espn_id": 4428914,
+    "pfr_id": "WintDe00",
+    "espn_id_new": 4428914
   },
   {
     "mfl_id": 16347,
     "sleeper_id": 11010,
-    "pfr_id": "RobbBr00"
+    "espn_id": 4258197,
+    "pfr_id": "RobbBr00",
+    "espn_id_new": 4258197
   },
   {
     "mfl_id": 16348,
+    "gsis_id": "00-0038405",
     "sleeper_id": 11054,
-    "pfr_id": "BellTr01",
-    "gsis_id": "00-0038405"
+    "pfr_id": "BellTr01"
   },
   {
     "mfl_id": 16349,
-    "sleeper_id": 11053,
-    "pfr_id": "GreeAn00",
     "gsis_id": "00-0038627",
-    "yahoo_id": 40281
+    "sleeper_id": 11053,
+    "yahoo_id": 40281,
+    "espn_id": 4373266,
+    "pfr_id": "GreeAn00",
+    "espn_id_new": 4373266
   },
   {
     "mfl_id": 16350,
-    "sleeper_id": 11052,
-    "pfr_id": "JoneJa13",
     "gsis_id": "00-0038407",
-    "yahoo_id": 40258
+    "sleeper_id": 11052,
+    "yahoo_id": 40258,
+    "espn_id": 4685145,
+    "pfr_id": "JoneJa13",
+    "espn_id_new": 4685145
   },
   {
     "mfl_id": 16351,
     "sleeper_id": 11051,
-    "pfr_id": "EvanEt00"
+    "espn_id": 5125875,
+    "pfr_id": "EvanEt00",
+    "espn_id_new": 5125875
   },
   {
     "mfl_id": 16352,
+    "gsis_id": "00-0038628",
     "sleeper_id": 11050,
+    "espn_id": 4567111,
     "pfr_id": "HellDe00",
-    "gsis_id": "00-0038628"
+    "espn_id_new": 4567111
   },
   {
     "mfl_id": 16353,
@@ -15289,149 +16109,185 @@
   },
   {
     "mfl_id": 16354,
-    "sleeper_id": 11046,
-    "pfr_id": "DoweCo00",
     "gsis_id": "00-0038632",
-    "yahoo_id": 40263
+    "sleeper_id": 11046,
+    "yahoo_id": 40263,
+    "espn_id": 4250945,
+    "pfr_id": "DoweCo00",
+    "espn_id_new": 4250945
   },
   {
     "mfl_id": 16355,
+    "gsis_id": "00-0038634",
     "sleeper_id": 11043,
+    "espn_id": 4362497,
     "pfr_id": "JadeNe00",
-    "gsis_id": "00-0038634"
+    "espn_id_new": 4362497
   },
   {
     "mfl_id": 16356,
-    "sleeper_id": 11042,
-    "pfr_id": "ValeCa00",
     "gsis_id": "00-0038408",
-    "yahoo_id": 40274
+    "sleeper_id": 11042,
+    "yahoo_id": 40274,
+    "espn_id": 4430965,
+    "pfr_id": "ValeCa00",
+    "espn_id_new": 4430965
   },
   {
     "mfl_id": 16357,
-    "sleeper_id": 11041,
-    "pfr_id": "JoneAn02",
     "gsis_id": "00-0038635",
-    "yahoo_id": 40247
+    "sleeper_id": 11041,
+    "yahoo_id": 40247,
+    "espn_id": 4249214,
+    "pfr_id": "JoneAn02",
+    "espn_id_new": 4249214
   },
   {
     "mfl_id": 16358,
-    "sleeper_id": 11040,
-    "pfr_id": "TaylJa05",
     "gsis_id": "00-0039060",
-    "yahoo_id": 40287
+    "sleeper_id": 11040,
+    "yahoo_id": 40287,
+    "espn_id": 4361835,
+    "pfr_id": "TaylJa05",
+    "espn_id_new": 4361835
   },
   {
     "mfl_id": 16359,
-    "sleeper_id": 9510,
-    "pfr_id": "NichLe00",
     "gsis_id": "00-0038409",
-    "yahoo_id": 40260
+    "sleeper_id": 9510,
+    "yahoo_id": 40260,
+    "pfr_id": "NichLe00"
   },
   {
     "mfl_id": 16360,
+    "gsis_id": "00-0038638",
     "sleeper_id": 11038,
-    "pfr_id": "PariDe00",
-    "gsis_id": "00-0038638"
+    "pfr_id": "PariDe00"
   },
   {
     "mfl_id": 16361,
-    "sleeper_id": 11037,
-    "pfr_id": "TricCo00",
     "gsis_id": "00-0038639",
-    "yahoo_id": 40256
+    "sleeper_id": 11037,
+    "yahoo_id": 40256,
+    "espn_id": 4372492,
+    "pfr_id": "TricCo00",
+    "espn_id_new": 4372492
   },
   {
     "mfl_id": 16362,
     "sleeper_id": 11036,
-    "pfr_id": "JohnAn08",
-    "yahoo_id": 40282
+    "yahoo_id": 40282,
+    "pfr_id": "JohnAn08"
   },
   {
     "mfl_id": 16363,
+    "gsis_id": "00-0038506",
     "sleeper_id": 11035,
+    "espn_id": 4240677,
     "pfr_id": "RileJo00",
-    "gsis_id": "00-0038506"
+    "espn_id_new": 4240677
   },
   {
     "mfl_id": 16364,
-    "sleeper_id": 11034,
-    "pfr_id": "BrooJa03",
     "gsis_id": "00-0038640",
-    "yahoo_id": 40257
+    "sleeper_id": 11034,
+    "yahoo_id": 40257,
+    "espn_id": 4692835,
+    "pfr_id": "BrooJa03",
+    "espn_id_new": 4692835
   },
   {
     "mfl_id": 16365,
+    "gsis_id": "00-0038641",
     "sleeper_id": 11033,
-    "pfr_id": "BoldIs00",
-    "gsis_id": "00-0038641"
+    "pfr_id": "BoldIs00"
   },
   {
     "mfl_id": 16366,
-    "sleeper_id": 11032,
-    "pfr_id": "IveyDJ00",
     "gsis_id": "00-0038642",
-    "yahoo_id": 40259
+    "sleeper_id": 11032,
+    "yahoo_id": 40259,
+    "espn_id": 4362502,
+    "pfr_id": "IveyDJ00",
+    "espn_id_new": 4362502
   },
   {
     "mfl_id": 16367,
-    "sleeper_id": 10224,
-    "pfr_id": "WillBr06",
     "gsis_id": "00-0038643",
-    "yahoo_id": 40261
+    "sleeper_id": 10224,
+    "yahoo_id": 40261,
+    "espn_id": 4360290,
+    "pfr_id": "WillBr06",
+    "espn_id_new": 4360290
   },
   {
     "mfl_id": 16368,
     "sleeper_id": 11031,
-    "pfr_id": "HillBr03"
+    "espn_id": 4568662,
+    "pfr_id": "HillBr03",
+    "espn_id_new": 4568662
   },
   {
     "mfl_id": 16369,
+    "gsis_id": "00-0038412",
     "sleeper_id": 11030,
+    "espn_id": 4362116,
     "pfr_id": "OjomMo00",
-    "gsis_id": "00-0038412"
+    "espn_id_new": 4362116
   },
   {
     "mfl_id": 16370,
+    "gsis_id": "00-0038986",
     "sleeper_id": 11029,
+    "espn_id": 4427636,
     "pfr_id": "JoneNi00",
-    "gsis_id": "00-0038986"
+    "espn_id_new": 4427636
   },
   {
     "mfl_id": 16371,
+    "gsis_id": "00-0038646",
     "sleeper_id": 11027,
+    "espn_id": 4426599,
     "pfr_id": "AustAl00",
-    "gsis_id": "00-0038646"
+    "espn_id_new": 4426599
   },
   {
     "mfl_id": 16372,
     "sleeper_id": 11026,
-    "pfr_id": "OwenGe00"
+    "espn_id": 4567482,
+    "pfr_id": "OwenGe00",
+    "espn_id_new": 4567482
   },
   {
     "mfl_id": 16373,
-    "sleeper_id": 11025,
-    "pfr_id": "GrahJa02",
     "gsis_id": "00-0038648",
-    "yahoo_id": 40265
+    "sleeper_id": 11025,
+    "yahoo_id": 40265,
+    "espn_id": 4570410,
+    "pfr_id": "GrahJa02",
+    "espn_id_new": 4570410
   },
   {
     "mfl_id": 16374,
     "sleeper_id": 11024,
-    "pfr_id": "DuboGr00",
-    "yahoo_id": 40251
+    "yahoo_id": 40251,
+    "pfr_id": "DuboGr00"
   },
   {
     "mfl_id": 16375,
     "sleeper_id": 11022,
+    "yahoo_id": 40248,
+    "espn_id": 4360745,
     "pfr_id": "WillKe07",
-    "yahoo_id": 40248
+    "espn_id_new": 4360745
   },
   {
     "mfl_id": 16376,
+    "gsis_id": "00-0039061",
     "sleeper_id": 11021,
+    "espn_id": 4362294,
     "pfr_id": "JohnDe08",
-    "gsis_id": "00-0039061"
+    "espn_id_new": 4362294
   },
   {
     "mfl_id": 16377,
@@ -15440,20 +16296,22 @@
   },
   {
     "mfl_id": 16378,
-    "sleeper_id": 11214,
-    "gsis_id": "00-0038744"
+    "gsis_id": "00-0038744",
+    "sleeper_id": 11214
   },
   {
     "mfl_id": 16379,
-    "sleeper_id": 9499,
     "gsis_id": "00-0038477",
+    "sleeper_id": 9499,
     "yahoo_id": 40529
   },
   {
     "mfl_id": 16380,
-    "sleeper_id": 10870,
     "gsis_id": "00-0038518",
-    "yahoo_id": 40570
+    "sleeper_id": 10870,
+    "yahoo_id": 40570,
+    "espn_id": 4372526,
+    "espn_id_new": 4372526
   },
   {
     "mfl_id": 16381,
@@ -15462,41 +16320,51 @@
   },
   {
     "mfl_id": 16382,
-    "sleeper_id": 11232,
     "gsis_id": "00-0038883",
-    "yahoo_id": 40466
+    "sleeper_id": 11232,
+    "yahoo_id": 40466,
+    "espn_id": 4247942,
+    "espn_id_new": 4247942
   },
   {
     "mfl_id": 16383,
-    "sleeper_id": 11086,
-    "pfr_id": "PaceIv00",
     "gsis_id": "00-0038807",
-    "yahoo_id": 40301
+    "sleeper_id": 11086,
+    "yahoo_id": 40301,
+    "espn_id": 4430280,
+    "pfr_id": "PaceIv00",
+    "espn_id_new": 4430280
   },
   {
     "mfl_id": 16384,
-    "sleeper_id": 11256,
-    "pfr_id": "BageTy00",
     "gsis_id": "00-0038416",
-    "yahoo_id": 40504
+    "sleeper_id": 11256,
+    "yahoo_id": 40504,
+    "espn_id": 4434153,
+    "pfr_id": "BageTy00",
+    "espn_id_new": 4434153
   },
   {
     "mfl_id": 16385,
-    "sleeper_id": 11199,
-    "pfr_id": "DemeEm00",
     "gsis_id": "00-0038705",
-    "yahoo_id": 40430
+    "sleeper_id": 11199,
+    "yahoo_id": 40430,
+    "espn_id": 4362478,
+    "pfr_id": "DemeEm00",
+    "espn_id_new": 4362478
   },
   {
     "mfl_id": 16386,
-    "sleeper_id": 10861,
     "gsis_id": "00-0038727",
+    "sleeper_id": 10861,
     "yahoo_id": 40721
   },
   {
     "mfl_id": 16387,
     "sleeper_id": 11370,
-    "yahoo_id": 40625
+    "yahoo_id": 40625,
+    "espn_id": 3149687,
+    "espn_id_new": 3149687
   },
   {
     "mfl_id": 16388,
@@ -15504,34 +16372,40 @@
   },
   {
     "mfl_id": 16389,
-    "sleeper_id": 11505,
-    "gsis_id": "00-0038734"
+    "gsis_id": "00-0038734",
+    "sleeper_id": 11505
   },
   {
     "mfl_id": 16390,
-    "sleeper_id": 11439,
-    "pfr_id": "McLaJa00",
     "gsis_id": "00-0038794",
-    "yahoo_id": 40696
+    "sleeper_id": 11439,
+    "yahoo_id": 40696,
+    "espn_id": 4722893,
+    "pfr_id": "McLaJa00",
+    "espn_id_new": 4722893
   },
   {
     "mfl_id": 16391,
-    "sleeper_id": 11510,
-    "pfr_id": "LuepHu00",
     "gsis_id": "00-0038738",
-    "yahoo_id": 40780
+    "sleeper_id": 11510,
+    "yahoo_id": 40780,
+    "espn_id": 4383396,
+    "pfr_id": "LuepHu00",
+    "espn_id_new": 4383396
   },
   {
     "mfl_id": 16392,
-    "sleeper_id": 11472,
-    "gsis_id": "00-0038957"
+    "gsis_id": "00-0038957",
+    "sleeper_id": 11472
   },
   {
     "mfl_id": 16393,
-    "sleeper_id": 10867,
-    "pfr_id": "BoboJa00",
     "gsis_id": "00-0038752",
-    "yahoo_id": 40452
+    "sleeper_id": 10867,
+    "yahoo_id": 40452,
+    "espn_id": 4360405,
+    "pfr_id": "BoboJa00",
+    "espn_id_new": 4360405
   },
   {
     "mfl_id": 16394,
@@ -15540,69 +16414,83 @@
   {
     "mfl_id": 16395,
     "sleeper_id": 11506,
-    "yahoo_id": 40774
+    "yahoo_id": 40774,
+    "espn_id": 4426990,
+    "espn_id_new": 4426990
   },
   {
     "mfl_id": 16396,
-    "sleeper_id": 11270,
     "gsis_id": "00-0038714",
-    "yahoo_id": 40507
+    "sleeper_id": 11270,
+    "yahoo_id": 40507,
+    "espn_id": 4360805,
+    "espn_id_new": 4360805
   },
   {
     "mfl_id": 16397,
-    "sleeper_id": 11335,
-    "gsis_id": "00-0038539"
+    "gsis_id": "00-0038539",
+    "sleeper_id": 11335
   },
   {
     "mfl_id": 16398,
-    "sleeper_id": 11192,
-    "gsis_id": "00-0038904"
+    "gsis_id": "00-0038904",
+    "sleeper_id": 11192
   },
   {
     "mfl_id": 16399,
-    "sleeper_id": 10869,
     "gsis_id": "00-0038762",
-    "yahoo_id": 40458
+    "sleeper_id": 10869,
+    "yahoo_id": 40458,
+    "espn_id": 4259550,
+    "espn_id_new": 4259550
   },
   {
     "mfl_id": 16400,
-    "sleeper_id": 11225,
-    "gsis_id": "00-0038758"
+    "gsis_id": "00-0038758",
+    "sleeper_id": 11225
   },
   {
     "mfl_id": 16401,
-    "sleeper_id": 9503,
     "gsis_id": "00-0038843",
-    "yahoo_id": 40710
+    "sleeper_id": 9503,
+    "yahoo_id": 40710,
+    "espn_id": 4360233,
+    "espn_id_new": 4360233
   },
   {
     "mfl_id": 16402,
+    "gsis_id": "00-0038910",
     "sleeper_id": 11104,
+    "espn_id": 4362162,
     "pfr_id": "ThomSa00",
-    "gsis_id": "00-0038910"
+    "espn_id_new": 4362162
   },
   {
     "mfl_id": 16403,
-    "sleeper_id": 11068,
-    "pfr_id": "TinsMi00",
     "gsis_id": "00-0038839",
-    "yahoo_id": 40313
+    "sleeper_id": 11068,
+    "yahoo_id": 40313,
+    "espn_id": 4690070,
+    "pfr_id": "TinsMi00",
+    "espn_id_new": 4690070
   },
   {
     "mfl_id": 16404,
-    "sleeper_id": 11528,
-    "gsis_id": "00-0039043"
+    "gsis_id": "00-0039043",
+    "sleeper_id": 11528
   },
   {
     "mfl_id": 16405,
-    "sleeper_id": 8670,
     "gsis_id": "00-0037542",
-    "yahoo_id": 34657
+    "sleeper_id": 8670,
+    "yahoo_id": 34657,
+    "espn_id": 4051167,
+    "espn_id_new": 4051167
   },
   {
     "mfl_id": 16406,
-    "sleeper_id": 8192,
     "gsis_id": "00-0037164",
+    "sleeper_id": 8192,
     "yahoo_id": 34274
   },
   {
@@ -15611,65 +16499,79 @@
   },
   {
     "mfl_id": 16409,
-    "sleeper_id": 11114,
-    "pfr_id": "DotsEl00",
     "gsis_id": "00-0038862",
-    "yahoo_id": 40358
+    "sleeper_id": 11114,
+    "yahoo_id": 40358,
+    "espn_id": 4248909,
+    "pfr_id": "DotsEl00",
+    "espn_id_new": 4248909
   },
   {
     "mfl_id": 16410,
-    "sleeper_id": 11145,
     "gsis_id": "00-0038354",
-    "yahoo_id": 40376
+    "sleeper_id": 11145,
+    "yahoo_id": 40376,
+    "espn_id": 4696736,
+    "espn_id_new": 4696736
   },
   {
     "mfl_id": 16411,
-    "sleeper_id": 11119,
-    "gsis_id": "00-0038861"
+    "gsis_id": "00-0038861",
+    "sleeper_id": 11119
   },
   {
     "mfl_id": 16412,
-    "sleeper_id": 8938,
     "gsis_id": "00-0038150",
-    "yahoo_id": 40016
+    "sleeper_id": 8938,
+    "yahoo_id": 40016,
+    "espn_id": 4244688,
+    "espn_id_new": 4244688
   },
   {
     "mfl_id": 16413,
-    "sleeper_id": 11210,
-    "pfr_id": "HeatMa00",
     "gsis_id": "00-0038465",
-    "yahoo_id": 40445
+    "sleeper_id": 11210,
+    "yahoo_id": 40445,
+    "espn_id": 4689334,
+    "pfr_id": "HeatMa00",
+    "espn_id_new": 4689334
   },
   {
     "mfl_id": 16414,
-    "sleeper_id": 11533,
     "gsis_id": "00-0037692",
-    "yahoo_id": 40819
+    "sleeper_id": 11533,
+    "yahoo_id": 40819,
+    "espn_id": 3953687,
+    "espn_id_new": 3953687
   },
   {
     "mfl_id": 16415,
-    "sleeper_id": 11170,
-    "gsis_id": "00-0038949"
+    "gsis_id": "00-0038949",
+    "sleeper_id": 11170
   },
   {
     "mfl_id": 16416,
-    "sleeper_id": 11306,
-    "pfr_id": "GipsXa00",
     "gsis_id": "00-0038496",
-    "yahoo_id": 40548
+    "sleeper_id": 11306,
+    "yahoo_id": 40548,
+    "espn_id": 4427278,
+    "pfr_id": "GipsXa00",
+    "espn_id_new": 4427278
   },
   {
     "mfl_id": 16417,
-    "sleeper_id": 11216,
     "gsis_id": "00-0038749",
+    "sleeper_id": 11216,
     "yahoo_id": 40450
   },
   {
     "mfl_id": 16418,
-    "sleeper_id": 11514,
-    "pfr_id": "LandIs00",
     "gsis_id": "00-0038737",
-    "yahoo_id": 40779
+    "sleeper_id": 11514,
+    "yahoo_id": 40779,
+    "espn_id": 4574551,
+    "pfr_id": "LandIs00",
+    "espn_id_new": 4574551
   },
   {
     "mfl_id": 16419,
@@ -15687,29 +16589,35 @@
   },
   {
     "mfl_id": 16422,
-    "sleeper_id": 11320,
-    "gsis_id": "00-0038519"
+    "gsis_id": "00-0038519",
+    "sleeper_id": 11320
   },
   {
     "mfl_id": 16423,
-    "sleeper_id": 11311,
-    "pfr_id": "BrowJa07",
     "gsis_id": "00-0038492",
-    "yahoo_id": 40545
+    "sleeper_id": 11311,
+    "yahoo_id": 40545,
+    "espn_id": 4689988,
+    "pfr_id": "BrowJa07",
+    "espn_id_new": 4689988
   },
   {
     "mfl_id": 16424,
-    "sleeper_id": 11378,
-    "pfr_id": "MimsJo00",
     "gsis_id": "00-0038678",
-    "yahoo_id": 40631
+    "sleeper_id": 11378,
+    "yahoo_id": 40631,
+    "espn_id": 4243004,
+    "pfr_id": "MimsJo00",
+    "espn_id_new": 4243004
   },
   {
     "mfl_id": 16425,
-    "sleeper_id": 11371,
-    "pfr_id": "HillJu02",
     "gsis_id": "00-0038720",
-    "yahoo_id": 40629
+    "sleeper_id": 11371,
+    "yahoo_id": 40629,
+    "espn_id": 4365395,
+    "pfr_id": "HillJu02",
+    "espn_id_new": 4365395
   },
   {
     "mfl_id": 16426,
@@ -15717,122 +16625,150 @@
   },
   {
     "mfl_id": 16427,
-    "sleeper_id": 11247,
-    "gsis_id": "00-0038887"
+    "gsis_id": "00-0038887",
+    "sleeper_id": 11247
   },
   {
     "mfl_id": 16428,
-    "sleeper_id": 11168,
     "gsis_id": "00-0038359",
+    "sleeper_id": 11168,
     "yahoo_id": 40399
   },
   {
     "mfl_id": 16429,
-    "sleeper_id": 11474,
-    "pfr_id": "DrumDy00",
     "gsis_id": "00-0038953",
-    "yahoo_id": 40737
+    "sleeper_id": 11474,
+    "yahoo_id": 40737,
+    "espn_id": 4363551,
+    "pfr_id": "DrumDy00",
+    "espn_id_new": 4363551
   },
   {
     "mfl_id": 16430,
+    "gsis_id": "00-0038671",
     "sleeper_id": 11133,
-    "gsis_id": "00-0038671"
+    "espn_id": 4362650,
+    "espn_id_new": 4362650
   },
   {
     "mfl_id": 16431,
+    "gsis_id": "00-0038877",
     "sleeper_id": 11173,
+    "espn_id": 4362082,
     "pfr_id": "JamiDS00",
-    "gsis_id": "00-0038877"
+    "espn_id_new": 4362082
   },
   {
     "mfl_id": 16432,
-    "sleeper_id": 11435,
-    "pfr_id": "WilsEm00",
     "gsis_id": "00-0038797",
-    "yahoo_id": 40707
+    "sleeper_id": 11435,
+    "yahoo_id": 40707,
+    "espn_id": 4887558,
+    "pfr_id": "WilsEm00",
+    "espn_id_new": 4887558
   },
   {
     "mfl_id": 16433,
-    "sleeper_id": 11511
+    "sleeper_id": 11511,
+    "espn_id": 4362489,
+    "espn_id_new": 4362489
   },
   {
     "mfl_id": 16434,
     "sleeper_id": 11077,
-    "yahoo_id": 40307
+    "yahoo_id": 40307,
+    "espn_id": 4379410,
+    "espn_id_new": 4379410
   },
   {
     "mfl_id": 16435,
-    "sleeper_id": 8840,
     "gsis_id": "00-0037506",
+    "sleeper_id": 8840,
     "yahoo_id": 34543
   },
   {
     "mfl_id": 16436,
-    "sleeper_id": 11108,
-    "gsis_id": "00-0038908"
+    "gsis_id": "00-0038908",
+    "sleeper_id": 11108
   },
   {
     "mfl_id": 16437,
+    "gsis_id": "00-0038651",
     "sleeper_id": 11347,
-    "gsis_id": "00-0038651"
+    "espn_id": 4367186,
+    "espn_id_new": 4367186
   },
   {
     "mfl_id": 16438,
-    "sleeper_id": 11483,
     "gsis_id": "00-0038965",
+    "sleeper_id": 11483,
     "yahoo_id": 40748
   },
   {
     "mfl_id": 16439,
+    "gsis_id": "00-0038711",
     "sleeper_id": 11350,
+    "espn_id": 4567403,
     "pfr_id": "DiabMo00",
-    "gsis_id": "00-0038711"
+    "espn_id_new": 4567403
   },
   {
     "mfl_id": 16440,
+    "gsis_id": "00-0038851",
     "sleeper_id": 11098,
+    "espn_id": 4911489,
     "pfr_id": "MurpCa00",
-    "gsis_id": "00-0038851"
+    "espn_id_new": 4911489
   },
   {
     "mfl_id": 16441,
-    "sleeper_id": 11292,
-    "pfr_id": "DeViTo00",
     "gsis_id": "00-0038476",
-    "yahoo_id": 40533
+    "sleeper_id": 11292,
+    "yahoo_id": 40533,
+    "espn_id": 4240391,
+    "pfr_id": "DeViTo00",
+    "espn_id_new": 4240391
   },
   {
     "mfl_id": 16442,
-    "sleeper_id": 11184,
     "gsis_id": "00-0038702",
-    "yahoo_id": 40432
+    "sleeper_id": 11184,
+    "yahoo_id": 40432,
+    "espn_id": 4360644,
+    "espn_id_new": 4360644
   },
   {
     "mfl_id": 16443,
-    "sleeper_id": 11230,
-    "gsis_id": "00-0038764"
+    "gsis_id": "00-0038764",
+    "sleeper_id": 11230
   },
   {
     "mfl_id": 16444,
-    "sleeper_id": 11058,
     "gsis_id": "00-0038905",
-    "yahoo_id": 40296
+    "sleeper_id": 11058,
+    "yahoo_id": 40296,
+    "espn_id": 4259619,
+    "espn_id_new": 4259619
   },
   {
     "mfl_id": 16445,
-    "sleeper_id": 11105,
     "gsis_id": "00-0038902",
+    "sleeper_id": 11105,
     "yahoo_id": 40338
   },
   {
     "mfl_id": 16446,
-    "sleeper_id": 11432
+    "sleeper_id": 11432,
+    "espn_id": 4373706,
+    "espn_id_new": 4373706
   },
   {
     "mfl_id": 16447,
-    "sleeper_id": 11381,
     "gsis_id": "00-0038456",
-    "yahoo_id": 40643
+    "sleeper_id": 11381,
+    "yahoo_id": 40643,
+    "espn_id": 4259324,
+    "espn_id_new": 4259324
   },
   {
     "mfl_id": 16448,
@@ -15840,312 +16776,392 @@
   },
   {
     "mfl_id": 16449,
-    "sleeper_id": 11479,
-    "pfr_id": "GarrEr00",
     "gsis_id": "00-0038961",
-    "yahoo_id": 40739
+    "sleeper_id": 11479,
+    "yahoo_id": 40739,
+    "espn_id": 4363101,
+    "pfr_id": "GarrEr00",
+    "espn_id_new": 4363101
   },
   {
     "mfl_id": 16450,
+    "gsis_id": "00-0038922",
     "sleeper_id": 11470,
+    "espn_id": 4428659,
     "pfr_id": "ThomDr00",
-    "gsis_id": "00-0038922"
+    "espn_id_new": 4428659
   },
   {
     "mfl_id": 16451,
-    "sleeper_id": 11377,
     "gsis_id": "00-0038679",
+    "sleeper_id": 11377,
     "yahoo_id": 40630
   },
   {
     "mfl_id": 16452,
-    "sleeper_id": 8674
+    "sleeper_id": 8674,
+    "espn_id": 4248789,
+    "espn_id_new": 4248789
   },
   {
     "mfl_id": 16453,
-    "sleeper_id": 11139,
-    "pfr_id": "CookEl00",
     "gsis_id": "00-0038667",
-    "yahoo_id": 40374
+    "sleeper_id": 11139,
+    "yahoo_id": 40374,
+    "pfr_id": "CookEl00"
   },
   {
     "mfl_id": 16454,
-    "sleeper_id": 11278,
-    "pfr_id": "RickEl00",
     "gsis_id": "00-0038487",
-    "yahoo_id": 40511
+    "sleeper_id": 11278,
+    "yahoo_id": 40511,
+    "espn_id": 4429011,
+    "pfr_id": "RickEl00",
+    "espn_id_new": 4429011
   },
   {
     "mfl_id": 16455,
+    "gsis_id": "00-0038463",
     "sleeper_id": 11193,
+    "espn_id": 4361776,
     "pfr_id": "CoxxBr02",
-    "gsis_id": "00-0038463"
+    "espn_id_new": 4361776
   },
   {
     "mfl_id": 16456,
-    "sleeper_id": 11099,
-    "pfr_id": "JackKe02",
     "gsis_id": "00-0038969",
-    "yahoo_id": 40326
+    "sleeper_id": 11099,
+    "yahoo_id": 40326,
+    "espn_id": 4361778,
+    "pfr_id": "JackKe02",
+    "espn_id_new": 4361778
   },
   {
     "mfl_id": 16457,
     "sleeper_id": 11427,
-    "yahoo_id": 40681
+    "yahoo_id": 40681,
+    "espn_id": 4372459,
+    "espn_id_new": 4372459
   },
   {
     "mfl_id": 16458,
-    "sleeper_id": 11107
+    "sleeper_id": 11107,
+    "espn_id": 4568308,
+    "espn_id_new": 4568308
   },
   {
     "mfl_id": 16459,
+    "gsis_id": "00-0038853",
     "sleeper_id": 11454,
+    "espn_id": 4379411,
     "pfr_id": "ReesOt00",
-    "gsis_id": "00-0038853"
+    "espn_id_new": 4379411
   },
   {
     "mfl_id": 16460,
+    "gsis_id": "00-0038715",
     "sleeper_id": 11352,
+    "espn_id": 4569620,
     "pfr_id": "HickRo00",
-    "gsis_id": "00-0038715"
+    "espn_id_new": 4569620
   },
   {
     "mfl_id": 16461,
+    "gsis_id": "00-0037544",
     "sleeper_id": 8328,
+    "espn_id": 4241611,
     "pfr_id": "SeweNe00",
-    "gsis_id": "00-0037544"
+    "espn_id_new": 4241611
   },
   {
     "mfl_id": 16462,
-    "sleeper_id": 11277
+    "sleeper_id": 11277,
+    "espn_id": 4569130,
+    "espn_id_new": 4569130
   },
   {
     "mfl_id": 16463,
-    "sleeper_id": 11429,
-    "pfr_id": "MerrKa00",
     "gsis_id": "00-0038823",
-    "yahoo_id": 40684
+    "sleeper_id": 11429,
+    "yahoo_id": 40684,
+    "espn_id": 4360502,
+    "pfr_id": "MerrKa00",
+    "espn_id_new": 4360502
   },
   {
     "mfl_id": 16465,
+    "gsis_id": "00-0038811",
     "sleeper_id": 11076,
+    "espn_id": 4361382,
     "pfr_id": "ThomNa00",
-    "gsis_id": "00-0038811"
+    "espn_id_new": 4361382
   },
   {
     "mfl_id": 16466,
-    "sleeper_id": 8887,
-    "gsis_id": "00-0037627"
+    "gsis_id": "00-0037627",
+    "sleeper_id": 8887
   },
   {
     "mfl_id": 16467,
+    "gsis_id": "00-0038848",
     "sleeper_id": 11455,
+    "espn_id": 5143279,
     "pfr_id": "KendAn00",
-    "gsis_id": "00-0038848"
+    "espn_id_new": 5143279
   },
   {
     "mfl_id": 16468,
     "sleeper_id": 8841,
-    "yahoo_id": 34561
+    "yahoo_id": 34561,
+    "espn_id": 4569479,
+    "espn_id_new": 4569479
   },
   {
     "mfl_id": 16472,
-    "sleeper_id": 8397
+    "sleeper_id": 8397,
+    "espn_id": 4360590,
+    "espn_id_new": 4360590
   },
   {
     "mfl_id": 16474,
-    "sleeper_id": 11433,
-    "pfr_id": "AdkiNa00",
     "gsis_id": "00-0038783",
-    "yahoo_id": 40702
+    "sleeper_id": 11433,
+    "yahoo_id": 40702,
+    "espn_id": 4383440,
+    "pfr_id": "AdkiNa00",
+    "espn_id_new": 4383440
   },
   {
     "mfl_id": 16475,
+    "gsis_id": "00-0037136",
     "sleeper_id": 8298,
-    "gsis_id": "00-0037136"
+    "espn_id": 4360318,
+    "espn_id_new": 4360318
   },
   {
     "mfl_id": 16476,
+    "gsis_id": "00-0038513",
     "sleeper_id": 11315,
+    "espn_id": 4371959,
     "pfr_id": "JoneCa04",
-    "gsis_id": "00-0038513"
+    "espn_id_new": 4371959
   },
   {
     "mfl_id": 16477,
+    "gsis_id": "00-0038368",
     "sleeper_id": 11150,
+    "espn_id": 4371731,
     "pfr_id": "JohnQu01",
-    "gsis_id": "00-0038368"
+    "espn_id_new": 4371731
   },
   {
     "mfl_id": 16482,
-    "sleeper_id": 8537,
-    "gsis_id": "00-0037608"
+    "gsis_id": "00-0037608",
+    "sleeper_id": 8537
   },
   {
     "mfl_id": 16483,
-    "sleeper_id": 11082,
-    "pfr_id": "SimsBe00",
     "gsis_id": "00-0038809",
-    "yahoo_id": 40335
+    "sleeper_id": 11082,
+    "yahoo_id": 40335,
+    "espn_id": 4373030,
+    "pfr_id": "SimsBe00",
+    "espn_id_new": 4373030
   },
   {
     "mfl_id": 16484,
+    "gsis_id": "00-0037392",
     "sleeper_id": 8834,
+    "espn_id": 4360538,
     "pfr_id": "DenbTr00",
-    "gsis_id": "00-0037392"
+    "espn_id_new": 4360538
   },
   {
     "mfl_id": 16485,
+    "gsis_id": "00-0038791",
     "sleeper_id": 11441,
-    "pfr_id": "IncoTh00",
-    "gsis_id": "00-0038791"
+    "pfr_id": "IncoTh00"
   },
   {
     "mfl_id": 16486,
+    "gsis_id": "00-0038694",
     "sleeper_id": 11396,
-    "pfr_id": "PiliBr00",
-    "gsis_id": "00-0038694"
+    "pfr_id": "PiliBr00"
   },
   {
     "mfl_id": 16490,
+    "gsis_id": "00-0038827",
     "sleeper_id": 11425,
-    "pfr_id": "PittDe01",
-    "gsis_id": "00-0038827"
+    "pfr_id": "PittDe01"
   },
   {
     "mfl_id": 16492,
+    "gsis_id": "00-0038493",
     "sleeper_id": 11305,
+    "espn_id": 4256224,
     "pfr_id": "CherCl00",
-    "gsis_id": "00-0038493"
+    "espn_id_new": 4256224
   },
   {
     "mfl_id": 16493,
+    "gsis_id": "00-0038845",
     "sleeper_id": 11458,
+    "espn_id": 4250737,
     "pfr_id": "JackMa04",
-    "gsis_id": "00-0038845"
+    "espn_id_new": 4250737
   },
   {
     "mfl_id": 16496,
-    "sleeper_id": 11280,
-    "pfr_id": "RussBr00",
     "gsis_id": "00-0038488",
-    "yahoo_id": 40519
+    "sleeper_id": 11280,
+    "yahoo_id": 40519,
+    "espn_id": 4243176,
+    "pfr_id": "RussBr00",
+    "espn_id_new": 4243176
   },
   {
     "mfl_id": 16499,
-    "sleeper_id": 7521,
     "gsis_id": "00-0036463",
-    "yahoo_id": 33376
+    "sleeper_id": 7521,
+    "yahoo_id": 33376,
+    "espn_id": 4369886,
+    "espn_id_new": 4369886
   },
   {
     "mfl_id": 16502,
+    "gsis_id": "00-0038865",
     "sleeper_id": 11122,
+    "espn_id": 4394894,
     "pfr_id": "FarmAn00",
-    "gsis_id": "00-0038865"
+    "espn_id_new": 4394894
   },
   {
     "mfl_id": 16504,
+    "gsis_id": "00-0038655",
     "sleeper_id": 11487,
-    "pfr_id": "GilmSt01",
-    "gsis_id": "00-0038655"
+    "pfr_id": "GilmSt01"
   },
   {
     "mfl_id": 16507,
-    "sleeper_id": 8435,
-    "pfr_id": "LassKw20",
     "gsis_id": "00-0037420",
-    "yahoo_id": 34473
+    "sleeper_id": 8435,
+    "yahoo_id": 34473,
+    "espn_id": 4035912,
+    "pfr_id": "LassKw20",
+    "espn_id_new": 4035912
   },
   {
     "mfl_id": 16516,
+    "gsis_id": "00-0038742",
     "sleeper_id": 11512,
+    "espn_id": 4689333,
     "pfr_id": "WheaTy02",
-    "gsis_id": "00-0038742"
+    "espn_id_new": 4689333
   },
   {
     "mfl_id": 16517,
+    "gsis_id": "00-0038719",
     "sleeper_id": 11272,
-    "pfr_id": "ThomCh02",
-    "gsis_id": "00-0038719"
+    "pfr_id": "ThomCh02"
   },
   {
     "mfl_id": 16519,
+    "gsis_id": "00-0038663",
     "sleeper_id": 11343,
+    "espn_id": 4363408,
     "pfr_id": "ThomSt01",
-    "gsis_id": "00-0038663"
+    "espn_id_new": 4363408
   },
   {
     "mfl_id": 16520,
+    "gsis_id": "00-0038653",
     "sleeper_id": 11338,
-    "pfr_id": "DurdCo00",
-    "gsis_id": "00-0038653"
+    "pfr_id": "DurdCo00"
   },
   {
     "mfl_id": 16523,
-    "sleeper_id": 11384,
-    "pfr_id": "WrigOw00",
     "gsis_id": "00-0038458",
-    "yahoo_id": 40639
+    "sleeper_id": 11384,
+    "yahoo_id": 40639,
+    "espn_id": 4249616,
+    "pfr_id": "WrigOw00",
+    "espn_id_new": 4249616
   },
   {
     "mfl_id": 16526,
+    "gsis_id": "00-0038385",
     "sleeper_id": 11169,
-    "gsis_id": "00-0038385"
+    "espn_id": 4250970,
+    "espn_id_new": 4250970
   },
   {
     "mfl_id": 16529,
-    "sleeper_id": 11336,
-    "pfr_id": "LeotEk00",
     "gsis_id": "00-0038782",
-    "yahoo_id": 40574
+    "sleeper_id": 11336,
+    "yahoo_id": 40574,
+    "espn_id": 4361272,
+    "pfr_id": "LeotEk00",
+    "espn_id_new": 4361272
   },
   {
     "mfl_id": 16531,
+    "gsis_id": "00-0038523",
     "sleeper_id": 11489,
+    "espn_id": 4373814,
     "pfr_id": "HailKa00",
-    "gsis_id": "00-0038523"
+    "espn_id_new": 4373814
   },
   {
     "mfl_id": 16532,
+    "gsis_id": "00-0038660",
     "sleeper_id": 11348,
-    "pfr_id": "NowaTr00",
-    "gsis_id": "00-0038660"
+    "pfr_id": "NowaTr00"
   },
   {
     "mfl_id": 16533,
-    "sleeper_id": 11257,
-    "pfr_id": "JackSh01",
     "gsis_id": "00-0038891",
-    "yahoo_id": 40491
+    "sleeper_id": 11257,
+    "yahoo_id": 40491,
+    "pfr_id": "JackSh01"
   },
   {
     "mfl_id": 16535,
+    "gsis_id": "00-0038850",
     "sleeper_id": 11096,
+    "espn_id": 4568018,
     "pfr_id": "McLeTK00",
-    "gsis_id": "00-0038850"
+    "espn_id_new": 4568018
   },
   {
     "mfl_id": 16537,
-    "sleeper_id": 8763,
-    "pfr_id": "ThomTr01",
     "gsis_id": "00-0037377",
-    "yahoo_id": 34675
+    "sleeper_id": 8763,
+    "yahoo_id": 34675,
+    "espn_id": 4036817,
+    "pfr_id": "ThomTr01",
+    "espn_id_new": 4036817
   },
   {
     "mfl_id": 16542,
+    "gsis_id": "00-0038423",
     "sleeper_id": 11258,
+    "espn_id": 4259370,
     "pfr_id": "HarrJa04",
-    "gsis_id": "00-0038423"
+    "espn_id_new": 4259370
   },
   {
     "mfl_id": 16546,
+    "gsis_id": "00-0038674",
     "sleeper_id": 11132,
+    "espn_id": 4361779,
     "pfr_id": "WilsDi00",
-    "gsis_id": "00-0038674"
+    "espn_id_new": 4361779
   },
   {
     "mfl_id": 13675,
-    "gsis_id": "00-0034270"
+    "gsis_id": "00-0034270",
+    "espn_id": 3915486,
+    "espn_id_new": 3915486
   },
   {
     "mfl_id": 13847,


### PR DESCRIPTION
Replaced 5 incorrect espn_id values (Ramiz Ahmed, Nick Williams, Randy Gregory were wrong due to MFL API errors, and Michael Carter's were switched in missing_ids file even though MFL had it right).

Also added ~ 600 missing espn_id values by importing carefully from ffscrapr::espn_players() via joins by cleaned player + team. Took steps to maneuver duplicates in full_join.

I wanted to attach my R script but GitHub doesn't support that kind of file as an attachment. I'll just copy-paste my code below so you can check it and test it further. I'm willing to keep working on this in case there are any edge cases my code misses because the 600 missing ids are quite useful to me. But I do think my checking for duplicates and conservative approach with a left_join at the last step should minimize any errors.

```
#Read in Missing IDs file from Dynasty Process
old_missingplayerids <- jsonlite::fromJSON("https://raw.githubusercontent.com/dynastyprocess/data/master/files/missing_ids.json")

#First populate full MFL player list
mfl_names_list <- ffscrapr::mfl_players() %>%
  select(player_id,
         player_name,
         pos,
         team,
         espn_id) %>%
  rename(mfl_id = player_id,
         mfl_pos = pos,
         mfl_name_raw = player_name,
         mfl_team_raw = team) %>%
  mutate(player_name = nflreadr::clean_player_names(mfl_name_raw),
         team = nflreadr::clean_team_abbrs(mfl_team_raw),
         #Change mfl_id type to match original JSON
         mfl_id = as.integer(mfl_id),
         #Change espn_id type to match original JSON
         espn_id = as.integer(espn_id)) %>%
  # Filter out all MFL team position entries
  filter(mfl_id > 999)

# Clean ESPN player list for join
espn_names_list <- ffscrapr::espn_players() %>%
  rename(espn_id = player_id,
         espn_pos = pos,
         espn_name_raw = player_name,
         espn_team_raw = team) %>%
  mutate(player_name = nflreadr::clean_player_names(espn_name_raw),
         team = nflreadr::clean_team_abbrs(espn_team_raw))

# Find errors in mfl_players() espn_id by mapping mfl_players() to espn_players() by joining name and team
# Where test_1 entries are from duplicates above, we need to filter out wrong duplicate
# Where they are not duplicates, we need to overwrite incorrect data

joined_mfl_espn_players_raw <- mfl_names_list %>%
  full_join(., y = espn_names_list,
            by = c("player_name",
                   "team"))

# Test for contradictions in joined list
test_1_contradictions <- joined_mfl_espn_players_raw %>%
  filter(espn_id.x != espn_id.y)
view(test_1_contradictions)

# Test for duplicates in joined list to show which contradictions are from over-joined duplicates
test_2_duplicates <- joined_mfl_espn_players_raw %>%
  group_by(player_name, team) %>%
  filter(n() > 1) %>%
  arrange(player_name, team)
view(test_2_duplicates)

joined_mfl_espn_players_cleaned <- joined_mfl_espn_players_raw %>%
  mutate(espn_id.x = if_else(
    player_name %in% c("Nick Williams", "Randy Gregory", "Ramiz Ahmed") | is.na(espn_id.x),
    espn_id.y,  # Use espn_players() ID to correct errors and overwrite missing values
    espn_id.x   # Otherwise, keep mfl_players() espn_id value
  )) %>%
  #Filter out remaining contradictions from duplicates or team mismatch
  filter(espn_id.x == espn_id.y | is.na(espn_id.x) | is.na(espn_id.y)) %>%
  mutate(espn_id_new = espn_id.x) %>%
  select(-espn_id.x, -espn_id.y)

view(joined_mfl_espn_players_cleaned)

#Next, join these new espn_id's to the missing ID JSON and check for contradictions
complete_join <- old_missingplayerids %>%
  left_join(., y = joined_mfl_espn_players_cleaned %>%
              select(mfl_id, espn_id_new),
            by = "mfl_id")

#Check for contradictions in espn_id; use joined_mfl_espn_players_cleaned for mfl_id reference check
test_1_contradictions_final <- complete_join %>%
  filter(espn_id != espn_id_new)

new_missingplayerids <- complete_join %>%
  mutate(espn_id = if_else(
    is.na(espn_id) | espn_id != espn_id_new,
    espn_id_new,  # Overwrite with espn_id_new if espn_id is NA or not equal to espn_id_new
    espn_id       # Otherwise, keep the original espn_id
  ))

#convert back to json format
new_missingplayerids %>%
  toJSON(pretty = TRUE) %>%
  write(file = "C:/Users/filim/Documents/R/PullRequests/missing_ids.json")
```