### PR TITLE
Added 574 espn_id values

### DIFF
--- a/files/missing_ids.json
+++ b/files/missing_ids.json
@@ -12219,8 +12219,7 @@
   {
     "mfl_id": 15784,
     "sleeper_id": 8222,
-    "yahoo_id": 34557,
-    "espn_id": 4390717
+    "yahoo_id": 34557
   },
   {
     "mfl_id": 15785,

--- a/files/missing_ids.json
+++ b/files/missing_ids.json
@@ -134,6 +134,7 @@
     "gsis_id": "00-0022999",
     "pff_id": 2686,
     "sleeper_id": 53,
+    "espn_id": 9530,
     "ras_id": 7143,
     "otc_id": 1119
   },
@@ -177,6 +178,7 @@
     "gsis_id": "00-0026286",
     "pff_id": 4460,
     "sleeper_id": 25,
+    "espn_id": 11369,
     "pfr_id": "FeltJe00",
     "ras_id": 8216,
     "otc_id": 1951
@@ -196,6 +198,7 @@
     "gsis_id": "00-0026035",
     "pff_id": 4717,
     "sleeper_id": 491,
+    "espn_id": 11674,
     "pfr_id": "AmenDa00",
     "ras_id": 8128,
     "otc_id": 402
@@ -205,6 +208,7 @@
     "gsis_id": "00-0026069",
     "pff_id": 4740,
     "sleeper_id": 182,
+    "espn_id": 11658,
     "ras_id": 8314,
     "otc_id": 1186
   },
@@ -218,6 +222,7 @@
     "gsis_id": "00-0026932",
     "pff_id": 5109,
     "sleeper_id": 659,
+    "espn_id": 12519,
     "pfr_id": "PeerCe00",
     "ras_id": 8453,
     "otc_id": 1968
@@ -227,6 +232,7 @@
     "gsis_id": "00-0026393",
     "pff_id": 4702,
     "sleeper_id": 126,
+    "espn_id": 11717,
     "ras_id": 8283,
     "otc_id": 1283
   },
@@ -235,6 +241,7 @@
     "gsis_id": "00-0027651",
     "pff_id": 5561,
     "sleeper_id": 564,
+    "espn_id": 13207,
     "pfr_id": "McClDe00",
     "ras_id": 8899,
     "otc_id": 500
@@ -249,6 +256,7 @@
     "gsis_id": "00-0026855",
     "pff_id": 5440,
     "sleeper_id": 609,
+    "espn_id": 13158,
     "ras_id": 8418,
     "otc_id": 505
   },
@@ -262,6 +270,7 @@
     "gsis_id": "00-0028121",
     "pff_id": 6335,
     "sleeper_id": 895,
+    "espn_id": 14186,
     "pfr_id": "TodmJo00",
     "ras_id": 9447,
     "otc_id": 940
@@ -271,6 +280,7 @@
     "gsis_id": "00-0028149",
     "pff_id": 6363,
     "sleeper_id": 982,
+    "espn_id": 14083,
     "pfr_id": "MillBr02",
     "otc_id": 57
   },
@@ -284,6 +294,7 @@
     "gsis_id": "00-0028409",
     "pff_id": 6595,
     "sleeper_id": 863,
+    "espn_id": 14255,
     "ras_id": 9367,
     "otc_id": 1104
   },
@@ -321,6 +332,7 @@
     "gsis_id": "00-0029119",
     "pff_id": 7406,
     "sleeper_id": 1718,
+    "espn_id": 15403,
     "pfr_id": "CarrDe00",
     "ras_id": 9866,
     "otc_id": 743
@@ -330,6 +342,7 @@
     "gsis_id": "00-0029004",
     "pff_id": 7332,
     "sleeper_id": 1284,
+    "espn_id": 15369,
     "ras_id": 10087,
     "otc_id": 641
   },
@@ -348,6 +361,7 @@
     "gsis_id": "00-0029510",
     "pff_id": 7585,
     "sleeper_id": 1275,
+    "espn_id": 15632,
     "ras_id": 10019,
     "otc_id": 939
   },
@@ -356,6 +370,7 @@
     "gsis_id": "00-0028237",
     "pff_id": 6468,
     "sleeper_id": 1329,
+    "espn_id": 14402,
     "pfr_id": "HogaCh00",
     "ras_id": 8107,
     "otc_id": 216
@@ -388,6 +403,7 @@
     "gsis_id": "00-0029104",
     "pff_id": 7393,
     "sleeper_id": 1698,
+    "espn_id": 15364,
     "ras_id": 10017,
     "otc_id": 693
   },
@@ -396,6 +412,7 @@
     "gsis_id": "00-0029738",
     "pff_id": 8549,
     "sleeper_id": 1592,
+    "espn_id": 15773,
     "pfr_id": "FellDa01",
     "otc_id": 2426
   },
@@ -404,6 +421,7 @@
     "gsis_id": "00-0030155",
     "pff_id": 8524,
     "sleeper_id": 1619,
+    "espn_id": 16318,
     "pfr_id": "HarrDe03",
     "ras_id": 10487,
     "otc_id": 2736
@@ -413,6 +431,7 @@
     "gsis_id": "00-0030348",
     "pff_id": 8514,
     "sleeper_id": 1720,
+    "espn_id": 16530,
     "ras_id": 10673,
     "otc_id": 2592
   },
@@ -421,6 +440,7 @@
     "gsis_id": "00-0030181",
     "pff_id": 8520,
     "sleeper_id": 1706,
+    "espn_id": 16504,
     "pfr_id": "DoylJa00",
     "ras_id": 10557,
     "otc_id": 2520
@@ -430,6 +450,7 @@
     "gsis_id": "00-0030216",
     "pff_id": 8200,
     "sleeper_id": 1777,
+    "espn_id": 16143,
     "pfr_id": "HillJo02",
     "ras_id": 10629,
     "otc_id": 2594
@@ -439,17 +460,20 @@
     "gsis_id": "00-0030710",
     "pff_id": 9185,
     "sleeper_id": 1793,
+    "espn_id": 16974,
     "pfr_id": "BurtTr01",
     "ras_id": 11621,
     "otc_id": 3521
   },
   {
     "mfl_id": 11719,
-    "gsis_id": "00-0031193"
+    "gsis_id": "00-0031193",
+    "espn_id": 16952
   },
   {
     "mfl_id": 11724,
-    "gsis_id": "00-0031130"
+    "gsis_id": "00-0031130",
+    "espn_id": 17070
   },
   {
     "mfl_id": 11886,
@@ -466,6 +490,7 @@
     "gsis_id": "00-0030669",
     "pff_id": 8943,
     "sleeper_id": 2025,
+    "espn_id": 17051,
     "pfr_id": "WilsAl02",
     "ras_id": 11001,
     "otc_id": 3428
@@ -475,6 +500,7 @@
     "gsis_id": "00-0030789",
     "pff_id": 9014,
     "sleeper_id": 1928,
+    "espn_id": 17105,
     "ras_id": 11027,
     "otc_id": 3600
   },
@@ -511,6 +537,7 @@
     "gsis_id": "00-0028411",
     "pff_id": 6597,
     "sleeper_id": 2291,
+    "espn_id": 14269,
     "pfr_id": "InmaDo00",
     "ras_id": 9362,
     "otc_id": 2731
@@ -520,12 +547,14 @@
     "gsis_id": "00-0030860",
     "pff_id": 9173,
     "sleeper_id": 1819,
+    "espn_id": 17331,
     "ras_id": 11493,
     "otc_id": 3648
   },
   {
     "mfl_id": 12072,
-    "gsis_id": "00-0031120"
+    "gsis_id": "00-0031120",
+    "espn_id": 17401
   },
   {
     "mfl_id": 12110,
@@ -568,16 +597,16 @@
     "gsis_id": "00-0032189",
     "sleeper_id": 2489,
     "yahoo_id": 28576,
-    "pfr_id": "StewTo01",
-    "espn_id": 2576504
+    "espn_id": 2576504,
+    "pfr_id": "StewTo01"
   },
   {
     "mfl_id": 12354,
     "gsis_id": "00-0031613",
     "sleeper_id": 2508,
     "yahoo_id": 28595,
-    "pfr_id": "HerrAm00",
-    "espn_id": 2578542
+    "espn_id": 2578542,
+    "pfr_id": "HerrAm00"
   },
   {
     "mfl_id": 12386,
@@ -598,6 +627,7 @@
     "gsis_id": "00-0032160",
     "pff_id": 10154,
     "sleeper_id": 2583,
+    "espn_id": 2587819,
     "pfr_id": "WillTy00",
     "ras_id": 12252,
     "otc_id": 4630
@@ -682,14 +712,15 @@
     "gsis_id": "00-0032181",
     "sleeper_id": 2642,
     "yahoo_id": 29121,
-    "pfr_id": "BateHo00",
-    "espn_id": 2516049
+    "espn_id": 2516049,
+    "pfr_id": "BateHo00"
   },
   {
     "mfl_id": 12505,
     "gsis_id": "00-0032009",
     "pff_id": 10075,
     "sleeper_id": 2822,
+    "espn_id": 2576491,
     "pfr_id": "HumpAd00",
     "ras_id": 11672,
     "otc_id": 4567
@@ -699,6 +730,7 @@
     "gsis_id": "00-0032098",
     "pff_id": 10144,
     "sleeper_id": 2751,
+    "espn_id": 2519013,
     "pfr_id": "BrowDa04"
   },
   {
@@ -706,20 +738,21 @@
     "gsis_id": "00-0032044",
     "sleeper_id": 3069,
     "yahoo_id": 29065,
-    "pfr_id": "TavaJ.00",
-    "espn_id": 2577264
+    "espn_id": 2577264,
+    "pfr_id": "TavaJ.00"
   },
   {
     "mfl_id": 12605,
     "gsis_id": "00-0031791",
-    "pfr_id": "RoacTr00",
-    "espn_id": 2514179
+    "espn_id": 2514179,
+    "pfr_id": "RoacTr00"
   },
   {
     "mfl_id": 12637,
     "gsis_id": "00-0032741",
     "pff_id": 10927,
     "sleeper_id": 3594,
+    "espn_id": 3051902,
     "pfr_id": "BarbPe01",
     "ras_id": 12906,
     "otc_id": 5023
@@ -730,14 +763,14 @@
     "pff_id": 10907,
     "sleeper_id": 3453,
     "yahoo_id": 29599,
-    "pfr_id": "FergJo02",
-    "espn_id": 2576165
+    "espn_id": 2576165,
+    "pfr_id": "FergJo02"
   },
   {
     "mfl_id": 12641,
     "gsis_id": "00-0032672",
-    "pfr_id": "GreeAa01",
-    "espn_id": 2570994
+    "espn_id": 2570994,
+    "pfr_id": "GreeAa01"
   },
   {
     "mfl_id": 12642,
@@ -745,8 +778,8 @@
     "pff_id": 10988,
     "sleeper_id": 3532,
     "yahoo_id": 29518,
-    "pfr_id": "FarrKe02",
-    "espn_id": 2575553
+    "espn_id": 2575553,
+    "pfr_id": "FarrKe02"
   },
   {
     "mfl_id": 12644,
@@ -762,14 +795,14 @@
     "pff_id": 11246,
     "sleeper_id": 3519,
     "yahoo_id": 29855,
-    "pfr_id": "LewiRo03",
-    "espn_id": 3125745
+    "espn_id": 3125745,
+    "pfr_id": "LewiRo03"
   },
   {
     "mfl_id": 12653,
     "gsis_id": "00-0032694",
-    "pfr_id": "MarsJa01",
-    "espn_id": 3051400
+    "espn_id": 3051400,
+    "pfr_id": "MarsJa01"
   },
   {
     "mfl_id": 12661,
@@ -782,8 +815,8 @@
   {
     "mfl_id": 12663,
     "gsis_id": "00-0032974",
-    "pfr_id": "PaytJo00",
-    "espn_id": 2971588
+    "espn_id": 2971588,
+    "pfr_id": "PaytJo00"
   },
   {
     "mfl_id": 12665,
@@ -791,8 +824,8 @@
     "pff_id": 11141,
     "sleeper_id": 3503,
     "yahoo_id": 29719,
-    "pfr_id": "AlliGe01",
-    "espn_id": 3115913
+    "espn_id": 3115913,
+    "pfr_id": "AlliGe01"
   },
   {
     "mfl_id": 12667,
@@ -805,18 +838,19 @@
   {
     "mfl_id": 12669,
     "gsis_id": "00-0032400",
-    "pfr_id": "MitcMa01",
-    "espn_id": 2578553
+    "espn_id": 2578553,
+    "pfr_id": "MitcMa01"
   },
   {
     "mfl_id": 12672,
     "gsis_id": "00-0032801",
-    "pfr_id": "BravDa00",
-    "espn_id": 2973052
+    "espn_id": 2973052,
+    "pfr_id": "BravDa00"
   },
   {
     "mfl_id": 12675,
-    "sleeper_id": 3652
+    "sleeper_id": 3652,
+    "espn_id": 3123986
   },
   {
     "mfl_id": 12682,
@@ -840,46 +874,48 @@
     "pff_id": 11051,
     "sleeper_id": 3668,
     "yahoo_id": 29654,
-    "pfr_id": "PerkJo02",
-    "espn_id": 2578377
+    "espn_id": 2578377,
+    "pfr_id": "PerkJo02"
   },
   {
     "mfl_id": 12689,
     "gsis_id": "00-0033074",
-    "pfr_id": "DoddKe00",
-    "espn_id": 2977682
+    "espn_id": 2977682,
+    "pfr_id": "DoddKe00"
   },
   {
     "mfl_id": 12704,
     "gsis_id": "00-0032979",
-    "pfr_id": "WrigSc00",
-    "espn_id": 3056472
+    "espn_id": 3056472,
+    "pfr_id": "WrigSc00"
   },
   {
     "mfl_id": 12708,
     "gsis_id": "00-0032894",
-    "pfr_id": "PerrJo01",
-    "espn_id": 2976306
+    "espn_id": 2976306,
+    "pfr_id": "PerrJo01"
   },
   {
     "mfl_id": 12709,
     "gsis_id": "00-0032983",
-    "pfr_id": "AlexDo01",
-    "espn_id": 3052651
+    "espn_id": 3052651,
+    "pfr_id": "AlexDo01"
   },
   {
     "mfl_id": 12765,
-    "gsis_id": "00-0032769"
+    "gsis_id": "00-0032769",
+    "espn_id": 2972286
   },
   {
     "mfl_id": 12775,
-    "sleeper_id": 5547
+    "sleeper_id": 5547,
+    "espn_id": 2574666
   },
   {
     "mfl_id": 12793,
     "gsis_id": "00-0032973",
-    "pfr_id": "SancZa00",
-    "espn_id": 2976596
+    "espn_id": 2976596,
+    "pfr_id": "SancZa00"
   },
   {
     "mfl_id": 12797,
@@ -892,14 +928,14 @@
   {
     "mfl_id": 12818,
     "gsis_id": "00-0033113",
-    "pfr_id": "ForrJo00",
-    "espn_id": 2576678
+    "espn_id": 2576678,
+    "pfr_id": "ForrJo00"
   },
   {
     "mfl_id": 12820,
     "gsis_id": "00-0033056",
-    "pfr_id": "JameCo00",
-    "espn_id": 2575663
+    "espn_id": 2575663,
+    "pfr_id": "JameCo00"
   },
   {
     "mfl_id": 12822,
@@ -912,8 +948,8 @@
   {
     "mfl_id": 12825,
     "gsis_id": "00-0032796",
-    "pfr_id": "NicoDa00",
-    "espn_id": 3929954
+    "espn_id": 3929954,
+    "pfr_id": "NicoDa00"
   },
   {
     "mfl_id": 12844,
@@ -943,8 +979,8 @@
   {
     "mfl_id": 12863,
     "gsis_id": "00-0032679",
-    "pfr_id": "McRoPa00",
-    "espn_id": 2975817
+    "espn_id": 2975817,
+    "pfr_id": "McRoPa00"
   },
   {
     "mfl_id": 12864,
@@ -957,8 +993,8 @@
   {
     "mfl_id": 12865,
     "gsis_id": "00-0032739",
-    "pfr_id": "WillWe00",
-    "espn_id": 3933497
+    "espn_id": 3933497,
+    "pfr_id": "WillWe00"
   },
   {
     "mfl_id": 12867,
@@ -966,8 +1002,8 @@
     "pff_id": 11057,
     "sleeper_id": 3573,
     "yahoo_id": 29661,
-    "pfr_id": "WildBr01",
-    "espn_id": 2577692
+    "espn_id": 2577692,
+    "pfr_id": "WildBr01"
   },
   {
     "mfl_id": 12868,
@@ -975,8 +1011,8 @@
     "pff_id": 11335,
     "sleeper_id": 3465,
     "yahoo_id": 29913,
-    "pfr_id": "BrauBe00",
-    "espn_id": 2969241
+    "espn_id": 2969241,
+    "pfr_id": "BrauBe00"
   },
   {
     "mfl_id": 12870,
@@ -984,8 +1020,8 @@
     "pff_id": 11007,
     "sleeper_id": 3436,
     "yahoo_id": 29501,
-    "pfr_id": "CashJe00",
-    "espn_id": 2576378
+    "espn_id": 2576378,
+    "pfr_id": "CashJe00"
   },
   {
     "mfl_id": 12871,
@@ -993,14 +1029,14 @@
     "pff_id": 11214,
     "sleeper_id": 3488,
     "yahoo_id": 29872,
-    "pfr_id": "FostD.01",
-    "espn_id": 2978124
+    "espn_id": 2978124,
+    "pfr_id": "FostD.01"
   },
   {
     "mfl_id": 12872,
     "gsis_id": "00-0032322",
-    "pfr_id": "McCoDe00",
-    "espn_id": 2470860
+    "espn_id": 2470860,
+    "pfr_id": "McCoDe00"
   },
   {
     "mfl_id": 12873,
@@ -1016,12 +1052,13 @@
     "pff_id": 10960,
     "sleeper_id": 3612,
     "yahoo_id": 29587,
-    "pfr_id": "VallHa00",
-    "espn_id": 2567213
+    "espn_id": 2567213,
+    "pfr_id": "VallHa00"
   },
   {
     "mfl_id": 12878,
     "gsis_id": "00-0032462",
+    "espn_id": 2575910,
     "pfr_id": "BoykTr00"
   },
   {
@@ -1046,8 +1083,8 @@
     "pff_id": 11090,
     "sleeper_id": 3657,
     "yahoo_id": 29694,
-    "pfr_id": "KellRo00",
-    "espn_id": 2575408
+    "espn_id": 2575408,
+    "pfr_id": "KellRo00"
   },
   {
     "mfl_id": 12888,
@@ -1071,12 +1108,13 @@
     "pff_id": 11020,
     "sleeper_id": 3485,
     "yahoo_id": 29623,
-    "pfr_id": "KrieHe00",
-    "espn_id": 3144999
+    "espn_id": 3144999,
+    "pfr_id": "KrieHe00"
   },
   {
     "mfl_id": 12896,
     "gsis_id": "00-0032621",
+    "espn_id": 2579623,
     "pfr_id": "ScotRa01"
   },
   {
@@ -1090,8 +1128,8 @@
     "pff_id": 11139,
     "sleeper_id": 3715,
     "yahoo_id": 29783,
-    "pfr_id": "WickCo00",
-    "espn_id": 2982151
+    "espn_id": 2982151,
+    "pfr_id": "WickCo00"
   },
   {
     "mfl_id": 12900,
@@ -1107,8 +1145,8 @@
     "pff_id": 10902,
     "sleeper_id": 3550,
     "yahoo_id": 29514,
-    "pfr_id": "WilsJa00",
-    "espn_id": 2970661
+    "espn_id": 2970661,
+    "pfr_id": "WilsJa00"
   },
   {
     "mfl_id": 12908,
@@ -1116,8 +1154,8 @@
     "pff_id": 10115,
     "sleeper_id": 2634,
     "yahoo_id": 29085,
-    "pfr_id": "BrowMa02",
-    "espn_id": 2512191
+    "espn_id": 2512191,
+    "pfr_id": "BrowMa02"
   },
   {
     "mfl_id": 12912,
@@ -1125,8 +1163,8 @@
     "pff_id": 11395,
     "sleeper_id": 3868,
     "yahoo_id": 30000,
-    "pfr_id": "RichJa01",
-    "espn_id": 2972091
+    "espn_id": 2972091,
+    "pfr_id": "RichJa01"
   },
   {
     "mfl_id": 12913,
@@ -1149,8 +1187,8 @@
     "pff_id": 11354,
     "sleeper_id": 3476,
     "yahoo_id": 29958,
-    "pfr_id": "HoltJo00",
-    "espn_id": 3056906
+    "espn_id": 3056906,
+    "pfr_id": "HoltJo00"
   },
   {
     "mfl_id": 12917,
@@ -1158,8 +1196,8 @@
     "pff_id": 11035,
     "sleeper_id": 3650,
     "yahoo_id": 29638,
-    "pfr_id": "HarrMa05",
-    "espn_id": 2576868
+    "espn_id": 2576868,
+    "pfr_id": "HarrMa05"
   },
   {
     "mfl_id": 12918,
@@ -1175,8 +1213,8 @@
     "pff_id": 11231,
     "sleeper_id": 3614,
     "yahoo_id": 29854,
-    "pfr_id": "LewiTo00",
-    "espn_id": 2574918
+    "espn_id": 2574918,
+    "pfr_id": "LewiTo00"
   },
   {
     "mfl_id": 12923,
@@ -1208,6 +1246,7 @@
   {
     "mfl_id": 12927,
     "gsis_id": "00-0032841",
+    "espn_id": 2577286,
     "pfr_id": "TurnPa01"
   },
   {
@@ -1216,8 +1255,8 @@
     "pff_id": 10940,
     "sleeper_id": 3598,
     "yahoo_id": 29588,
-    "pfr_id": "RhodLu00",
-    "espn_id": 2566045
+    "espn_id": 2566045,
+    "pfr_id": "RhodLu00"
   },
   {
     "mfl_id": 12929,
@@ -1225,8 +1264,8 @@
     "pff_id": 11473,
     "sleeper_id": 3934,
     "yahoo_id": 30061,
-    "pfr_id": "PopeTr00",
-    "espn_id": 2983319
+    "espn_id": 2983319,
+    "pfr_id": "PopeTr00"
   },
   {
     "mfl_id": 12930,
@@ -1244,14 +1283,15 @@
     "pff_id": 11227,
     "sleeper_id": 3424,
     "yahoo_id": 29847,
-    "pfr_id": "HarrDe04",
-    "espn_id": 2972273
+    "espn_id": 2972273,
+    "pfr_id": "HarrDe04"
   },
   {
     "mfl_id": 12934,
     "gsis_id": "00-0032355",
     "pff_id": 10918,
     "sleeper_id": 3582,
+    "espn_id": 2983209,
     "pfr_id": "RogeCh02",
     "ras_id": 12407,
     "otc_id": 5086
@@ -1270,8 +1310,8 @@
     "pff_id": 11052,
     "sleeper_id": 3669,
     "yahoo_id": 29655,
-    "pfr_id": "PoolBr01",
-    "espn_id": 2980115
+    "espn_id": 2980115,
+    "pfr_id": "PoolBr01"
   },
   {
     "mfl_id": 12939,
@@ -1284,8 +1324,8 @@
     "pff_id": 11142,
     "sleeper_id": 3716,
     "yahoo_id": 29720,
-    "pfr_id": "BricKe00",
-    "espn_id": 2971881
+    "espn_id": 2971881,
+    "pfr_id": "BricKe00"
   },
   {
     "mfl_id": 12941,
@@ -1314,6 +1354,7 @@
   {
     "mfl_id": 12947,
     "gsis_id": "00-0032724",
+    "espn_id": 2978219,
     "pfr_id": "TregBr00"
   },
   {
@@ -1331,8 +1372,8 @@
     "pff_id": 11288,
     "sleeper_id": 3788,
     "yahoo_id": 29825,
-    "pfr_id": "McEvTa01",
-    "espn_id": 2577684
+    "espn_id": 2577684,
+    "pfr_id": "McEvTa01"
   },
   {
     "mfl_id": 12950,
@@ -1340,8 +1381,8 @@
     "pff_id": 11162,
     "sleeper_id": 3446,
     "yahoo_id": 29794,
-    "pfr_id": "HeatJo00",
-    "espn_id": 2576267
+    "espn_id": 2576267,
+    "pfr_id": "HeatJo00"
   },
   {
     "mfl_id": 12951,
@@ -1349,8 +1390,8 @@
     "pff_id": 11187,
     "sleeper_id": 3745,
     "yahoo_id": 29716,
-    "pfr_id": "GrigNi01",
-    "espn_id": 2576660
+    "espn_id": 2576660,
+    "pfr_id": "GrigNi01"
   },
   {
     "mfl_id": 12952,
@@ -1371,6 +1412,7 @@
   {
     "mfl_id": 12954,
     "gsis_id": "00-0032515",
+    "espn_id": 3125253,
     "pfr_id": "BowmBr00"
   },
   {
@@ -1395,8 +1437,8 @@
     "pff_id": 11224,
     "sleeper_id": 3426,
     "yahoo_id": 29842,
-    "pfr_id": "CrawKe02",
-    "espn_id": 2979612
+    "espn_id": 2979612,
+    "pfr_id": "CrawKe02"
   },
   {
     "mfl_id": 12958,
@@ -1404,8 +1446,8 @@
     "pff_id": 11011,
     "sleeper_id": 3513,
     "yahoo_id": 29505,
-    "pfr_id": "NorrJa00",
-    "espn_id": 2575997
+    "espn_id": 2575997,
+    "pfr_id": "NorrJa00"
   },
   {
     "mfl_id": 12960,
@@ -1413,8 +1455,8 @@
     "pff_id": 11083,
     "sleeper_id": 3784,
     "yahoo_id": 29687,
-    "pfr_id": "VaeaDe01",
-    "espn_id": 2978355
+    "espn_id": 2978355,
+    "pfr_id": "VaeaDe01"
   },
   {
     "mfl_id": 12961,
@@ -1427,6 +1469,7 @@
   {
     "mfl_id": 12962,
     "gsis_id": "00-0032361",
+    "espn_id": 2577719,
     "pfr_id": "MaggCu00"
   },
   {
@@ -1440,8 +1483,8 @@
     "pff_id": 11169,
     "sleeper_id": 3734,
     "yahoo_id": 29807,
-    "pfr_id": "ScarBr00",
-    "espn_id": 2576885
+    "espn_id": 2576885,
+    "pfr_id": "ScarBr00"
   },
   {
     "mfl_id": 12965,
@@ -1449,8 +1492,8 @@
     "pff_id": 11343,
     "sleeper_id": 3828,
     "yahoo_id": 29952,
-    "pfr_id": "EvanMa00",
-    "espn_id": 3053027
+    "espn_id": 3053027,
+    "pfr_id": "EvanMa00"
   },
   {
     "mfl_id": 12966,
@@ -1463,6 +1506,7 @@
   {
     "mfl_id": 12967,
     "gsis_id": "00-0032491",
+    "espn_id": 2978064,
     "pfr_id": "AlbrBr00"
   },
   {
@@ -1471,8 +1515,8 @@
     "pff_id": 10903,
     "sleeper_id": 3474,
     "yahoo_id": 29507,
-    "pfr_id": "BoddBr01",
-    "espn_id": 2970694
+    "espn_id": 2970694,
+    "pfr_id": "BoddBr01"
   },
   {
     "mfl_id": 12971,
@@ -1480,12 +1524,13 @@
     "pff_id": 10937,
     "sleeper_id": 3597,
     "yahoo_id": 29581,
-    "pfr_id": "LambDa01",
-    "espn_id": 3121601
+    "espn_id": 3121601,
+    "pfr_id": "LambDa01"
   },
   {
     "mfl_id": 12972,
     "gsis_id": "00-0032465",
+    "espn_id": 2575655,
     "pfr_id": "ElliDe01"
   },
   {
@@ -1567,8 +1612,8 @@
     "pff_id": 11149,
     "sleeper_id": 3721,
     "yahoo_id": 29729,
-    "pfr_id": "HawkJo00",
-    "espn_id": 2575523
+    "espn_id": 2575523,
+    "pfr_id": "HawkJo00"
   },
   {
     "mfl_id": 12998,
@@ -1585,8 +1630,8 @@
     "pff_id": 11218,
     "sleeper_id": 3416,
     "yahoo_id": 29876,
-    "pfr_id": "LeBlCr01",
-    "espn_id": 2982870
+    "espn_id": 2982870,
+    "pfr_id": "LeBlCr01"
   },
   {
     "mfl_id": 13011,
@@ -1594,8 +1639,8 @@
     "pff_id": 11243,
     "sleeper_id": 3766,
     "yahoo_id": 29848,
-    "pfr_id": "HuntMi00",
-    "espn_id": 2578305
+    "espn_id": 2578305,
+    "pfr_id": "HuntMi00"
   },
   {
     "mfl_id": 13013,
@@ -1603,8 +1648,8 @@
     "pff_id": 11215,
     "sleeper_id": 3763,
     "yahoo_id": 29873,
-    "pfr_id": "HamiWo00",
-    "espn_id": 2577392
+    "espn_id": 2577392,
+    "pfr_id": "HamiWo00"
   },
   {
     "mfl_id": 13015,
@@ -1612,8 +1657,8 @@
     "pff_id": 11285,
     "sleeper_id": 3563,
     "yahoo_id": 29818,
-    "pfr_id": "LongSt00",
-    "espn_id": 2982803
+    "espn_id": 2982803,
+    "pfr_id": "LongSt00"
   },
   {
     "mfl_id": 13019,
@@ -1621,12 +1666,13 @@
     "pff_id": 10933,
     "sleeper_id": 3461,
     "yahoo_id": 29575,
-    "pfr_id": "HansRu00",
-    "espn_id": 2971435
+    "espn_id": 2971435,
+    "pfr_id": "HansRu00"
   },
   {
     "mfl_id": 13021,
     "gsis_id": "00-0032636",
+    "espn_id": 3042945,
     "pfr_id": "JackDo01"
   },
   {
@@ -1635,8 +1681,8 @@
     "pff_id": 11004,
     "sleeper_id": 3438,
     "yahoo_id": 29534,
-    "pfr_id": "WillTr05",
-    "espn_id": 2979605
+    "espn_id": 2979605,
+    "pfr_id": "WillTr05"
   },
   {
     "mfl_id": 13023,
@@ -1649,8 +1695,8 @@
     "pff_id": 11100,
     "sleeper_id": 3680,
     "yahoo_id": 29758,
-    "pfr_id": "OnwuPa00",
-    "espn_id": 2576761
+    "espn_id": 2576761,
+    "pfr_id": "OnwuPa00"
   },
   {
     "mfl_id": 13027,
@@ -1658,8 +1704,8 @@
     "pff_id": 11391,
     "sleeper_id": 3864,
     "yahoo_id": 30002,
-    "pfr_id": "LampJa00",
-    "espn_id": 3057850
+    "espn_id": 3057850,
+    "pfr_id": "LampJa00"
   },
   {
     "mfl_id": 13043,
@@ -1667,8 +1713,8 @@
     "pff_id": 10992,
     "sleeper_id": 3537,
     "yahoo_id": 29522,
-    "pfr_id": "LandCh00",
-    "espn_id": 2574558
+    "espn_id": 2574558,
+    "pfr_id": "LandCh00"
   },
   {
     "mfl_id": 13045,
@@ -1676,8 +1722,8 @@
     "pff_id": 11181,
     "sleeper_id": 3417,
     "yahoo_id": 29885,
-    "pfr_id": "SmitTe04",
-    "espn_id": 2576809
+    "espn_id": 2576809,
+    "pfr_id": "SmitTe04"
   },
   {
     "mfl_id": 13052,
@@ -1728,8 +1774,8 @@
     "pff_id": 11326,
     "sleeper_id": 3824,
     "yahoo_id": 29944,
-    "pfr_id": "ElliAl01",
-    "espn_id": 2577731
+    "espn_id": 2577731,
+    "pfr_id": "ElliAl01"
   },
   {
     "mfl_id": 13069,
@@ -1753,8 +1799,8 @@
     "pff_id": 11394,
     "sleeper_id": 3867,
     "yahoo_id": 29999,
-    "pfr_id": "JackBr04",
-    "espn_id": 2577642
+    "espn_id": 2577642,
+    "pfr_id": "JackBr04"
   },
   {
     "mfl_id": 13075,
@@ -1767,6 +1813,7 @@
   {
     "mfl_id": 13078,
     "gsis_id": "00-0032290",
+    "espn_id": 2512218,
     "pfr_id": "ReedTr00"
   },
   {
@@ -1775,8 +1822,8 @@
     "pff_id": 11262,
     "sleeper_id": 3643,
     "yahoo_id": 29798,
-    "pfr_id": "MiddDo01",
-    "espn_id": 2567725
+    "espn_id": 2567725,
+    "pfr_id": "MiddDo01"
   },
   {
     "mfl_id": 13083,
@@ -1805,8 +1852,8 @@
     "pff_id": 11050,
     "sleeper_id": 3667,
     "yahoo_id": 29653,
-    "pfr_id": "NeasSh00",
-    "espn_id": 2982866
+    "espn_id": 2982866,
+    "pfr_id": "NeasSh00"
   },
   {
     "mfl_id": 13100,
@@ -1874,8 +1921,8 @@
     "pff_id": 12202,
     "sleeper_id": 4635,
     "yahoo_id": 30370,
-    "pfr_id": "DaviJu00",
-    "espn_id": 3043216
+    "espn_id": 3043216,
+    "pfr_id": "DaviJu00"
   },
   {
     "mfl_id": 13161,
@@ -1907,8 +1954,8 @@
     "pff_id": 47997,
     "sleeper_id": 4644,
     "yahoo_id": 30737,
-    "pfr_id": "RudoTr00",
-    "espn_id": 3122935
+    "espn_id": 3122935,
+    "pfr_id": "RudoTr00"
   },
   {
     "mfl_id": 13184,
@@ -1923,6 +1970,7 @@
     "gsis_id": "00-0032813",
     "pff_id": 11300,
     "sleeper_id": 3803,
+    "espn_id": 2575965,
     "pfr_id": "PennEl00",
     "ras_id": 12565,
     "otc_id": 5530
@@ -1964,6 +2012,7 @@
   {
     "mfl_id": 13318,
     "gsis_id": "00-0033961",
+    "espn_id": 2584628,
     "pfr_id": "DonaDy00"
   },
   {
@@ -1980,14 +2029,15 @@
     "pff_id": 12215,
     "sleeper_id": 4416,
     "yahoo_id": 30656,
-    "pfr_id": "CarrAu00",
-    "espn_id": 2974339
+    "espn_id": 2974339,
+    "pfr_id": "CarrAu00"
   },
   {
     "mfl_id": 13369,
     "gsis_id": "00-0033338",
     "pff_id": 47149,
     "sleeper_id": 4362,
+    "espn_id": 3040470,
     "pfr_id": "CartCe00"
   },
   {
@@ -1996,8 +2046,8 @@
     "pff_id": 12014,
     "sleeper_id": 4526,
     "yahoo_id": 30487,
-    "pfr_id": "HogaKr00",
-    "espn_id": 4198679
+    "espn_id": 4198679,
+    "pfr_id": "HogaKr00"
   },
   {
     "mfl_id": 13371,
@@ -2013,8 +2063,8 @@
     "pff_id": 12170,
     "sleeper_id": 4551,
     "yahoo_id": 30720,
-    "pfr_id": "GentTa00",
-    "espn_id": 3043841
+    "espn_id": 3043841,
+    "pfr_id": "GentTa00"
   },
   {
     "mfl_id": 13375,
@@ -2022,14 +2072,15 @@
     "pff_id": 12269,
     "sleeper_id": 4453,
     "yahoo_id": 30550,
-    "pfr_id": "BoldVi00",
-    "espn_id": 3056476
+    "espn_id": 3056476,
+    "pfr_id": "BoldVi00"
   },
   {
     "mfl_id": 13377,
     "gsis_id": "00-0033375",
     "pff_id": 12087,
     "sleeper_id": 4351,
+    "espn_id": 3134353,
     "pfr_id": "PatrTi00",
     "ras_id": 15006,
     "otc_id": 6035
@@ -2049,6 +2100,7 @@
     "gsis_id": "00-0033611",
     "pff_id": 12020,
     "sleeper_id": 4531,
+    "espn_id": 3051806,
     "pfr_id": "SealRi00",
     "ras_id": 14780,
     "otc_id": 5938
@@ -2067,8 +2119,8 @@
     "pff_id": 45675,
     "sleeper_id": 4349,
     "yahoo_id": 900125,
-    "pfr_id": "MizzTa00",
-    "espn_id": 3048680
+    "espn_id": 3048680,
+    "pfr_id": "MizzTa00"
   },
   {
     "mfl_id": 13385,
@@ -2083,6 +2135,7 @@
     "gsis_id": "00-0032980",
     "pff_id": 11074,
     "sleeper_id": 3445,
+    "espn_id": 2971718,
     "pfr_id": "JohnMa07",
     "otc_id": 5178
   },
@@ -2092,8 +2145,8 @@
     "pff_id": 50118,
     "sleeper_id": 4426,
     "yahoo_id": 30666,
-    "pfr_id": "LangHa00",
-    "espn_id": 2570996
+    "espn_id": 2570996,
+    "pfr_id": "LangHa00"
   },
   {
     "mfl_id": 13389,
@@ -2109,14 +2162,15 @@
     "pff_id": 31892,
     "sleeper_id": 4750,
     "yahoo_id": 30899,
-    "pfr_id": "LenoLa00",
-    "espn_id": 3049249
+    "espn_id": 3049249,
+    "pfr_id": "LenoLa00"
   },
   {
     "mfl_id": 13391,
     "gsis_id": "00-0033387",
     "pff_id": 12051,
     "sleeper_id": 4421,
+    "espn_id": 3125404,
     "pfr_id": "HollJa03",
     "ras_id": 13986,
     "otc_id": 6126
@@ -2127,14 +2181,15 @@
     "pff_id": 10140,
     "sleeper_id": 2613,
     "yahoo_id": 29111,
-    "pfr_id": "AdamTy00",
-    "espn_id": 3895228
+    "espn_id": 3895228,
+    "pfr_id": "AdamTy00"
   },
   {
     "mfl_id": 13396,
     "gsis_id": "00-0033258",
     "pff_id": 12122,
     "sleeper_id": 4323,
+    "espn_id": 3052166,
     "pfr_id": "DaniDa02",
     "ras_id": 13610,
     "otc_id": 5978
@@ -2145,8 +2200,8 @@
     "pff_id": 12102,
     "sleeper_id": 4564,
     "yahoo_id": 30548,
-    "pfr_id": "NacuKa00",
-    "espn_id": 3053804
+    "espn_id": 3053804,
+    "pfr_id": "NacuKa00"
   },
   {
     "mfl_id": 13398,
@@ -2159,6 +2214,7 @@
   {
     "mfl_id": 13400,
     "gsis_id": "00-0033316",
+    "espn_id": 3050534,
     "pfr_id": "JeroLo00"
   },
   {
@@ -2167,8 +2223,8 @@
     "pff_id": 12081,
     "sleeper_id": 4311,
     "yahoo_id": 30499,
-    "pfr_id": "GracJe00",
-    "espn_id": 3051924
+    "espn_id": 3051924,
+    "pfr_id": "GracJe00"
   },
   {
     "mfl_id": 13403,
@@ -2193,8 +2249,8 @@
     "pff_id": 12085,
     "sleeper_id": 4342,
     "yahoo_id": 30512,
-    "pfr_id": "AdebQu00",
-    "espn_id": 3051869
+    "espn_id": 3051869,
+    "pfr_id": "AdebQu00"
   },
   {
     "mfl_id": 13407,
@@ -2207,6 +2263,7 @@
   {
     "mfl_id": 13408,
     "gsis_id": "00-0033352",
+    "espn_id": 3931763,
     "pfr_id": "ClarMi00"
   },
   {
@@ -2223,8 +2280,8 @@
     "pff_id": 12267,
     "sleeper_id": 4678,
     "yahoo_id": 30763,
-    "pfr_id": "SwooTy00",
-    "espn_id": 3046705
+    "espn_id": 3046705,
+    "pfr_id": "SwooTy00"
   },
   {
     "mfl_id": 13412,
@@ -2260,8 +2317,8 @@
     "pff_id": 12250,
     "sleeper_id": 4511,
     "yahoo_id": 30700,
-    "pfr_id": "LewiLa01",
-    "espn_id": 2972232
+    "espn_id": 2972232,
+    "pfr_id": "LewiLa01"
   },
   {
     "mfl_id": 13418,
@@ -2387,6 +2444,7 @@
     "gsis_id": "00-0033748",
     "pff_id": 12185,
     "sleeper_id": 4596,
+    "espn_id": 2979825,
     "pfr_id": "GreeTi00",
     "ras_id": 15010,
     "otc_id": 6214
@@ -2397,8 +2455,8 @@
     "pff_id": 12037,
     "sleeper_id": 4660,
     "yahoo_id": 30420,
-    "pfr_id": "CulkSe00",
-    "espn_id": 2971426
+    "espn_id": 2971426,
+    "pfr_id": "CulkSe00"
   },
   {
     "mfl_id": 13439,
@@ -2422,8 +2480,8 @@
     "pff_id": 37997,
     "sleeper_id": 4684,
     "yahoo_id": 30846,
-    "pfr_id": "HillJa01",
-    "espn_id": 3057517
+    "espn_id": 3057517,
+    "pfr_id": "HillJa01"
   },
   {
     "mfl_id": 13442,
@@ -2431,8 +2489,8 @@
     "pff_id": 51190,
     "sleeper_id": 4400,
     "yahoo_id": 30652,
-    "pfr_id": "SmitMa04",
-    "espn_id": 3054859
+    "espn_id": 3054859,
+    "pfr_id": "SmitMa04"
   },
   {
     "mfl_id": 13443,
@@ -2440,8 +2498,8 @@
     "pff_id": 49282,
     "sleeper_id": 4689,
     "yahoo_id": 30848,
-    "pfr_id": "CartJa02",
-    "espn_id": 3051925
+    "espn_id": 3051925,
+    "pfr_id": "CartJa02"
   },
   {
     "mfl_id": 13444,
@@ -2449,14 +2507,15 @@
     "pff_id": 12236,
     "sleeper_id": 4643,
     "yahoo_id": 30736,
-    "pfr_id": "MunsCa00",
-    "espn_id": 3047530
+    "espn_id": 3047530,
+    "pfr_id": "MunsCa00"
   },
   {
     "mfl_id": 13445,
     "gsis_id": "00-0033421",
     "pff_id": 24606,
     "sleeper_id": 4468,
+    "espn_id": 4081127,
     "pfr_id": "AuclAn00"
   },
   {
@@ -2465,8 +2524,8 @@
     "pff_id": 50712,
     "sleeper_id": 4368,
     "yahoo_id": 30583,
-    "pfr_id": "NickHa02",
-    "espn_id": 2978211
+    "espn_id": 2978211,
+    "pfr_id": "NickHa02"
   },
   {
     "mfl_id": 13447,
@@ -2491,8 +2550,8 @@
     "pff_id": 12338,
     "sleeper_id": 4720,
     "yahoo_id": 30865,
-    "pfr_id": "HatfDo00",
-    "espn_id": 3052502
+    "espn_id": 3052502,
+    "pfr_id": "HatfDo00"
   },
   {
     "mfl_id": 13450,
@@ -2508,8 +2567,8 @@
     "pff_id": 38329,
     "sleeper_id": 4696,
     "yahoo_id": 30850,
-    "pfr_id": "EdmuTr00",
-    "espn_id": 2970090
+    "espn_id": 2970090,
+    "pfr_id": "EdmuTr00"
   },
   {
     "mfl_id": 13453,
@@ -2525,8 +2584,8 @@
     "pff_id": 12083,
     "sleeper_id": 4345,
     "yahoo_id": 30514,
-    "pfr_id": "BradBa00",
-    "espn_id": 2970256
+    "espn_id": 2970256,
+    "pfr_id": "BradBa00"
   },
   {
     "mfl_id": 13455,
@@ -2540,8 +2599,8 @@
     "pff_id": 12068,
     "sleeper_id": 4476,
     "yahoo_id": 30477,
-    "pfr_id": "MabiGr00",
-    "espn_id": 2979515
+    "espn_id": 2979515,
+    "pfr_id": "MabiGr00"
   },
   {
     "mfl_id": 13457,
@@ -2549,8 +2608,8 @@
     "pff_id": 51176,
     "sleeper_id": 4363,
     "yahoo_id": 30578,
-    "pfr_id": "CoxxDe00",
-    "espn_id": 2979535
+    "espn_id": 2979535,
+    "pfr_id": "CoxxDe00"
   },
   {
     "mfl_id": 13459,
@@ -2558,8 +2617,8 @@
     "pff_id": 12194,
     "sleeper_id": 4603,
     "yahoo_id": 30778,
-    "pfr_id": "ValoJe00",
-    "espn_id": 2976151
+    "espn_id": 2976151,
+    "pfr_id": "ValoJe00"
   },
   {
     "mfl_id": 13460,
@@ -2567,8 +2626,8 @@
     "pff_id": 48856,
     "sleeper_id": 4604,
     "yahoo_id": 30792,
-    "pfr_id": "AnkoEl00",
-    "espn_id": 3008150
+    "espn_id": 3008150,
+    "pfr_id": "AnkoEl00"
   },
   {
     "mfl_id": 13461,
@@ -2576,8 +2635,8 @@
     "pff_id": 51589,
     "sleeper_id": 4352,
     "yahoo_id": 30622,
-    "pfr_id": "PaynDo00",
-    "espn_id": 3048402
+    "espn_id": 3048402,
+    "pfr_id": "PaynDo00"
   },
   {
     "mfl_id": 13462,
@@ -2585,8 +2644,8 @@
     "pff_id": 12039,
     "sleeper_id": 4668,
     "yahoo_id": 30428,
-    "pfr_id": "OnwuJa00",
-    "espn_id": 3052889
+    "espn_id": 3052889,
+    "pfr_id": "OnwuJa00"
   },
   {
     "mfl_id": 13463,
@@ -2594,8 +2653,8 @@
     "pff_id": 12211,
     "sleeper_id": 4389,
     "yahoo_id": 30640,
-    "pfr_id": "AlleCh02",
-    "espn_id": 2975680
+    "espn_id": 2975680,
+    "pfr_id": "AlleCh02"
   },
   {
     "mfl_id": 13465,
@@ -2603,8 +2662,8 @@
     "pff_id": 12097,
     "sleeper_id": 4558,
     "yahoo_id": 30539,
-    "pfr_id": "BellB.00",
-    "espn_id": 2970622
+    "espn_id": 2970622,
+    "pfr_id": "BellB.00"
   },
   {
     "mfl_id": 13466,
@@ -2637,8 +2696,8 @@
     "pff_id": 50835,
     "sleeper_id": 4452,
     "yahoo_id": 30638,
-    "pfr_id": "WoodXa01",
-    "espn_id": 3042370
+    "espn_id": 3042370,
+    "pfr_id": "WoodXa01"
   },
   {
     "mfl_id": 13474,
@@ -2646,8 +2705,8 @@
     "pff_id": 12183,
     "sleeper_id": 4594,
     "yahoo_id": 30766,
-    "pfr_id": "BarrAl00",
-    "espn_id": 2976114
+    "espn_id": 2976114,
+    "pfr_id": "BarrAl00"
   },
   {
     "mfl_id": 13475,
@@ -2655,8 +2714,8 @@
     "pff_id": 12038,
     "sleeper_id": 4664,
     "yahoo_id": 30424,
-    "pfr_id": "HarrNi00",
-    "espn_id": 3051368
+    "espn_id": 3051368,
+    "pfr_id": "HarrNi00"
   },
   {
     "mfl_id": 13476,
@@ -2664,8 +2723,8 @@
     "pff_id": 23652,
     "sleeper_id": 4605,
     "yahoo_id": 30795,
-    "pfr_id": "BaylEv00",
-    "espn_id": 2971280
+    "espn_id": 2971280,
+    "pfr_id": "BaylEv00"
   },
   {
     "mfl_id": 13479,
@@ -2708,8 +2767,8 @@
     "pff_id": 12330,
     "sleeper_id": 4719,
     "yahoo_id": 30861,
-    "pfr_id": "ThomCh05",
-    "espn_id": 3054970
+    "espn_id": 3054970,
+    "pfr_id": "ThomCh05"
   },
   {
     "mfl_id": 13493,
@@ -2725,8 +2784,8 @@
     "pff_id": 10935,
     "sleeper_id": 3592,
     "yahoo_id": 29577,
-    "pfr_id": "JohnIs00",
-    "espn_id": 2570484
+    "espn_id": 2570484,
+    "pfr_id": "JohnIs00"
   },
   {
     "mfl_id": 13502,
@@ -2741,6 +2800,7 @@
     "gsis_id": "00-0033481",
     "pff_id": 12137,
     "sleeper_id": 4491,
+    "espn_id": 3046399,
     "pfr_id": "KempMa00"
   },
   {
@@ -2756,6 +2816,7 @@
     "gsis_id": "00-0033094",
     "pff_id": 11440,
     "sleeper_id": 3895,
+    "espn_id": 2578369,
     "pfr_id": "HallMa02",
     "ras_id": 12832,
     "otc_id": 5460
@@ -2766,8 +2827,8 @@
     "pff_id": 12117,
     "sleeper_id": 4386,
     "yahoo_id": 30619,
-    "pfr_id": "PipkLe00",
-    "espn_id": 2972562
+    "espn_id": 2972562,
+    "pfr_id": "PipkLe00"
   },
   {
     "mfl_id": 13509,
@@ -2775,14 +2836,15 @@
     "pff_id": 11242,
     "sleeper_id": 3765,
     "yahoo_id": 29846,
-    "pfr_id": "DeayDo01",
-    "espn_id": 2972896
+    "espn_id": 2972896,
+    "pfr_id": "DeayDo01"
   },
   {
     "mfl_id": 13510,
     "gsis_id": "00-0033006",
     "pff_id": 11371,
     "sleeper_id": 3852,
+    "espn_id": 2978308,
     "pfr_id": "MickJa01",
     "ras_id": 12662,
     "otc_id": 5524
@@ -2793,8 +2855,8 @@
     "pff_id": 12276,
     "sleeper_id": 4460,
     "yahoo_id": 30559,
-    "pfr_id": "HikuCo00",
-    "espn_id": 2968204
+    "espn_id": 2968204,
+    "pfr_id": "HikuCo00"
   },
   {
     "mfl_id": 13512,
@@ -2802,8 +2864,8 @@
     "pff_id": 12092,
     "sleeper_id": 4357,
     "yahoo_id": 30379,
-    "pfr_id": "CoxxBr01",
-    "espn_id": 2980098
+    "espn_id": 2980098,
+    "pfr_id": "CoxxBr01"
   },
   {
     "mfl_id": 13529,
@@ -2824,8 +2886,8 @@
     "pff_id": 9698,
     "sleeper_id": 3016,
     "yahoo_id": 28801,
-    "pfr_id": "WhitJe02",
-    "espn_id": 2574557
+    "espn_id": 2574557,
+    "pfr_id": "WhitJe02"
   },
   {
     "mfl_id": 13535,
@@ -2838,8 +2900,8 @@
     "pff_id": 12171,
     "sleeper_id": 4552,
     "yahoo_id": 30722,
-    "pfr_id": "IrviIs00",
-    "espn_id": 3043197
+    "espn_id": 3043197,
+    "pfr_id": "IrviIs00"
   },
   {
     "mfl_id": 13537,
@@ -2847,8 +2909,8 @@
     "pff_id": 50170,
     "sleeper_id": 4402,
     "yahoo_id": 30427,
-    "pfr_id": "BoweTa00",
-    "espn_id": 3042726
+    "espn_id": 3042726,
+    "pfr_id": "BoweTa00"
   },
   {
     "mfl_id": 13538,
@@ -2861,6 +2923,7 @@
   {
     "mfl_id": 13539,
     "gsis_id": "00-0033384",
+    "espn_id": 3040143,
     "pfr_id": "DaniLe00"
   },
   {
@@ -2885,8 +2948,8 @@
     "pff_id": 12067,
     "sleeper_id": 4480,
     "yahoo_id": 30481,
-    "pfr_id": "WilsJe00",
-    "espn_id": 3045380
+    "espn_id": 3045380,
+    "pfr_id": "WilsJe00"
   },
   {
     "mfl_id": 13545,
@@ -2894,14 +2957,15 @@
     "pff_id": 12251,
     "sleeper_id": 4451,
     "yahoo_id": 30637,
-    "pfr_id": "WhitIs00",
-    "espn_id": 3894883
+    "espn_id": 3894883,
+    "pfr_id": "WhitIs00"
   },
   {
     "mfl_id": 13546,
     "gsis_id": "00-0033095",
     "pff_id": 11439,
     "sleeper_id": 3894,
+    "espn_id": 2987440,
     "pfr_id": "GrifGa00",
     "ras_id": 12580,
     "otc_id": 5459
@@ -2920,8 +2984,8 @@
     "pff_id": 48388,
     "sleeper_id": 4616,
     "yahoo_id": 30803,
-    "pfr_id": "PresGi00",
-    "espn_id": 2971022
+    "espn_id": 2971022,
+    "pfr_id": "PresGi00"
   },
   {
     "mfl_id": 13549,
@@ -2937,8 +3001,8 @@
     "pff_id": 48353,
     "sleeper_id": 4632,
     "yahoo_id": 30405,
-    "pfr_id": "PhilCa00",
-    "espn_id": 3115911
+    "espn_id": 3115911,
+    "pfr_id": "PhilCa00"
   },
   {
     "mfl_id": 13553,
@@ -2946,8 +3010,8 @@
     "pff_id": 49357,
     "sleeper_id": 4395,
     "yahoo_id": 30646,
-    "pfr_id": "McTyTo00",
-    "espn_id": 3058965
+    "espn_id": 3058965,
+    "pfr_id": "McTyTo00"
   },
   {
     "mfl_id": 13556,
@@ -2960,8 +3024,8 @@
     "pff_id": 50096,
     "sleeper_id": 4361,
     "yahoo_id": 30576,
-    "pfr_id": "BellBr01",
-    "espn_id": 3057972
+    "espn_id": 3057972,
+    "pfr_id": "BellBr01"
   },
   {
     "mfl_id": 13559,
@@ -2977,8 +3041,8 @@
     "pff_id": 51592,
     "sleeper_id": 4617,
     "yahoo_id": 30802,
-    "pfr_id": "RossDa02",
-    "espn_id": 4220624
+    "espn_id": 4220624,
+    "pfr_id": "RossDa02"
   },
   {
     "mfl_id": 13563,
@@ -2986,8 +3050,8 @@
     "pff_id": 12062,
     "sleeper_id": 4470,
     "yahoo_id": 30471,
-    "pfr_id": "BullRi00",
-    "espn_id": 2979532
+    "espn_id": 2979532,
+    "pfr_id": "BullRi00"
   },
   {
     "mfl_id": 13565,
@@ -3066,14 +3130,15 @@
     "pff_id": 45662,
     "sleeper_id": 5136,
     "yahoo_id": 31567,
-    "pfr_id": "AdamJo03",
-    "espn_id": 3932420
+    "espn_id": 3932420,
+    "pfr_id": "AdamJo03"
   },
   {
     "mfl_id": 13614,
     "gsis_id": "00-0034109",
     "pff_id": 12660,
     "sleeper_id": 5170,
+    "espn_id": 3052117,
     "pfr_id": "LindPh00",
     "ras_id": 16846,
     "otc_id": 7144
@@ -3102,8 +3167,8 @@
     "pff_id": 27875,
     "sleeper_id": 5274,
     "yahoo_id": 31241,
-    "pfr_id": "ThomRo05",
-    "espn_id": 3121583
+    "espn_id": 3121583,
+    "pfr_id": "ThomRo05"
   },
   {
     "mfl_id": 13632,
@@ -3129,8 +3194,8 @@
     "pff_id": 47477,
     "sleeper_id": 5290,
     "yahoo_id": 31624,
-    "pfr_id": "BurnDe00",
-    "espn_id": 3932935
+    "espn_id": 3932935,
+    "pfr_id": "BurnDe00"
   },
   {
     "mfl_id": 13653,
@@ -3138,8 +3203,8 @@
     "pff_id": 48230,
     "sleeper_id": 5250,
     "yahoo_id": 31601,
-    "pfr_id": "FostRo01",
-    "espn_id": 3054845
+    "espn_id": 3054845,
+    "pfr_id": "FostRo01"
   },
   {
     "mfl_id": 13655,
@@ -3147,8 +3212,8 @@
     "pff_id": 47593,
     "sleeper_id": 5625,
     "yahoo_id": 31598,
-    "pfr_id": "PhilCa01",
-    "espn_id": 3124079
+    "espn_id": 3124079,
+    "pfr_id": "PhilCa01"
   },
   {
     "mfl_id": 13656,
@@ -3164,8 +3229,8 @@
     "pff_id": 47508,
     "sleeper_id": 5132,
     "yahoo_id": 31391,
-    "pfr_id": "MitcSt02",
-    "espn_id": 3043225
+    "espn_id": 3043225,
+    "pfr_id": "MitcSt02"
   },
   {
     "mfl_id": 13661,
@@ -3186,8 +3251,8 @@
     "pff_id": 48078,
     "sleeper_id": 5781,
     "yahoo_id": 31777,
-    "pfr_id": "TurnMa00",
-    "espn_id": 3115928
+    "espn_id": 3115928,
+    "pfr_id": "TurnMa00"
   },
   {
     "mfl_id": 13689,
@@ -3226,6 +3291,7 @@
     "gsis_id": "00-0033658",
     "pff_id": 12320,
     "sleeper_id": 4571,
+    "espn_id": 2991767,
     "pfr_id": "JarwBl00",
     "ras_id": 13283,
     "otc_id": 6230
@@ -3307,8 +3373,8 @@
     "pff_id": 21605,
     "sleeper_id": 5450,
     "yahoo_id": 31372,
-    "pfr_id": "MoorSk00",
-    "espn_id": 3048912
+    "espn_id": 3048912,
+    "pfr_id": "MoorSk00"
   },
   {
     "mfl_id": 13854,
@@ -3332,8 +3398,8 @@
     "pff_id": 29556,
     "sleeper_id": 5277,
     "yahoo_id": 31519,
-    "pfr_id": "YeldDe00",
-    "espn_id": 3059766
+    "espn_id": 3059766,
+    "pfr_id": "YeldDe00"
   },
   {
     "mfl_id": 13858,
@@ -3400,8 +3466,8 @@
     "pff_id": 13612,
     "sleeper_id": 5767,
     "yahoo_id": 31762,
-    "pfr_id": "AlexAd00",
-    "espn_id": 3871875
+    "espn_id": 3871875,
+    "pfr_id": "AlexAd00"
   },
   {
     "mfl_id": 13868,
@@ -3409,8 +3475,8 @@
     "pff_id": 31615,
     "sleeper_id": 5209,
     "yahoo_id": 31228,
-    "pfr_id": "BoonMi00",
-    "espn_id": 3139033
+    "espn_id": 3139033,
+    "pfr_id": "BoonMi00"
   },
   {
     "mfl_id": 13869,
@@ -3426,8 +3492,8 @@
     "pff_id": 49204,
     "sleeper_id": 4859,
     "yahoo_id": 30635,
-    "pfr_id": "ThomAh00",
-    "espn_id": 3042403
+    "espn_id": 3042403,
+    "pfr_id": "ThomAh00"
   },
   {
     "mfl_id": 13871,
@@ -3460,8 +3526,8 @@
     "pff_id": 45993,
     "sleeper_id": 5395,
     "yahoo_id": 31278,
-    "pfr_id": "WilsSh01",
-    "espn_id": 3116563
+    "espn_id": 3116563,
+    "pfr_id": "WilsSh01"
   },
   {
     "mfl_id": 13875,
@@ -3491,6 +3557,7 @@
     "gsis_id": "00-0033367",
     "pff_id": 12088,
     "sleeper_id": 4344,
+    "espn_id": 2973626,
     "pfr_id": "BoarC.00",
     "ras_id": 13358,
     "otc_id": 6027
@@ -3545,8 +3612,8 @@
     "pff_id": 66957,
     "sleeper_id": 5260,
     "yahoo_id": 31588,
-    "pfr_id": "SmitVy00",
-    "espn_id": 3155188
+    "espn_id": 3155188,
+    "pfr_id": "SmitVy00"
   },
   {
     "mfl_id": 13885,
@@ -3586,8 +3653,8 @@
     "pff_id": 45695,
     "sleeper_id": 5266,
     "yahoo_id": 31685,
-    "pfr_id": "NewsDe00",
-    "espn_id": 3117131
+    "espn_id": 3117131,
+    "pfr_id": "NewsDe00"
   },
   {
     "mfl_id": 13892,
@@ -3639,8 +3706,8 @@
     "pff_id": 50287,
     "sleeper_id": 5443,
     "yahoo_id": 31377,
-    "pfr_id": "HollJe01",
-    "espn_id": 3916928
+    "espn_id": 3916928,
+    "pfr_id": "HollJe01"
   },
   {
     "mfl_id": 13898,
@@ -3685,8 +3752,8 @@
     "pff_id": 50942,
     "sleeper_id": 5605,
     "yahoo_id": 31532,
-    "pfr_id": "ThomMa00",
-    "espn_id": 3045376
+    "espn_id": 3045376,
+    "pfr_id": "ThomMa00"
   },
   {
     "mfl_id": 13904,
@@ -3694,13 +3761,14 @@
     "pff_id": 47561,
     "sleeper_id": 5567,
     "yahoo_id": 31506,
-    "pfr_id": "GranJa01",
-    "espn_id": 3047490
+    "espn_id": 3047490,
+    "pfr_id": "GranJa01"
   },
   {
     "mfl_id": 13905,
     "gsis_id": "00-0034560",
     "yahoo_id": 31683,
+    "espn_id": 4329471,
     "pfr_id": "JoneJJ00"
   },
   {
@@ -3750,8 +3818,8 @@
     "pff_id": 48345,
     "sleeper_id": 5539,
     "yahoo_id": 31462,
-    "pfr_id": "WillDe06",
-    "espn_id": 3040137
+    "espn_id": 3040137,
+    "pfr_id": "WillDe06"
   },
   {
     "mfl_id": 13912,
@@ -3759,8 +3827,8 @@
     "pff_id": 47669,
     "sleeper_id": 5289,
     "yahoo_id": 31623,
-    "pfr_id": "BatsCa00",
-    "espn_id": 3139456
+    "espn_id": 3139456,
+    "pfr_id": "BatsCa00"
   },
   {
     "mfl_id": 13913,
@@ -3794,8 +3862,8 @@
     "pff_id": 12888,
     "sleeper_id": 5271,
     "yahoo_id": 31537,
-    "pfr_id": "HoweGr00",
-    "espn_id": 3122716
+    "espn_id": 3122716,
+    "pfr_id": "HoweGr00"
   },
   {
     "mfl_id": 13917,
@@ -3845,8 +3913,8 @@
     "pff_id": 48759,
     "sleeper_id": 5613,
     "yahoo_id": 31572,
-    "pfr_id": "HectBr00",
-    "espn_id": 3051369
+    "espn_id": 3051369,
+    "pfr_id": "HectBr00"
   },
   {
     "mfl_id": 13923,
@@ -3854,8 +3922,8 @@
     "pff_id": 50154,
     "sleeper_id": 5183,
     "yahoo_id": 31484,
-    "pfr_id": "AdenOl00",
-    "espn_id": 3126081
+    "espn_id": 3126081,
+    "pfr_id": "AdenOl00"
   },
   {
     "mfl_id": 13924,
@@ -3888,8 +3956,8 @@
     "pff_id": 50381,
     "sleeper_id": 5159,
     "yahoo_id": 31314,
-    "pfr_id": "NichDe00",
-    "espn_id": 3126311
+    "espn_id": 3126311,
+    "pfr_id": "NichDe00"
   },
   {
     "mfl_id": 13929,
@@ -3922,8 +3990,8 @@
     "pff_id": 50893,
     "sleeper_id": 5147,
     "yahoo_id": 31356,
-    "pfr_id": "ElleEm00",
-    "espn_id": 3123863
+    "espn_id": 3123863,
+    "pfr_id": "ElleEm00"
   },
   {
     "mfl_id": 13933,
@@ -3965,8 +4033,8 @@
     "pff_id": 49836,
     "sleeper_id": 5141,
     "yahoo_id": 31785,
-    "pfr_id": "CrawJa01",
-    "espn_id": 3042445
+    "espn_id": 3042445,
+    "pfr_id": "CrawJa01"
   },
   {
     "mfl_id": 13938,
@@ -3974,8 +4042,8 @@
     "pff_id": 24750,
     "sleeper_id": 5545,
     "yahoo_id": 31433,
-    "pfr_id": "GreeRa02",
-    "espn_id": 3049331
+    "espn_id": 3049331,
+    "pfr_id": "GreeRa02"
   },
   {
     "mfl_id": 13939,
@@ -4026,7 +4094,7 @@
     "pff_id": 11352,
     "sleeper_id": 3837,
     "yahoo_id": 29956,
-    "espn_id": 3140596
+    "espn_id": 2577484
   },
   {
     "mfl_id": 13945,
@@ -4034,8 +4102,8 @@
     "pff_id": 50414,
     "sleeper_id": 5214,
     "yahoo_id": 31233,
-    "pfr_id": "HillHo00",
-    "espn_id": 3929847
+    "espn_id": 3929847,
+    "pfr_id": "HillHo00"
   },
   {
     "mfl_id": 13946,
@@ -4069,8 +4137,8 @@
     "pff_id": 50221,
     "sleeper_id": 5669,
     "yahoo_id": 31615,
-    "pfr_id": "FincSh00",
-    "espn_id": 3051333
+    "espn_id": 3051333,
+    "pfr_id": "FincSh00"
   },
   {
     "mfl_id": 13955,
@@ -4078,8 +4146,8 @@
     "pff_id": 51146,
     "sleeper_id": 5662,
     "yahoo_id": 31652,
-    "pfr_id": "MoorA.00",
-    "espn_id": 3128746
+    "espn_id": 3128746,
+    "pfr_id": "MoorA.00"
   },
   {
     "mfl_id": 13956,
@@ -4087,8 +4155,8 @@
     "pff_id": 51315,
     "sleeper_id": 5178,
     "yahoo_id": 31548,
-    "pfr_id": "ChanSe00",
-    "espn_id": 3138733
+    "espn_id": 3138733,
+    "pfr_id": "ChanSe00"
   },
   {
     "mfl_id": 13958,
@@ -4096,8 +4164,8 @@
     "pff_id": 25681,
     "sleeper_id": 5464,
     "yahoo_id": 31425,
-    "pfr_id": "TurnDe01",
-    "espn_id": 3928461
+    "espn_id": 3928461,
+    "pfr_id": "TurnDe01"
   },
   {
     "mfl_id": 13959,
@@ -4114,8 +4182,8 @@
     "pff_id": 39541,
     "sleeper_id": 5619,
     "yahoo_id": 31620,
-    "pfr_id": "DawkDa01",
-    "espn_id": 3052449
+    "espn_id": 3052449,
+    "pfr_id": "DawkDa01"
   },
   {
     "mfl_id": 13963,
@@ -4149,8 +4217,8 @@
     "pff_id": 9974,
     "sleeper_id": 2885,
     "yahoo_id": 28959,
-    "pfr_id": "DaniRo01",
-    "espn_id": 3053794
+    "espn_id": 3053794,
+    "pfr_id": "DaniRo01"
   },
   {
     "mfl_id": 13968,
@@ -4168,8 +4236,8 @@
     "pff_id": 22489,
     "sleeper_id": 5175,
     "yahoo_id": 31551,
-    "pfr_id": "DaviJa07",
-    "espn_id": 3066147
+    "espn_id": 3066147,
+    "pfr_id": "DaviJa07"
   },
   {
     "mfl_id": 13970,
@@ -4185,8 +4253,8 @@
     "pff_id": 27390,
     "sleeper_id": 5418,
     "yahoo_id": 31679,
-    "pfr_id": "HineDJ00",
-    "espn_id": 3040024
+    "espn_id": 3040024,
+    "pfr_id": "HineDJ00"
   },
   {
     "mfl_id": 13973,
@@ -4194,8 +4262,8 @@
     "pff_id": 38566,
     "sleeper_id": 5188,
     "yahoo_id": 31270,
-    "pfr_id": "MeekQu00",
-    "espn_id": 3931400
+    "espn_id": 3931400,
+    "pfr_id": "MeekQu00"
   },
   {
     "mfl_id": 13978,
@@ -4203,8 +4271,8 @@
     "pff_id": 47268,
     "sleeper_id": 5756,
     "yahoo_id": 31751,
-    "pfr_id": "DickGa00",
-    "espn_id": 3116132
+    "espn_id": 3116132,
+    "pfr_id": "DickGa00"
   },
   {
     "mfl_id": 13980,
@@ -4219,8 +4287,8 @@
     "pff_id": 50036,
     "sleeper_id": 5601,
     "yahoo_id": 31542,
-    "pfr_id": "PittJa00",
-    "espn_id": 3128455
+    "espn_id": 3128455,
+    "pfr_id": "PittJa00"
   },
   {
     "mfl_id": 13987,
@@ -4247,8 +4315,8 @@
     "pff_id": 48604,
     "sleeper_id": 5483,
     "yahoo_id": 31436,
-    "pfr_id": "LancTy00",
-    "espn_id": 3045242
+    "espn_id": 3045242,
+    "pfr_id": "LancTy00"
   },
   {
     "mfl_id": 13990,
@@ -4256,8 +4324,8 @@
     "pff_id": 39588,
     "sleeper_id": 5166,
     "yahoo_id": 31460,
-    "pfr_id": "ScotDa02",
-    "espn_id": 3056577
+    "espn_id": 3056577,
+    "pfr_id": "ScotDa02"
   },
   {
     "mfl_id": 13991,
@@ -4265,8 +4333,8 @@
     "pff_id": 48008,
     "sleeper_id": 5279,
     "yahoo_id": 31486,
-    "pfr_id": "HendQu00",
-    "espn_id": 3895789
+    "espn_id": 3895789,
+    "pfr_id": "HendQu00"
   },
   {
     "mfl_id": 13993,
@@ -4300,8 +4368,8 @@
     "pff_id": 50473,
     "sleeper_id": 5647,
     "yahoo_id": 31555,
-    "pfr_id": "HaleGr00",
-    "espn_id": 3116166
+    "espn_id": 3116166,
+    "pfr_id": "HaleGr00"
   },
   {
     "mfl_id": 13998,
@@ -4316,6 +4384,7 @@
     "gsis_id": "00-0034309",
     "pff_id": 21528,
     "sleeper_id": 5570,
+    "espn_id": 3047968,
     "pfr_id": "BeebCh00",
     "ras_id": 15494,
     "otc_id": 7453
@@ -4334,8 +4403,8 @@
     "pff_id": 48088,
     "sleeper_id": 5135,
     "yahoo_id": 31479,
-    "pfr_id": "BlacSa00",
-    "espn_id": 3116155
+    "espn_id": 3116155,
+    "pfr_id": "BlacSa00"
   },
   {
     "mfl_id": 14010,
@@ -4368,8 +4437,8 @@
     "pff_id": 49349,
     "sleeper_id": 5181,
     "yahoo_id": 31589,
-    "pfr_id": "SullCh00",
-    "espn_id": 3124849
+    "espn_id": 3124849,
+    "pfr_id": "SullCh00"
   },
   {
     "mfl_id": 14015,
@@ -4377,8 +4446,8 @@
     "pff_id": 66933,
     "sleeper_id": 5383,
     "yahoo_id": 31322,
-    "pfr_id": "TollJa00",
-    "espn_id": 4329491
+    "espn_id": 4329491,
+    "pfr_id": "TollJa00"
   },
   {
     "mfl_id": 14016,
@@ -4386,8 +4455,8 @@
     "pff_id": 18551,
     "sleeper_id": 5680,
     "yahoo_id": 31597,
-    "pfr_id": "ThomCo02",
-    "espn_id": 2976524
+    "espn_id": 2976524,
+    "pfr_id": "ThomCo02"
   },
   {
     "mfl_id": 14017,
@@ -4437,8 +4506,8 @@
     "pff_id": 23614,
     "sleeper_id": 5624,
     "yahoo_id": 31595,
-    "pfr_id": "FordKe00",
-    "espn_id": 3052662
+    "espn_id": 3052662,
+    "pfr_id": "FordKe00"
   },
   {
     "mfl_id": 14032,
@@ -4446,8 +4515,8 @@
     "pff_id": 48376,
     "sleeper_id": 5623,
     "yahoo_id": 31605,
-    "pfr_id": "LoveMi00",
-    "espn_id": 3051371
+    "espn_id": 3051371,
+    "pfr_id": "LoveMi00"
   },
   {
     "mfl_id": 14034,
@@ -4455,8 +4524,8 @@
     "pff_id": 51161,
     "sleeper_id": 5641,
     "yahoo_id": 31566,
-    "pfr_id": "WorlCh00",
-    "espn_id": 3051412
+    "espn_id": 3051412,
+    "pfr_id": "WorlCh00"
   },
   {
     "mfl_id": 14035,
@@ -4464,8 +4533,8 @@
     "pff_id": 45861,
     "sleeper_id": 5259,
     "yahoo_id": 31575,
-    "pfr_id": "ColeLa02",
-    "espn_id": 3052163
+    "espn_id": 3052163,
+    "pfr_id": "ColeLa02"
   },
   {
     "mfl_id": 14037,
@@ -4473,8 +4542,8 @@
     "pff_id": 50431,
     "sleeper_id": 5222,
     "yahoo_id": 31534,
-    "pfr_id": "DaviJa06",
-    "espn_id": 3125356
+    "espn_id": 3125356,
+    "pfr_id": "DaviJa06"
   },
   {
     "mfl_id": 14038,
@@ -4490,8 +4559,8 @@
     "pff_id": 51015,
     "sleeper_id": 5581,
     "yahoo_id": 31504,
-    "pfr_id": "WintAn00",
-    "espn_id": 3128853
+    "espn_id": 3128853,
+    "pfr_id": "WintAn00"
   },
   {
     "mfl_id": 14043,
@@ -4508,8 +4577,8 @@
     "pff_id": 29726,
     "sleeper_id": 5661,
     "yahoo_id": 31651,
-    "pfr_id": "LacyCh00",
-    "espn_id": 3122430
+    "espn_id": 3122430,
+    "pfr_id": "LacyCh00"
   },
   {
     "mfl_id": 14046,
@@ -4517,8 +4586,8 @@
     "pff_id": 23254,
     "sleeper_id": 5722,
     "yahoo_id": 31722,
-    "pfr_id": "KidsDa00",
-    "espn_id": 3051650
+    "espn_id": 3051650,
+    "pfr_id": "KidsDa00"
   },
   {
     "mfl_id": 14060,
@@ -4550,8 +4619,8 @@
     "pff_id": 46508,
     "sleeper_id": 6450,
     "yahoo_id": 32272,
-    "pfr_id": "BlouDa00",
-    "espn_id": 3116188
+    "espn_id": 3116188,
+    "pfr_id": "BlouDa00"
   },
   {
     "mfl_id": 14072,
@@ -4603,6 +4672,7 @@
     "gsis_id": "00-0035448",
     "pff_id": 27436,
     "sleeper_id": 6334,
+    "espn_id": 4035102,
     "pfr_id": "CrocDa01"
   },
   {
@@ -4651,6 +4721,7 @@
     "gsis_id": "00-0035457",
     "pff_id": 34427,
     "sleeper_id": 6063,
+    "espn_id": 3894912,
     "pfr_id": "JohnTy03",
     "ras_id": 19874,
     "otc_id": 8331
@@ -4660,6 +4731,7 @@
     "gsis_id": "00-0035406",
     "pff_id": 42247,
     "sleeper_id": 5938,
+    "espn_id": 4039057,
     "pfr_id": "HumpLi01",
     "ras_id": 19870,
     "otc_id": 8357
@@ -4748,7 +4820,8 @@
   },
   {
     "mfl_id": 14173,
-    "gsis_id": "00-0035528"
+    "gsis_id": "00-0035528",
+    "espn_id": 4034967
   },
   {
     "mfl_id": 14188,
@@ -4776,7 +4849,8 @@
   },
   {
     "mfl_id": 14191,
-    "sleeper_id": 6031
+    "sleeper_id": 6031,
+    "espn_id": 3886636
   },
   {
     "mfl_id": 14193,
@@ -4957,8 +5031,8 @@
     "pff_id": 29347,
     "sleeper_id": 6519,
     "yahoo_id": 32378,
-    "pfr_id": "ShepDa00",
-    "espn_id": 3120588
+    "espn_id": 3120588,
+    "pfr_id": "ShepDa00"
   },
   {
     "mfl_id": 14331,
@@ -4984,8 +5058,8 @@
     "pff_id": 30228,
     "sleeper_id": 6115,
     "yahoo_id": 32473,
-    "pfr_id": "HillWe00",
-    "espn_id": 3060919
+    "espn_id": 3060919,
+    "pfr_id": "HillWe00"
   },
   {
     "mfl_id": 14334,
@@ -5026,8 +5100,8 @@
     "pff_id": 45826,
     "sleeper_id": 6446,
     "yahoo_id": 32238,
-    "pfr_id": "HillJo03",
-    "espn_id": 3122799
+    "espn_id": 3122799,
+    "pfr_id": "HillJo03"
   },
   {
     "mfl_id": 14339,
@@ -5060,6 +5134,7 @@
     "gsis_id": "00-0034132",
     "pff_id": 47900,
     "sleeper_id": 5241,
+    "espn_id": 3126002,
     "pfr_id": "BlakCh00",
     "ras_id": 15548,
     "otc_id": 7472
@@ -5078,8 +5153,8 @@
     "pff_id": 28621,
     "sleeper_id": 6209,
     "yahoo_id": 31832,
-    "pfr_id": "HymaIs00",
-    "espn_id": 3039968
+    "espn_id": 3039968,
+    "pfr_id": "HymaIs00"
   },
   {
     "mfl_id": 14349,
@@ -5133,6 +5208,7 @@
     "mfl_id": 14356,
     "gsis_id": "00-0034192",
     "pff_id": 66940,
+    "espn_id": 4329472,
     "pfr_id": "KeizNi00"
   },
   {
@@ -5141,8 +5217,8 @@
     "pff_id": 47311,
     "sleeper_id": 6081,
     "yahoo_id": 32125,
-    "pfr_id": "BlanKe01",
-    "espn_id": 3122103
+    "espn_id": 3122103,
+    "pfr_id": "BlanKe01"
   },
   {
     "mfl_id": 14358,
@@ -5204,6 +5280,7 @@
     "gsis_id": "00-0032986",
     "pff_id": 11062,
     "sleeper_id": 3695,
+    "espn_id": 2970262,
     "pfr_id": "HoltJ.01"
   },
   {
@@ -5212,8 +5289,8 @@
     "pff_id": 61737,
     "sleeper_id": 6549,
     "yahoo_id": 32471,
-    "pfr_id": "WillDa11",
-    "espn_id": 4241723
+    "espn_id": 4241723,
+    "pfr_id": "WillDa11"
   },
   {
     "mfl_id": 14377,
@@ -5253,8 +5330,8 @@
     "pff_id": 50780,
     "sleeper_id": 6498,
     "yahoo_id": 32377,
-    "pfr_id": "HarvWi00",
-    "espn_id": 3128396
+    "espn_id": 3128396,
+    "pfr_id": "HarvWi00"
   },
   {
     "mfl_id": 14384,
@@ -5285,8 +5362,8 @@
     "pff_id": 51599,
     "sleeper_id": 4761,
     "yahoo_id": 30904,
-    "pfr_id": "ShelBr01",
-    "espn_id": 3057876
+    "espn_id": 3057876,
+    "pfr_id": "ShelBr01"
   },
   {
     "mfl_id": 14393,
@@ -5414,8 +5491,8 @@
     "pff_id": 48213,
     "sleeper_id": 6363,
     "yahoo_id": 32101,
-    "pfr_id": "WalkMi00",
-    "espn_id": 3915296
+    "espn_id": 3915296,
+    "pfr_id": "WalkMi00"
   },
   {
     "mfl_id": 14441,
@@ -5471,8 +5548,8 @@
     "pff_id": 51088,
     "sleeper_id": 6244,
     "yahoo_id": 32102,
-    "pfr_id": "WatsBr01",
-    "espn_id": 3115968
+    "espn_id": 3115968,
+    "pfr_id": "WatsBr01"
   },
   {
     "mfl_id": 14458,
@@ -5512,8 +5589,8 @@
     "pff_id": 45764,
     "sleeper_id": 6585,
     "yahoo_id": 32559,
-    "pfr_id": "BrooTo01",
-    "espn_id": 3886841
+    "espn_id": 3886841,
+    "pfr_id": "BrooTo01"
   },
   {
     "mfl_id": 14466,
@@ -5561,8 +5638,8 @@
     "pff_id": 47959,
     "sleeper_id": 6628,
     "yahoo_id": 32556,
-    "pfr_id": "BryaVe00",
-    "espn_id": 3138760
+    "espn_id": 3138760,
+    "pfr_id": "BryaVe00"
   },
   {
     "mfl_id": 14482,
@@ -5570,8 +5647,8 @@
     "pff_id": 35771,
     "sleeper_id": 6666,
     "yahoo_id": 32557,
-    "pfr_id": "DawkNo00",
-    "espn_id": 3911689
+    "espn_id": 3911689,
+    "pfr_id": "DawkNo00"
   },
   {
     "mfl_id": 14486,
@@ -5587,8 +5664,8 @@
     "pff_id": 94365,
     "sleeper_id": 6451,
     "yahoo_id": 32273,
-    "pfr_id": "CarlSt00",
-    "espn_id": 3948283
+    "espn_id": 3948283,
+    "pfr_id": "CarlSt00"
   },
   {
     "mfl_id": 14489,
@@ -5644,6 +5721,7 @@
     "gsis_id": "00-0034930",
     "pff_id": 94356,
     "sleeper_id": 6395,
+    "espn_id": 4422214,
     "pfr_id": "BensTr00"
   },
   {
@@ -5660,8 +5738,8 @@
     "pff_id": 49154,
     "sleeper_id": 5442,
     "yahoo_id": 31381,
-    "pfr_id": "MarsTr00",
-    "espn_id": 3116602
+    "espn_id": 3116602,
+    "pfr_id": "MarsTr00"
   },
   {
     "mfl_id": 14503,
@@ -5669,8 +5747,8 @@
     "pff_id": 94379,
     "sleeper_id": 6588,
     "yahoo_id": 32561,
-    "pfr_id": "KennTo01",
-    "espn_id": 3126997
+    "espn_id": 3126997,
+    "pfr_id": "KennTo01"
   },
   {
     "mfl_id": 14506,
@@ -5752,8 +5830,8 @@
     "pff_id": 36862,
     "sleeper_id": 6026,
     "yahoo_id": 32509,
-    "pfr_id": "HuggAl01",
-    "espn_id": 3728248
+    "espn_id": 3728248,
+    "pfr_id": "HuggAl01"
   },
   {
     "mfl_id": 14532,
@@ -5824,8 +5902,8 @@
     "pff_id": 91472,
     "sleeper_id": 6247,
     "yahoo_id": 32547,
-    "pfr_id": "MoorJa02",
-    "espn_id": 4069806
+    "espn_id": 4069806,
+    "pfr_id": "MoorJa02"
   },
   {
     "mfl_id": 14548,
@@ -5866,8 +5944,8 @@
     "pff_id": 33158,
     "sleeper_id": 6380,
     "yahoo_id": 32141,
-    "pfr_id": "DaviDa03",
-    "espn_id": 3933568
+    "espn_id": 3933568,
+    "pfr_id": "DaviDa03"
   },
   {
     "mfl_id": 14554,
@@ -5875,8 +5953,8 @@
     "pff_id": 63664,
     "sleeper_id": 6381,
     "yahoo_id": 32143,
-    "pfr_id": "HollAl00",
-    "espn_id": 4249496
+    "espn_id": 4249496,
+    "pfr_id": "HollAl00"
   },
   {
     "mfl_id": 14555,
@@ -5911,8 +5989,8 @@
     "pff_id": 50290,
     "sleeper_id": 5996,
     "yahoo_id": 32492,
-    "pfr_id": "GustPo01",
-    "espn_id": 3912553
+    "espn_id": 3912553,
+    "pfr_id": "GustPo01"
   },
   {
     "mfl_id": 14560,
@@ -5945,6 +6023,7 @@
     "gsis_id": "00-0031319",
     "pff_id": 91248,
     "sleeper_id": 5828,
+    "espn_id": 17463,
     "pfr_id": "SpenDi00"
   },
   {
@@ -5976,8 +6055,8 @@
     "pff_id": 49722,
     "sleeper_id": 2894,
     "yahoo_id": 32222,
-    "pfr_id": "WatsJo00",
-    "espn_id": 2512419
+    "espn_id": 3124520,
+    "pfr_id": "WatsJo00"
   },
   {
     "mfl_id": 14589,
@@ -5985,8 +6064,8 @@
     "pff_id": 39145,
     "sleeper_id": 6593,
     "yahoo_id": 32560,
-    "pfr_id": "SchnSp00",
-    "espn_id": 3126075
+    "espn_id": 3126075,
+    "pfr_id": "SchnSp00"
   },
   {
     "mfl_id": 14590,
@@ -6037,8 +6116,8 @@
     "pff_id": 49677,
     "sleeper_id": 6472,
     "yahoo_id": 32204,
-    "pfr_id": "PhilJu00",
-    "espn_id": 3122441
+    "espn_id": 3122441,
+    "pfr_id": "PhilJu00"
   },
   {
     "mfl_id": 14603,
@@ -6054,8 +6133,8 @@
     "pff_id": 94382,
     "sleeper_id": 6584,
     "yahoo_id": 32578,
-    "pfr_id": "SizeDe00",
-    "espn_id": 3145343
+    "espn_id": 3145343,
+    "pfr_id": "SizeDe00"
   },
   {
     "mfl_id": 14612,
@@ -6082,8 +6161,8 @@
     "pff_id": 29838,
     "sleeper_id": 6595,
     "yahoo_id": 32581,
-    "pfr_id": "HodgDe00",
-    "espn_id": 3127051
+    "espn_id": 3127051,
+    "pfr_id": "HodgDe00"
   },
   {
     "mfl_id": 14622,
@@ -6154,8 +6233,8 @@
     "pff_id": 26229,
     "sleeper_id": 6601,
     "yahoo_id": 32425,
-    "pfr_id": "MackIs00",
-    "espn_id": 3131784
+    "espn_id": 3131784,
+    "pfr_id": "MackIs00"
   },
   {
     "mfl_id": 14654,
@@ -6163,8 +6242,8 @@
     "pff_id": 47150,
     "sleeper_id": 6439,
     "yahoo_id": 32295,
-    "pfr_id": "HentHa00",
-    "espn_id": 3925348
+    "espn_id": 3925348,
+    "pfr_id": "HentHa00"
   },
   {
     "mfl_id": 14657,
@@ -6187,14 +6266,15 @@
     "pff_id": 49714,
     "sleeper_id": 6160,
     "yahoo_id": 32241,
-    "pfr_id": "TauaJo00",
-    "espn_id": 3914595
+    "espn_id": 3914595,
+    "pfr_id": "TauaJo00"
   },
   {
     "mfl_id": 14665,
     "gsis_id": "00-0035102",
     "pff_id": 91468,
     "sleeper_id": 6279,
+    "espn_id": 4411192,
     "pfr_id": "DillBr00"
   },
   {
@@ -6245,8 +6325,8 @@
     "pff_id": 49805,
     "sleeper_id": 6055,
     "yahoo_id": 32134,
-    "pfr_id": "PatrNa00",
-    "espn_id": 3728310
+    "espn_id": 3728310,
+    "pfr_id": "PatrNa00"
   },
   {
     "mfl_id": 14674,
@@ -6288,8 +6368,8 @@
     "pff_id": 44583,
     "sleeper_id": 6679,
     "yahoo_id": 32582,
-    "pfr_id": "SkipTu00",
-    "espn_id": 4039521
+    "espn_id": 4039521,
+    "pfr_id": "SkipTu00"
   },
   {
     "mfl_id": 14679,
@@ -6329,8 +6409,8 @@
     "pff_id": 49339,
     "sleeper_id": 2682,
     "yahoo_id": 31636,
-    "pfr_id": "JoneCh06",
-    "espn_id": 3116104
+    "espn_id": 3116104,
+    "pfr_id": "JoneCh06"
   },
   {
     "mfl_id": 14696,
@@ -6402,8 +6482,8 @@
     "pff_id": 30462,
     "sleeper_id": 6581,
     "yahoo_id": 32427,
-    "pfr_id": "RobeDe01",
-    "espn_id": 3125126
+    "espn_id": 3125126,
+    "pfr_id": "RobeDe01"
   },
   {
     "mfl_id": 14737,
@@ -6411,8 +6491,8 @@
     "pff_id": 39382,
     "sleeper_id": 6105,
     "yahoo_id": 32091,
-    "pfr_id": "GileJo01",
-    "espn_id": 3917797
+    "espn_id": 3917797,
+    "pfr_id": "GileJo01"
   },
   {
     "mfl_id": 14738,
@@ -6452,8 +6532,8 @@
     "pff_id": 47186,
     "sleeper_id": 6591,
     "yahoo_id": 32565,
-    "pfr_id": "JoneCh10",
-    "espn_id": 3126263
+    "espn_id": 3126263,
+    "pfr_id": "JoneCh10"
   },
   {
     "mfl_id": 14752,
@@ -6469,8 +6549,8 @@
     "pff_id": 94366,
     "sleeper_id": 6429,
     "yahoo_id": 32280,
-    "pfr_id": "HassJT00",
-    "espn_id": 4264341
+    "espn_id": 4264341,
+    "pfr_id": "HassJT00"
   },
   {
     "mfl_id": 14755,
@@ -6478,8 +6558,8 @@
     "pff_id": 29951,
     "sleeper_id": 6398,
     "yahoo_id": 32192,
-    "pfr_id": "GoodAh00",
-    "espn_id": 3127075
+    "espn_id": 3127075,
+    "pfr_id": "GoodAh00"
   },
   {
     "mfl_id": 14756,
@@ -6503,8 +6583,8 @@
     "pff_id": 49390,
     "sleeper_id": 6090,
     "yahoo_id": 32435,
-    "pfr_id": "HartMo01",
-    "espn_id": 3915970
+    "espn_id": 3915970,
+    "pfr_id": "HartMo01"
   },
   {
     "mfl_id": 14760,
@@ -6624,6 +6704,7 @@
     "gsis_id": "00-0036312",
     "pff_id": 17287,
     "sleeper_id": 7084,
+    "espn_id": 3124900,
     "pfr_id": "LutoJa00",
     "ras_id": 17376,
     "otc_id": 8929
@@ -6753,6 +6834,7 @@
     "pff_id": 26306,
     "sleeper_id": 7101,
     "yahoo_id": 33153,
+    "espn_id": 3116074,
     "pfr_id": "SmitRo08"
   },
   {
@@ -6788,6 +6870,7 @@
     "gsis_id": "00-0035831",
     "pff_id": 22425,
     "sleeper_id": 6955,
+    "espn_id": 4052042,
     "pfr_id": "RobiJa00",
     "ras_id": 19056,
     "otc_id": 9041
@@ -6827,8 +6910,8 @@
     "gsis_id": "00-0036078",
     "sleeper_id": 7088,
     "yahoo_id": 33297,
-    "pfr_id": "JoneXa00",
-    "espn_id": 3916209
+    "espn_id": 3916209,
+    "pfr_id": "JoneXa00"
   },
   {
     "mfl_id": 14819,
@@ -6843,8 +6926,8 @@
     "gsis_id": "00-0035868",
     "sleeper_id": 6966,
     "yahoo_id": 33037,
-    "pfr_id": "LeakJa01",
-    "espn_id": 4241940
+    "espn_id": 4241940,
+    "pfr_id": "LeakJa01"
   },
   {
     "mfl_id": 14821,
@@ -6877,10 +6960,10 @@
     "pff_id": 83711,
     "sleeper_id": 7005,
     "yahoo_id": 33161,
+    "espn_id": 4362878,
     "pfr_id": "PhilSc01",
     "ras_id": 14218,
-    "otc_id": 9030,
-    "espn_id": 4362878
+    "otc_id": 9030
   },
   {
     "mfl_id": 14826,
@@ -6888,10 +6971,10 @@
     "pff_id": 45749,
     "sleeper_id": 7227,
     "yahoo_id": 33179,
+    "espn_id": 4042808,
     "pfr_id": "PierAr00",
     "ras_id": 18719,
-    "otc_id": 9415,
-    "espn_id": 4042808
+    "otc_id": 9415
   },
   {
     "mfl_id": 14827,
@@ -6925,8 +7008,8 @@
     "pff_id": 45854,
     "sleeper_id": 6959,
     "yahoo_id": 32926,
-    "pfr_id": "BellLe02",
-    "espn_id": 3916721
+    "espn_id": 3916721,
+    "pfr_id": "BellLe02"
   },
   {
     "mfl_id": 14831,
@@ -6934,8 +7017,8 @@
     "pff_id": 42425,
     "sleeper_id": 7093,
     "yahoo_id": 32966,
-    "pfr_id": "KillAd00",
-    "espn_id": 4042112
+    "espn_id": 4042112,
+    "pfr_id": "KillAd00"
   },
   {
     "mfl_id": 14832,
@@ -6962,6 +7045,7 @@
     "gsis_id": "00-0036357",
     "pff_id": 61102,
     "sleeper_id": 6789,
+    "espn_id": 4241475,
     "pfr_id": "RuggHe00",
     "ras_id": 20192,
     "otc_id": 8752
@@ -6991,6 +7075,7 @@
     "gsis_id": "00-0036412",
     "pff_id": 61590,
     "sleeper_id": 6805,
+    "espn_id": 4240380,
     "pfr_id": "HamlKJ00",
     "ras_id": 20155,
     "otc_id": 8786
@@ -7100,6 +7185,7 @@
     "gsis_id": "00-0036133",
     "pff_id": 48037,
     "sleeper_id": 6957,
+    "espn_id": 3916204,
     "pfr_id": "ProcJa00",
     "ras_id": 18210,
     "otc_id": 8941
@@ -7119,6 +7205,7 @@
     "gsis_id": "00-0036382",
     "pff_id": 28025,
     "sleeper_id": 6866,
+    "espn_id": 3915522,
     "pfr_id": "HillKJ00",
     "ras_id": 899,
     "otc_id": 8960
@@ -7223,6 +7310,7 @@
     "gsis_id": "00-0036340",
     "pff_id": 39993,
     "sleeper_id": 6906,
+    "espn_id": 4029893,
     "pfr_id": "GandAn00",
     "ras_id": 18203,
     "otc_id": 8882
@@ -7315,10 +7403,10 @@
     "pff_id": 61072,
     "sleeper_id": 6846,
     "yahoo_id": 33186,
+    "espn_id": 4243318,
     "pfr_id": "BryaHu02",
     "ras_id": 20171,
-    "otc_id": 9133,
-    "espn_id": 4243318
+    "otc_id": 9133
   },
   {
     "mfl_id": 14875,
@@ -7335,6 +7423,7 @@
     "gsis_id": "00-0036332",
     "pff_id": 47034,
     "sleeper_id": 7050,
+    "espn_id": 3914151,
     "pfr_id": "DeguJo00",
     "ras_id": 18272,
     "otc_id": 8834
@@ -7373,19 +7462,23 @@
   },
   {
     "mfl_id": 14883,
-    "gsis_id": "00-0036291"
+    "gsis_id": "00-0036291",
+    "espn_id": 4035494
   },
   {
     "mfl_id": 14884,
-    "gsis_id": "00-0036160"
+    "gsis_id": "00-0036160",
+    "espn_id": 3895843
   },
   {
     "mfl_id": 14885,
-    "gsis_id": "00-0036296"
+    "gsis_id": "00-0036296",
+    "espn_id": 3915123
   },
   {
     "mfl_id": 14886,
-    "gsis_id": "00-0036379"
+    "gsis_id": "00-0036379",
+    "espn_id": 4035660
   },
   {
     "mfl_id": 14887,
@@ -7404,7 +7497,8 @@
   },
   {
     "mfl_id": 14890,
-    "gsis_id": "00-0036276"
+    "gsis_id": "00-0036276",
+    "espn_id": 4242206
   },
   {
     "mfl_id": 14891,
@@ -7482,7 +7576,8 @@
   },
   {
     "mfl_id": 14906,
-    "gsis_id": "00-0036359"
+    "gsis_id": "00-0036359",
+    "espn_id": 3915506
   },
   {
     "mfl_id": 14908,
@@ -7553,7 +7648,8 @@
   },
   {
     "mfl_id": 14920,
-    "gsis_id": "00-0036324"
+    "gsis_id": "00-0036324",
+    "espn_id": 3676819
   },
   {
     "mfl_id": 14921,
@@ -7607,7 +7703,8 @@
   },
   {
     "mfl_id": 14932,
-    "gsis_id": "00-0036419"
+    "gsis_id": "00-0036419",
+    "espn_id": 4040968
   },
   {
     "mfl_id": 14933,
@@ -7656,7 +7753,8 @@
   },
   {
     "mfl_id": 14941,
-    "gsis_id": "00-0036393"
+    "gsis_id": "00-0036393",
+    "espn_id": 4360645
   },
   {
     "mfl_id": 14942,
@@ -7670,11 +7768,13 @@
   },
   {
     "mfl_id": 14944,
-    "gsis_id": "00-0036394"
+    "gsis_id": "00-0036394",
+    "espn_id": 4242973
   },
   {
     "mfl_id": 14945,
-    "gsis_id": "00-0036299"
+    "gsis_id": "00-0036299",
+    "espn_id": 4046679
   },
   {
     "mfl_id": 14946,
@@ -7693,7 +7793,8 @@
   },
   {
     "mfl_id": 14949,
-    "gsis_id": "00-0036372"
+    "gsis_id": "00-0036372",
+    "espn_id": 3917006
   },
   {
     "mfl_id": 14950,
@@ -7707,7 +7808,8 @@
   },
   {
     "mfl_id": 14952,
-    "gsis_id": "00-0036373"
+    "gsis_id": "00-0036373",
+    "espn_id": 4035452
   },
   {
     "mfl_id": 14953,
@@ -7741,15 +7843,18 @@
   },
   {
     "mfl_id": 14959,
-    "gsis_id": "00-0036304"
+    "gsis_id": "00-0036304",
+    "espn_id": 3929653
   },
   {
     "mfl_id": 14960,
-    "gsis_id": "00-0036426"
+    "gsis_id": "00-0036426",
+    "espn_id": 4254276
   },
   {
     "mfl_id": 14961,
-    "gsis_id": "00-0036283"
+    "gsis_id": "00-0036283",
+    "espn_id": 4241889
   },
   {
     "mfl_id": 14962,
@@ -7781,13 +7886,15 @@
     "gsis_id": "00-0036398",
     "pff_id": 84142,
     "sleeper_id": 7086,
+    "espn_id": 4373673,
     "pfr_id": "HighJo00",
     "ras_id": 17407,
     "otc_id": 8908
   },
   {
     "mfl_id": 14970,
-    "gsis_id": "00-0036344"
+    "gsis_id": "00-0036344",
+    "espn_id": 4259170
   },
   {
     "mfl_id": 14971,
@@ -7799,6 +7906,7 @@
     "gsis_id": "00-0036278",
     "pff_id": 45693,
     "sleeper_id": 7107,
+    "espn_id": 4040790,
     "pfr_id": "HuntJa01",
     "ras_id": 19039,
     "otc_id": 8912
@@ -7820,7 +7928,8 @@
   },
   {
     "mfl_id": 14976,
-    "gsis_id": "00-0036270"
+    "gsis_id": "00-0036270",
+    "espn_id": 4034781
   },
   {
     "mfl_id": 14977,
@@ -7844,7 +7953,8 @@
   },
   {
     "mfl_id": 14981,
-    "gsis_id": "00-0036311"
+    "gsis_id": "00-0036311",
+    "espn_id": 4035407
   },
   {
     "mfl_id": 14982,
@@ -7873,7 +7983,8 @@
   },
   {
     "mfl_id": 14986,
-    "gsis_id": "00-0036227"
+    "gsis_id": "00-0036227",
+    "espn_id": 3929658
   },
   {
     "mfl_id": 14987,
@@ -7887,11 +7998,13 @@
   },
   {
     "mfl_id": 14989,
-    "gsis_id": "00-0036238"
+    "gsis_id": "00-0036238",
+    "espn_id": 4243257
   },
   {
     "mfl_id": 14990,
-    "gsis_id": "00-0036346"
+    "gsis_id": "00-0036346",
+    "espn_id": 4036213
   },
   {
     "mfl_id": 14991,
@@ -7925,7 +8038,8 @@
   },
   {
     "mfl_id": 14999,
-    "gsis_id": "00-0036229"
+    "gsis_id": "00-0036229",
+    "espn_id": 3929928
   },
   {
     "mfl_id": 15000,
@@ -7949,7 +8063,8 @@
   },
   {
     "mfl_id": 15006,
-    "gsis_id": "00-0036319"
+    "gsis_id": "00-0036319",
+    "espn_id": 3916449
   },
   {
     "mfl_id": 15007,
@@ -7961,13 +8076,15 @@
     "gsis_id": "00-0036384",
     "pff_id": 34311,
     "sleeper_id": 7143,
+    "espn_id": 3895785,
     "pfr_id": "DiNuBe00",
     "ras_id": 18961,
     "otc_id": 8971
   },
   {
     "mfl_id": 15009,
-    "gsis_id": "00-0036352"
+    "gsis_id": "00-0036352",
+    "espn_id": 3699462
   },
   {
     "mfl_id": 15010,
@@ -7976,11 +8093,13 @@
   },
   {
     "mfl_id": 15011,
-    "gsis_id": "00-0036432"
+    "gsis_id": "00-0036432",
+    "espn_id": 3928928
   },
   {
     "mfl_id": 15013,
-    "gsis_id": "00-0036243"
+    "gsis_id": "00-0036243",
+    "espn_id": 4038538
   },
   {
     "mfl_id": 15014,
@@ -7988,7 +8107,8 @@
   },
   {
     "mfl_id": 15015,
-    "gsis_id": "00-0036404"
+    "gsis_id": "00-0036404",
+    "espn_id": 4038811
   },
   {
     "mfl_id": 15016,
@@ -7997,15 +8117,18 @@
   },
   {
     "mfl_id": 15017,
-    "gsis_id": "00-0036433"
+    "gsis_id": "00-0036433",
+    "espn_id": 3791110
   },
   {
     "mfl_id": 15019,
-    "gsis_id": "00-0036239"
+    "gsis_id": "00-0036239",
+    "espn_id": 4240655
   },
   {
     "mfl_id": 15020,
-    "gsis_id": "00-0036240"
+    "gsis_id": "00-0036240",
+    "espn_id": 4043605
   },
   {
     "mfl_id": 15021,
@@ -8013,21 +8136,25 @@
     "pff_id": 45828,
     "sleeper_id": 6988,
     "yahoo_id": 32915,
+    "espn_id": 4040732,
     "pfr_id": "CalaRa00"
   },
   {
     "mfl_id": 15022,
-    "gsis_id": "00-0036245"
+    "gsis_id": "00-0036245",
+    "espn_id": 4039436
   },
   {
     "mfl_id": 15024,
-    "gsis_id": "00-0036436"
+    "gsis_id": "00-0036436",
+    "espn_id": 4038994
   },
   {
     "mfl_id": 15025,
     "gsis_id": "00-0036353",
     "sleeper_id": 6929,
     "yahoo_id": 32919,
+    "espn_id": 3672884,
     "pfr_id": "ColeBr01"
   },
   {
@@ -8042,7 +8169,8 @@
   },
   {
     "mfl_id": 15028,
-    "gsis_id": "00-0036440"
+    "gsis_id": "00-0036440",
+    "espn_id": 3930915
   },
   {
     "mfl_id": 15029,
@@ -8124,9 +8252,9 @@
     "pff_id": 34914,
     "sleeper_id": 7106,
     "yahoo_id": 33329,
+    "espn_id": 3917849,
     "ras_id": 20196,
-    "otc_id": 9307,
-    "espn_id": 3917849
+    "otc_id": 9307
   },
   {
     "mfl_id": 15042,
@@ -8182,8 +8310,8 @@
     "gsis_id": "00-0035789",
     "sleeper_id": 7175,
     "yahoo_id": 33066,
-    "pfr_id": "RowlCh00",
-    "espn_id": 4052137
+    "espn_id": 4052137,
+    "pfr_id": "RowlCh00"
   },
   {
     "mfl_id": 15054,
@@ -8207,8 +8335,8 @@
     "pff_id": 28987,
     "sleeper_id": 7311,
     "yahoo_id": 33318,
-    "pfr_id": "WhitJa04",
-    "espn_id": 3921709
+    "espn_id": 3921709,
+    "pfr_id": "WhitJa04"
   },
   {
     "mfl_id": 15057,
@@ -8216,8 +8344,8 @@
     "pff_id": 34061,
     "sleeper_id": 7357,
     "yahoo_id": 33023,
-    "pfr_id": "ChisDa00",
-    "espn_id": 3929637
+    "espn_id": 3929637,
+    "pfr_id": "ChisDa00"
   },
   {
     "mfl_id": 15059,
@@ -8289,8 +8417,8 @@
     "gsis_id": "00-0035845",
     "sleeper_id": 7356,
     "yahoo_id": 33243,
-    "pfr_id": "RendTy00",
-    "espn_id": 3914456
+    "espn_id": 3914456,
+    "pfr_id": "RendTy00"
   },
   {
     "mfl_id": 15069,
@@ -8305,6 +8433,7 @@
     "gsis_id": "00-0035547",
     "pff_id": 94384,
     "sleeper_id": 6665,
+    "espn_id": 4408854,
     "pfr_id": "FortJo01"
   },
   {
@@ -8321,8 +8450,8 @@
     "pff_id": 42189,
     "sleeper_id": 7449,
     "yahoo_id": 33293,
-    "pfr_id": "MotlPa00",
-    "espn_id": 4037647
+    "espn_id": 4037647,
+    "pfr_id": "MotlPa00"
   },
   {
     "mfl_id": 15074,
@@ -8330,8 +8459,8 @@
     "pff_id": 43811,
     "sleeper_id": 7232,
     "yahoo_id": 33180,
-    "pfr_id": "SmitRa02",
-    "espn_id": 4040762
+    "espn_id": 4040762,
+    "pfr_id": "SmitRa02"
   },
   {
     "mfl_id": 15075,
@@ -8352,13 +8481,15 @@
     "gsis_id": "00-0036142",
     "pff_id": 40113,
     "sleeper_id": 7407,
+    "espn_id": 4044121,
     "pfr_id": "WrigIs01",
     "ras_id": 19077,
     "otc_id": 9425
   },
   {
     "mfl_id": 15078,
-    "gsis_id": "00-0036316"
+    "gsis_id": "00-0036316",
+    "espn_id": 4371737
   },
   {
     "mfl_id": 15079,
@@ -8404,14 +8535,15 @@
     "pff_id": 45980,
     "sleeper_id": 7466,
     "yahoo_id": 33123,
-    "pfr_id": "CottNa00",
-    "espn_id": 3917812
+    "espn_id": 3917812,
+    "pfr_id": "CottNa00"
   },
   {
     "mfl_id": 15088,
     "gsis_id": "00-0035823",
     "pff_id": 27766,
     "sleeper_id": 7288,
+    "espn_id": 3930900,
     "pfr_id": "ElleBe00"
   },
   {
@@ -8445,8 +8577,8 @@
     "pff_id": 50275,
     "sleeper_id": 6981,
     "yahoo_id": 33225,
-    "pfr_id": "GaleTi01",
-    "espn_id": 3676832
+    "espn_id": 3676832,
+    "pfr_id": "GaleTi01"
   },
   {
     "mfl_id": 15096,
@@ -8454,8 +8586,8 @@
     "pff_id": 40117,
     "sleeper_id": 7318,
     "yahoo_id": 32987,
-    "pfr_id": "NabeGa00",
-    "espn_id": 4035611
+    "espn_id": 4035611,
+    "pfr_id": "NabeGa00"
   },
   {
     "mfl_id": 15097,
@@ -8474,16 +8606,16 @@
     "pff_id": 46445,
     "sleeper_id": 7316,
     "yahoo_id": 32975,
-    "pfr_id": "BradDa00",
-    "espn_id": 4040640
+    "espn_id": 4040640,
+    "pfr_id": "BradDa00"
   },
   {
     "mfl_id": 15099,
     "gsis_id": "00-0035897",
     "sleeper_id": 7328,
     "yahoo_id": 32974,
-    "pfr_id": "BilaAs00",
-    "espn_id": 3932422
+    "espn_id": 3932422,
+    "pfr_id": "BilaAs00"
   },
   {
     "mfl_id": 15101,
@@ -8522,7 +8654,8 @@
     "mfl_id": 15111,
     "gsis_id": "00-0035833",
     "sleeper_id": 7296,
-    "yahoo_id": 33149
+    "yahoo_id": 33149,
+    "espn_id": 3917558
   },
   {
     "mfl_id": 15114,
@@ -8530,8 +8663,8 @@
     "pff_id": 49159,
     "sleeper_id": 7226,
     "yahoo_id": 33139,
-    "pfr_id": "HartMy00",
-    "espn_id": 4035290
+    "espn_id": 4035290,
+    "pfr_id": "HartMy00"
   },
   {
     "mfl_id": 15116,
@@ -8539,8 +8672,8 @@
     "pff_id": 26884,
     "sleeper_id": 7458,
     "yahoo_id": 33020,
-    "pfr_id": "ZubeIs00",
-    "espn_id": 3916129
+    "espn_id": 3916129,
+    "pfr_id": "ZubeIs00"
   },
   {
     "mfl_id": 15117,
@@ -8563,6 +8696,7 @@
     "gsis_id": "00-0033720",
     "pff_id": 12239,
     "sleeper_id": 4647,
+    "espn_id": 2980120,
     "pfr_id": "ThomCo03"
   },
   {
@@ -8580,8 +8714,8 @@
     "pff_id": 50532,
     "sleeper_id": 6994,
     "yahoo_id": 33336,
-    "pfr_id": "JackLa02",
-    "espn_id": 4034849
+    "espn_id": 4034849,
+    "pfr_id": "JackLa02"
   },
   {
     "mfl_id": 15126,
@@ -8589,8 +8723,8 @@
     "pff_id": 44722,
     "sleeper_id": 7068,
     "yahoo_id": 33105,
-    "pfr_id": "BernFr01",
-    "espn_id": 3932336
+    "espn_id": 3932336,
+    "pfr_id": "BernFr01"
   },
   {
     "mfl_id": 15127,
@@ -8598,8 +8732,8 @@
     "pff_id": 44473,
     "sleeper_id": 7289,
     "yahoo_id": 33122,
-    "pfr_id": "CostDo00",
-    "espn_id": 4038987
+    "espn_id": 4038987,
+    "pfr_id": "CostDo00"
   },
   {
     "mfl_id": 15129,
@@ -8616,8 +8750,8 @@
     "pff_id": 49545,
     "sleeper_id": 7347,
     "yahoo_id": 33296,
-    "pfr_id": "HughJu00",
-    "espn_id": 4040901
+    "espn_id": 4040901,
+    "pfr_id": "HughJu00"
   },
   {
     "mfl_id": 15131,
@@ -8641,8 +8775,8 @@
     "pff_id": 49537,
     "sleeper_id": 7312,
     "yahoo_id": 33316,
-    "pfr_id": "HarpMa00",
-    "espn_id": 4038440
+    "espn_id": 4038440,
+    "pfr_id": "HarpMa00"
   },
   {
     "mfl_id": 15134,
@@ -8700,8 +8834,8 @@
     "pff_id": 56262,
     "sleeper_id": 7392,
     "yahoo_id": 33333,
-    "pfr_id": "GuidJa01",
-    "espn_id": 4243250
+    "espn_id": 4243250,
+    "pfr_id": "GuidJa01"
   },
   {
     "mfl_id": 15148,
@@ -8717,8 +8851,8 @@
     "pff_id": 84418,
     "sleeper_id": 7279,
     "yahoo_id": 33215,
-    "pfr_id": "HarrDe11",
-    "espn_id": 4374496
+    "espn_id": 4374496,
+    "pfr_id": "HarrDe11"
   },
   {
     "mfl_id": 15151,
@@ -8726,8 +8860,8 @@
     "pff_id": 51283,
     "sleeper_id": 7197,
     "yahoo_id": 33005,
-    "pfr_id": "WelcKr00",
-    "espn_id": 4036153
+    "espn_id": 4036153,
+    "pfr_id": "WelcKr00"
   },
   {
     "mfl_id": 15152,
@@ -8735,13 +8869,14 @@
     "pff_id": 26885,
     "sleeper_id": 7398,
     "yahoo_id": 33086,
-    "pfr_id": "WalkRe01",
-    "espn_id": 4046605
+    "espn_id": 4046605,
+    "pfr_id": "WalkRe01"
   },
   {
     "mfl_id": 15154,
     "gsis_id": "00-0031385",
-    "sleeper_id": 7515
+    "sleeper_id": 7515,
+    "espn_id": 17480
   },
   {
     "mfl_id": 15155,
@@ -8749,8 +8884,8 @@
     "pff_id": 43058,
     "sleeper_id": 7027,
     "yahoo_id": 33201,
-    "pfr_id": "MaydJa01",
-    "espn_id": 4040975
+    "espn_id": 4040975,
+    "pfr_id": "MaydJa01"
   },
   {
     "mfl_id": 15156,
@@ -8758,8 +8893,8 @@
     "pff_id": 48344,
     "sleeper_id": 7078,
     "yahoo_id": 33303,
-    "pfr_id": "BrowTo03",
-    "espn_id": 3915821
+    "espn_id": 3915821,
+    "pfr_id": "BrowTo03"
   },
   {
     "mfl_id": 15159,
@@ -8775,8 +8910,8 @@
     "pff_id": 25687,
     "sleeper_id": 7271,
     "yahoo_id": 33222,
-    "pfr_id": "BlacHe00",
-    "espn_id": 3928920
+    "espn_id": 3928920,
+    "pfr_id": "BlacHe00"
   },
   {
     "mfl_id": 15162,
@@ -8825,8 +8960,8 @@
     "pff_id": 55893,
     "sleeper_id": 6916,
     "yahoo_id": 33231,
-    "pfr_id": "SamuSt01",
-    "espn_id": 4240024
+    "espn_id": 4240024,
+    "pfr_id": "SamuSt01"
   },
   {
     "mfl_id": 15171,
@@ -8858,8 +8993,8 @@
     "pff_id": 50465,
     "sleeper_id": 7169,
     "yahoo_id": 33089,
-    "pfr_id": "WhitJa05",
-    "espn_id": 3821572
+    "espn_id": 3821572,
+    "pfr_id": "WhitJa05"
   },
   {
     "mfl_id": 15177,
@@ -8883,8 +9018,8 @@
     "pff_id": 83079,
     "sleeper_id": 7293,
     "yahoo_id": 33115,
-    "pfr_id": "BarcLu00",
-    "espn_id": 4361499
+    "espn_id": 4361499,
+    "pfr_id": "BarcLu00"
   },
   {
     "mfl_id": 15181,
@@ -8892,8 +9027,8 @@
     "pff_id": 38567,
     "sleeper_id": 6104,
     "yahoo_id": 32218,
-    "pfr_id": "HoldAl01",
-    "espn_id": 3117249
+    "espn_id": 3117249,
+    "pfr_id": "HoldAl01"
   },
   {
     "mfl_id": 15183,
@@ -8909,8 +9044,8 @@
     "pff_id": 106295,
     "sleeper_id": 7381,
     "yahoo_id": 33051,
-    "pfr_id": "LaloNi00",
-    "espn_id": 4030955
+    "espn_id": 4030955,
+    "pfr_id": "LaloNi00"
   },
   {
     "mfl_id": 15186,
@@ -8934,8 +9069,8 @@
     "pff_id": 48721,
     "sleeper_id": 7194,
     "yahoo_id": 33008,
-    "pfr_id": "CrawAa00",
-    "espn_id": 3895837
+    "espn_id": 3895837,
+    "pfr_id": "CrawAa00"
   },
   {
     "mfl_id": 15191,
@@ -8960,16 +9095,16 @@
     "pff_id": 27300,
     "sleeper_id": 6933,
     "yahoo_id": 32973,
-    "pfr_id": "WillRa03",
-    "espn_id": 3929834
+    "espn_id": 3929834,
+    "pfr_id": "WillRa03"
   },
   {
     "mfl_id": 15197,
     "gsis_id": "00-0035925",
     "sleeper_id": 7170,
     "yahoo_id": 33090,
-    "pfr_id": "WillJa09",
-    "espn_id": 3911073
+    "espn_id": 3911073,
+    "pfr_id": "WillJa09"
   },
   {
     "mfl_id": 15198,
@@ -8985,14 +9120,15 @@
     "pff_id": 48659,
     "sleeper_id": 6975,
     "yahoo_id": 33195,
-    "pfr_id": "DaniDa04",
-    "espn_id": 3919607
+    "espn_id": 3919607,
+    "pfr_id": "DaniDa04"
   },
   {
     "mfl_id": 15200,
     "gsis_id": "00-0036459",
     "sleeper_id": 7518,
-    "yahoo_id": 33372
+    "yahoo_id": 33372,
+    "espn_id": 4611153
   },
   {
     "mfl_id": 15201,
@@ -9008,8 +9144,8 @@
     "pff_id": 79271,
     "sleeper_id": 7276,
     "yahoo_id": 33156,
-    "pfr_id": "AlufAu00",
-    "espn_id": 3911982
+    "espn_id": 3911982,
+    "pfr_id": "AlufAu00"
   },
   {
     "mfl_id": 15203,
@@ -9026,8 +9162,8 @@
     "pff_id": 38339,
     "sleeper_id": 7046,
     "yahoo_id": 33135,
-    "pfr_id": "ReedJR01",
-    "espn_id": 3917012
+    "espn_id": 3917012,
+    "pfr_id": "ReedJR01"
   },
   {
     "mfl_id": 15206,
@@ -9035,8 +9171,8 @@
     "pff_id": 27003,
     "sleeper_id": 7244,
     "yahoo_id": 33302,
-    "pfr_id": "BradJa01",
-    "espn_id": 3917569
+    "espn_id": 3917569,
+    "pfr_id": "BradJa01"
   },
   {
     "mfl_id": 15208,
@@ -9044,8 +9180,8 @@
     "pff_id": 42867,
     "sleeper_id": 7302,
     "yahoo_id": 32953,
-    "pfr_id": "CobbOm00",
-    "espn_id": 4043618
+    "espn_id": 4043618,
+    "pfr_id": "CobbOm00"
   },
   {
     "mfl_id": 15209,
@@ -9060,8 +9196,8 @@
     "pff_id": 28092,
     "sleeper_id": 7474,
     "yahoo_id": 33174,
-    "pfr_id": "JoneKe03",
-    "espn_id": 4040621
+    "espn_id": 4040621,
+    "pfr_id": "JoneKe03"
   },
   {
     "mfl_id": 15212,
@@ -9084,6 +9220,7 @@
     "gsis_id": "00-0036456",
     "pff_id": 62825,
     "sleeper_id": 7502,
+    "espn_id": 4036129,
     "pfr_id": "DafnDo00"
   },
   {
@@ -9100,8 +9237,8 @@
     "pff_id": 28071,
     "sleeper_id": 7459,
     "yahoo_id": 33024,
-    "pfr_id": "BerrRa01",
-    "espn_id": 3915508
+    "espn_id": 3915508,
+    "pfr_id": "BerrRa01"
   },
   {
     "mfl_id": 15220,
@@ -9109,8 +9246,8 @@
     "pff_id": 40197,
     "sleeper_id": 7203,
     "yahoo_id": 33359,
-    "pfr_id": "WillAn03",
-    "espn_id": 4040629
+    "espn_id": 4040629,
+    "pfr_id": "WillAn03"
   },
   {
     "mfl_id": 15222,
@@ -9126,8 +9263,8 @@
     "pff_id": 113168,
     "sleeper_id": 7352,
     "yahoo_id": 33236,
-    "pfr_id": "ColeMa03",
-    "espn_id": 4041703
+    "espn_id": 4041703,
+    "pfr_id": "ColeMa03"
   },
   {
     "mfl_id": 15225,
@@ -9143,8 +9280,8 @@
     "gsis_id": "00-0036058",
     "sleeper_id": 7491,
     "yahoo_id": 33285,
-    "pfr_id": "LattCe00",
-    "espn_id": 4036138
+    "espn_id": 4036138,
+    "pfr_id": "LattCe00"
   },
   {
     "mfl_id": 15228,
@@ -9308,8 +9445,8 @@
     "pff_id": 83740,
     "sleeper_id": 7599,
     "yahoo_id": 33644,
-    "pfr_id": "JeffJe00",
-    "espn_id": 4374033
+    "espn_id": 4374033,
+    "pfr_id": "JeffJe00"
   },
   {
     "mfl_id": 15263,
@@ -9344,15 +9481,16 @@
     "mfl_id": 15268,
     "gsis_id": "00-0036827",
     "sleeper_id": 7563,
-    "yahoo_id": 33731
+    "yahoo_id": 33731,
+    "espn_id": 4360802
   },
   {
     "mfl_id": 15269,
     "gsis_id": "00-0036698",
     "pff_id": 83684,
     "sleeper_id": 8085,
-    "pfr_id": "SargMe00",
-    "espn_id": 4379504
+    "espn_id": 4379504,
+    "pfr_id": "SargMe00"
   },
   {
     "mfl_id": 15270,
@@ -9381,6 +9519,7 @@
     "pff_id": 42174,
     "sleeper_id": 7993,
     "yahoo_id": 33809,
+    "espn_id": 4040728,
     "pfr_id": "RagaTr00"
   },
   {
@@ -9393,8 +9532,8 @@
     "gsis_id": "00-0036543",
     "pff_id": 57441,
     "sleeper_id": 7867,
-    "pfr_id": "BrowSp01",
-    "espn_id": 4239768
+    "espn_id": 4239768,
+    "pfr_id": "BrowSp01"
   },
   {
     "mfl_id": 15277,
@@ -9463,6 +9602,7 @@
     "gsis_id": "00-0036907",
     "pff_id": 61510,
     "sleeper_id": 7586,
+    "espn_id": 4240661,
     "pfr_id": "NewsDa00"
   },
   {
@@ -9482,7 +9622,8 @@
   {
     "mfl_id": 15295,
     "sleeper_id": 7576,
-    "yahoo_id": 33773
+    "yahoo_id": 33773,
+    "espn_id": 4240432
   },
   {
     "mfl_id": 15296,
@@ -9561,8 +9702,8 @@
     "pff_id": 48304,
     "sleeper_id": 7996,
     "yahoo_id": 33812,
-    "pfr_id": "StonDi00",
-    "espn_id": 4038460
+    "espn_id": 4038460,
+    "pfr_id": "StonDi00"
   },
   {
     "mfl_id": 15312,
@@ -9651,6 +9792,7 @@
     "pff_id": 61442,
     "sleeper_id": 8005,
     "yahoo_id": 33797,
+    "espn_id": 4258170,
     "pfr_id": "BlacTa00"
   },
   {
@@ -9721,6 +9863,7 @@
     "pff_id": 40148,
     "sleeper_id": 7972,
     "yahoo_id": 33791,
+    "espn_id": 4039271,
     "pfr_id": "PoljTo00"
   },
   {
@@ -9899,6 +10042,7 @@
     "pff_id": 143769,
     "sleeper_id": 7622,
     "yahoo_id": 33386,
+    "espn_id": 3148929,
     "pfr_id": "ReyeSa00"
   },
   {
@@ -10259,7 +10403,8 @@
     "mfl_id": 15455,
     "gsis_id": "00-0036565",
     "pff_id": 57070,
-    "sleeper_id": 7808
+    "sleeper_id": 7808,
+    "espn_id": 4258190
   },
   {
     "mfl_id": 15456,
@@ -10325,8 +10470,8 @@
     "gsis_id": "00-0036573",
     "pff_id": 83111,
     "sleeper_id": 7786,
-    "pfr_id": "WildRa00",
-    "espn_id": 4372560
+    "espn_id": 4372560,
+    "pfr_id": "WildRa00"
   },
   {
     "mfl_id": 15471,
@@ -10342,13 +10487,14 @@
   },
   {
     "mfl_id": 15474,
-    "espn_id": 4568981
+    "espn_id": 4038967
   },
   {
     "mfl_id": 15475,
     "gsis_id": "00-0036925",
     "pff_id": 61402,
     "sleeper_id": 7779,
+    "espn_id": 4242204,
     "pfr_id": "StevJa00"
   },
   {
@@ -10365,10 +10511,10 @@
     "pff_id": 143358,
     "sleeper_id": 7944,
     "yahoo_id": 33620,
+    "espn_id": 4589245,
     "pfr_id": "StraMi03",
     "ras_id": 19156,
-    "otc_id": 9693,
-    "espn_id": 4589245
+    "otc_id": 9693
   },
   {
     "mfl_id": 15479,
@@ -10400,6 +10546,7 @@
     "gsis_id": "00-0036664",
     "pff_id": 44184,
     "sleeper_id": 7764,
+    "espn_id": 4036476,
     "pfr_id": "BradWi00"
   },
   {
@@ -10410,6 +10557,7 @@
     "mfl_id": 15487,
     "gsis_id": "00-0036889",
     "sleeper_id": 7762,
+    "espn_id": 4044064,
     "pfr_id": "WiggJa00"
   },
   {
@@ -10441,6 +10589,7 @@
     "gsis_id": "00-0036667",
     "pff_id": 43308,
     "sleeper_id": 7755,
+    "espn_id": 4046652,
     "pfr_id": "WilcCh00"
   },
   {
@@ -10452,6 +10601,7 @@
     "gsis_id": "00-0036668",
     "pff_id": 50306,
     "sleeper_id": 7754,
+    "espn_id": 4035372,
     "pfr_id": "SpenMa00"
   },
   {
@@ -10462,7 +10612,8 @@
     "mfl_id": 15497,
     "gsis_id": "00-0036939",
     "pff_id": 61639,
-    "sleeper_id": 7752
+    "sleeper_id": 7752,
+    "espn_id": 4068152
   },
   {
     "mfl_id": 15498,
@@ -10495,6 +10646,7 @@
     "pff_id": 88760,
     "sleeper_id": 8051,
     "yahoo_id": 33859,
+    "espn_id": 4390717,
     "pfr_id": "JohnJo06"
   },
   {
@@ -10502,8 +10654,8 @@
     "gsis_id": "00-0036582",
     "sleeper_id": 8058,
     "yahoo_id": 33793,
-    "pfr_id": "McCrNa00",
-    "espn_id": 4820592
+    "espn_id": 4820592,
+    "pfr_id": "McCrNa00"
   },
   {
     "mfl_id": 15504,
@@ -10525,6 +10677,7 @@
     "pff_id": 52008,
     "sleeper_id": 7992,
     "yahoo_id": 33804,
+    "espn_id": 4242369,
     "pfr_id": "BushMa00"
   },
   {
@@ -10556,7 +10709,8 @@
     "mfl_id": 15511,
     "gsis_id": "00-0036515",
     "sleeper_id": 8042,
-    "yahoo_id": 33700
+    "yahoo_id": 33700,
+    "espn_id": 4241822
   },
   {
     "mfl_id": 15512,
@@ -10564,6 +10718,7 @@
     "pff_id": 56977,
     "sleeper_id": 8029,
     "yahoo_id": 33750,
+    "espn_id": 4240029,
     "pfr_id": "WilsMa05"
   },
   {
@@ -10583,13 +10738,15 @@
     "gsis_id": "00-0036711",
     "pff_id": 62775,
     "sleeper_id": 7849,
-    "yahoo_id": 33914
+    "yahoo_id": 33914,
+    "espn_id": 4240849
   },
   {
     "mfl_id": 15516,
     "gsis_id": "00-0036488",
     "sleeper_id": 8040,
-    "yahoo_id": 33787
+    "yahoo_id": 33787,
+    "espn_id": 4046532
   },
   {
     "mfl_id": 15517,
@@ -10669,8 +10826,8 @@
     "pff_id": 28729,
     "sleeper_id": 7438,
     "yahoo_id": 33349,
-    "pfr_id": "WilkKr00",
-    "espn_id": 3910176
+    "espn_id": 3910176,
+    "pfr_id": "WilkKr00"
   },
   {
     "mfl_id": 15529,
@@ -10714,8 +10871,8 @@
     "pff_id": 47378,
     "sleeper_id": 7854,
     "yahoo_id": 33836,
-    "pfr_id": "ForrMi00",
-    "espn_id": 4040714
+    "espn_id": 4040714,
+    "pfr_id": "ForrMi00"
   },
   {
     "mfl_id": 15535,
@@ -10730,7 +10887,8 @@
     "gsis_id": "00-0036678",
     "pff_id": 42913,
     "sleeper_id": 8003,
-    "yahoo_id": 33878
+    "yahoo_id": 33878,
+    "espn_id": 4034835
   },
   {
     "mfl_id": 15537,
@@ -10738,8 +10896,8 @@
     "pff_id": 82319,
     "sleeper_id": 7987,
     "yahoo_id": 33846,
-    "pfr_id": "HodgDa01",
-    "espn_id": 4370351
+    "espn_id": 4370351,
+    "pfr_id": "HodgDa01"
   },
   {
     "mfl_id": 15538,
@@ -10756,12 +10914,14 @@
     "pff_id": 42212,
     "sleeper_id": 7915,
     "yahoo_id": 33664,
+    "espn_id": 4035554,
     "pfr_id": "AkerLa00"
   },
   {
     "mfl_id": 15540,
     "sleeper_id": 7619,
-    "yahoo_id": 33384
+    "yahoo_id": 33384,
+    "espn_id": 4039339
   },
   {
     "mfl_id": 15541,
@@ -10842,8 +11002,8 @@
     "pff_id": 44299,
     "sleeper_id": 8024,
     "yahoo_id": 33900,
-    "pfr_id": "MintAn00",
-    "espn_id": 4035279
+    "espn_id": 4035279,
+    "pfr_id": "MintAn00"
   },
   {
     "mfl_id": 15559,
@@ -10865,7 +11025,8 @@
     "mfl_id": 15561,
     "gsis_id": "00-0036068",
     "sleeper_id": 7277,
-    "yahoo_id": 33159
+    "yahoo_id": 33159,
+    "espn_id": 4046688
   },
   {
     "mfl_id": 15562,
@@ -10912,7 +11073,8 @@
     "gsis_id": "00-0036137",
     "pff_id": 76843,
     "sleeper_id": 7254,
-    "yahoo_id": 33106
+    "yahoo_id": 33106,
+    "espn_id": 4360328
   },
   {
     "mfl_id": 15578,
@@ -10920,6 +11082,7 @@
     "pff_id": 56356,
     "sleeper_id": 7930,
     "yahoo_id": 33654,
+    "espn_id": 4241135,
     "pfr_id": "JohnRa02"
   },
   {
@@ -10928,8 +11091,8 @@
     "pff_id": 48558,
     "sleeper_id": 7519,
     "yahoo_id": 33373,
-    "pfr_id": "PatrAa00",
-    "espn_id": 3908943
+    "espn_id": 3908943,
+    "pfr_id": "PatrAa00"
   },
   {
     "mfl_id": 15581,
@@ -10961,7 +11124,8 @@
     "gsis_id": "00-0036691",
     "pff_id": 57063,
     "sleeper_id": 7852,
-    "yahoo_id": 33835
+    "yahoo_id": 33835,
+    "espn_id": 4242212
   },
   {
     "mfl_id": 15589,
@@ -10984,7 +11148,8 @@
     "gsis_id": "00-0036774",
     "pff_id": 36101,
     "sleeper_id": 7941,
-    "yahoo_id": 33713
+    "yahoo_id": 33713,
+    "espn_id": 3893625
   },
   {
     "mfl_id": 15594,
@@ -10992,6 +11157,7 @@
     "pff_id": 56800,
     "sleeper_id": 7866,
     "yahoo_id": 33719,
+    "espn_id": 4242509,
     "pfr_id": "FaolAu00"
   },
   {
@@ -11007,6 +11173,7 @@
     "gsis_id": "00-0036506",
     "pff_id": 52129,
     "sleeper_id": 8044,
+    "espn_id": 4255989,
     "pfr_id": "DunnIs00"
   },
   {
@@ -11014,6 +11181,7 @@
     "gsis_id": "00-0036780",
     "sleeper_id": 7931,
     "yahoo_id": 33679,
+    "espn_id": 4373582,
     "pfr_id": "MerrFo00"
   },
   {
@@ -11028,7 +11196,8 @@
     "mfl_id": 15606,
     "gsis_id": "00-0036703",
     "sleeper_id": 8055,
-    "yahoo_id": 33906
+    "yahoo_id": 33906,
+    "espn_id": 4046184
   },
   {
     "mfl_id": 15608,
@@ -11069,6 +11238,7 @@
     "pff_id": 76643,
     "sleeper_id": 7912,
     "yahoo_id": 33684,
+    "espn_id": 4361942,
     "pfr_id": "WillTr07"
   },
   {
@@ -11077,8 +11247,8 @@
     "pff_id": 44363,
     "sleeper_id": 7853,
     "yahoo_id": 33833,
-    "pfr_id": "JoneNa01",
-    "espn_id": 4046716
+    "espn_id": 4046716,
+    "pfr_id": "JoneNa01"
   },
   {
     "mfl_id": 15620,
@@ -11127,8 +11297,8 @@
     "pff_id": 36668,
     "sleeper_id": 8037,
     "yahoo_id": 33687,
-    "pfr_id": "BronJo01",
-    "espn_id": 3923400
+    "espn_id": 3923400,
+    "pfr_id": "BronJo01"
   },
   {
     "mfl_id": 15632,
@@ -11136,6 +11306,7 @@
     "pff_id": 26144,
     "sleeper_id": 8084,
     "yahoo_id": 33659,
+    "espn_id": 4036033,
     "pfr_id": "GilbMa02"
   },
   {
@@ -11167,6 +11338,7 @@
     "pff_id": 44570,
     "sleeper_id": 7880,
     "yahoo_id": 33755,
+    "espn_id": 4039485,
     "pfr_id": "HeflJa00"
   },
   {
@@ -11174,12 +11346,14 @@
     "gsis_id": "00-0036517",
     "sleeper_id": 7877,
     "yahoo_id": 33702,
+    "espn_id": 4042827,
     "pfr_id": "RashHa00"
   },
   {
     "mfl_id": 15642,
     "gsis_id": "00-0036688",
     "sleeper_id": 8031,
+    "espn_id": 4034788,
     "pfr_id": "ThomKi00"
   },
   {
@@ -11202,6 +11376,7 @@
     "gsis_id": "00-0036700",
     "sleeper_id": 8054,
     "yahoo_id": 33903,
+    "espn_id": 4044146,
     "pfr_id": "ArchDa01"
   },
   {
@@ -11224,7 +11399,8 @@
     "gsis_id": "00-0035880",
     "pff_id": 49432,
     "sleeper_id": 6974,
-    "yahoo_id": 32958
+    "yahoo_id": 32958,
+    "espn_id": 3916926
   },
   {
     "mfl_id": 15653,
@@ -11245,13 +11421,15 @@
   {
     "mfl_id": 15655,
     "gsis_id": "00-0036792",
-    "sleeper_id": 7907
+    "sleeper_id": 7907,
+    "espn_id": 4369838
   },
   {
     "mfl_id": 15656,
     "gsis_id": "00-0036714",
     "sleeper_id": 7933,
-    "yahoo_id": 33677
+    "yahoo_id": 33677,
+    "espn_id": 4046164
   },
   {
     "mfl_id": 15657,
@@ -11266,7 +11444,8 @@
     "gsis_id": "00-0036768",
     "pff_id": 143793,
     "sleeper_id": 7863,
-    "yahoo_id": 33707
+    "yahoo_id": 33707,
+    "espn_id": 4069817
   },
   {
     "mfl_id": 15662,
@@ -11280,7 +11459,8 @@
     "mfl_id": 15666,
     "gsis_id": "00-0036462",
     "pff_id": 44443,
-    "sleeper_id": 7520
+    "sleeper_id": 7520,
+    "espn_id": 4038534
   },
   {
     "mfl_id": 15668,
@@ -11294,6 +11474,7 @@
     "gsis_id": "00-0036959",
     "sleeper_id": 8076,
     "yahoo_id": 33928,
+    "espn_id": 4034704,
     "pfr_id": "BandMi00"
   },
   {
@@ -11310,6 +11491,7 @@
     "pff_id": 27376,
     "sleeper_id": 7876,
     "yahoo_id": 33695,
+    "espn_id": 4046544,
     "pfr_id": "DwumMi00"
   },
   {
@@ -11318,15 +11500,16 @@
     "pff_id": 50195,
     "sleeper_id": 7456,
     "yahoo_id": 33277,
-    "pfr_id": "PotoBe00",
-    "espn_id": 3886826
+    "espn_id": 3886826,
+    "pfr_id": "PotoBe00"
   },
   {
     "mfl_id": 15675,
     "gsis_id": "00-0036127",
     "pff_id": 42930,
     "sleeper_id": 6986,
-    "yahoo_id": 33004
+    "yahoo_id": 33004,
+    "espn_id": 4035173
   },
   {
     "mfl_id": 15676,
@@ -11334,6 +11517,7 @@
     "pff_id": 34622,
     "sleeper_id": 8000,
     "yahoo_id": 33877,
+    "espn_id": 3932335,
     "pfr_id": "AndeZa02"
   },
   {
@@ -11355,6 +11539,7 @@
     "gsis_id": "00-0036764",
     "pff_id": 42631,
     "sleeper_id": 7942,
+    "espn_id": 4044079,
     "pfr_id": "CoylTy00"
   },
   {
@@ -11370,6 +11555,7 @@
     "gsis_id": "00-0036724",
     "pff_id": 79072,
     "sleeper_id": 7895,
+    "espn_id": 4369247,
     "pfr_id": "McCaMa02"
   },
   {
@@ -11377,6 +11563,7 @@
     "gsis_id": "00-0036910",
     "sleeper_id": 8068,
     "yahoo_id": 33921,
+    "espn_id": 4040627,
     "pfr_id": "SaunCJ00"
   },
   {
@@ -11423,23 +11610,24 @@
     "mfl_id": 15695,
     "gsis_id": "00-0037139",
     "sleeper_id": 8158,
-    "yahoo_id": 34385
+    "yahoo_id": 34385,
+    "espn_id": 4361435
   },
   {
     "mfl_id": 15696,
     "gsis_id": "00-0038108",
     "sleeper_id": 8157,
     "yahoo_id": 34093,
-    "pfr_id": "ZappBa00",
-    "espn_id": 4250360
+    "espn_id": 4250360,
+    "pfr_id": "ZappBa00"
   },
   {
     "mfl_id": 15697,
     "gsis_id": "00-0038122",
     "sleeper_id": 8159,
     "yahoo_id": 34030,
-    "pfr_id": "RiddDe00",
-    "espn_id": 4239086
+    "espn_id": 4239086,
+    "pfr_id": "RiddDe00"
   },
   {
     "mfl_id": 15698,
@@ -11498,7 +11686,8 @@
   {
     "mfl_id": 15707,
     "sleeper_id": 8193,
-    "yahoo_id": 34346
+    "yahoo_id": 34346,
+    "espn_id": 4239936
   },
   {
     "mfl_id": 15708,
@@ -11513,8 +11702,8 @@
     "gsis_id": "00-0038045",
     "sleeper_id": 8153,
     "yahoo_id": 34079,
-    "pfr_id": "SpilIs00",
-    "espn_id": 4426891
+    "espn_id": 4426891,
+    "pfr_id": "SpilIs00"
   },
   {
     "mfl_id": 15710,
@@ -11585,16 +11774,16 @@
     "gsis_id": "00-0037085",
     "sleeper_id": 8208,
     "yahoo_id": 34152,
-    "pfr_id": "BadiTy00",
-    "espn_id": 4362748
+    "espn_id": 4362748,
+    "pfr_id": "BadiTy00"
   },
   {
     "mfl_id": 15719,
     "gsis_id": "00-0037286",
     "sleeper_id": 8174,
     "yahoo_id": 34139,
-    "pfr_id": "HarrKe01",
-    "espn_id": 4570674
+    "espn_id": 4570674,
+    "pfr_id": "HarrKe01"
   },
   {
     "mfl_id": 15720,
@@ -11727,7 +11916,8 @@
     "mfl_id": 15740,
     "gsis_id": "00-0037182",
     "sleeper_id": 8239,
-    "yahoo_id": 34402
+    "yahoo_id": 34402,
+    "espn_id": 4361655
   },
   {
     "mfl_id": 15742,
@@ -11741,13 +11931,15 @@
     "mfl_id": 15743,
     "gsis_id": "00-0037509",
     "sleeper_id": 8220,
-    "yahoo_id": 34551
+    "yahoo_id": 34551,
+    "espn_id": 4430104
   },
   {
     "mfl_id": 15744,
     "gsis_id": "00-0037400",
     "sleeper_id": 8184,
-    "yahoo_id": 34521
+    "yahoo_id": 34521,
+    "espn_id": 4244651
   },
   {
     "mfl_id": 15745,
@@ -11759,8 +11951,8 @@
     "gsis_id": "00-0037827",
     "sleeper_id": 8211,
     "yahoo_id": 34049,
-    "pfr_id": "DaviTy03",
-    "espn_id": 4426475
+    "espn_id": 4426475,
+    "pfr_id": "DaviTy03"
   },
   {
     "mfl_id": 15747,
@@ -11893,7 +12085,8 @@
     "mfl_id": 15765,
     "gsis_id": "00-0037231",
     "sleeper_id": 8200,
-    "yahoo_id": 34242
+    "yahoo_id": 34242,
+    "espn_id": 4372758
   },
   {
     "mfl_id": 15766,
@@ -12026,7 +12219,8 @@
   {
     "mfl_id": 15784,
     "sleeper_id": 8222,
-    "yahoo_id": 34557
+    "yahoo_id": 34557,
+    "espn_id": 4390717
   },
   {
     "mfl_id": 15785,
@@ -12084,14 +12278,15 @@
     "mfl_id": 15792,
     "sleeper_id": 8202,
     "yahoo_id": 34158,
-    "pfr_id": "WoodMi00",
-    "espn_id": 4360174
+    "espn_id": 4360174,
+    "pfr_id": "WoodMi00"
   },
   {
     "mfl_id": 15793,
     "gsis_id": "00-0037436",
     "sleeper_id": 8115,
-    "yahoo_id": 34623
+    "yahoo_id": 34623,
+    "espn_id": 4428952
   },
   {
     "mfl_id": 15794,
@@ -12342,8 +12537,8 @@
     "gsis_id": "00-0037285",
     "sleeper_id": 8292,
     "yahoo_id": 34138,
-    "pfr_id": "BeavDa00",
-    "espn_id": 4239121
+    "espn_id": 4239121,
+    "pfr_id": "BeavDa00"
   },
   {
     "mfl_id": 15826,
@@ -12358,6 +12553,7 @@
     "gsis_id": "00-0037393",
     "sleeper_id": 8340,
     "yahoo_id": 34490,
+    "espn_id": 4034841,
     "pfr_id": "DomaJo00"
   },
   {
@@ -12365,8 +12561,8 @@
     "gsis_id": "00-0038113",
     "sleeper_id": 8324,
     "yahoo_id": 34076,
-    "pfr_id": "SmitBr08",
-    "espn_id": 4575416
+    "espn_id": 4575416,
+    "pfr_id": "SmitBr08"
   },
   {
     "mfl_id": 15829,
@@ -12469,8 +12665,8 @@
     "gsis_id": "00-0037098",
     "sleeper_id": 8235,
     "yahoo_id": 34214,
-    "pfr_id": "TourSa00",
-    "espn_id": 4027873
+    "espn_id": 4027873,
+    "pfr_id": "TourSa00"
   },
   {
     "mfl_id": 15842,
@@ -12853,8 +13049,8 @@
     "mfl_id": 15892,
     "sleeper_id": 8380,
     "yahoo_id": 34106,
-    "pfr_id": "BookTh00",
-    "espn_id": 4360749
+    "espn_id": 4360749,
+    "pfr_id": "BookTh00"
   },
   {
     "mfl_id": 15893,
@@ -12978,16 +13174,16 @@
     "gsis_id": "00-0037280",
     "sleeper_id": 8332,
     "yahoo_id": 34131,
-    "pfr_id": "ButlMa02",
-    "espn_id": 4242457
+    "espn_id": 4242457,
+    "pfr_id": "ButlMa02"
   },
   {
     "mfl_id": 15909,
     "gsis_id": "00-0037282",
     "sleeper_id": 8170,
     "yahoo_id": 34133,
-    "pfr_id": "MitcJa00",
-    "espn_id": 4361988
+    "espn_id": 4361988,
+    "pfr_id": "MitcJa00"
   },
   {
     "mfl_id": 15910,
@@ -13048,14 +13244,15 @@
     "gsis_id": "00-0037293",
     "sleeper_id": 8498,
     "yahoo_id": 34149,
+    "espn_id": 4038436,
     "pfr_id": "HarpDe00"
   },
   {
     "mfl_id": 15918,
     "sleeper_id": 8370,
     "yahoo_id": 34150,
-    "pfr_id": "JackJo06",
-    "espn_id": 4261090
+    "espn_id": 4261090,
+    "pfr_id": "JackJo06"
   },
   {
     "mfl_id": 15919,
@@ -13085,8 +13282,8 @@
     "mfl_id": 15922,
     "sleeper_id": 8495,
     "yahoo_id": 34161,
-    "pfr_id": "HennMa01",
-    "espn_id": 4242358
+    "espn_id": 4242358,
+    "pfr_id": "HennMa01"
   },
   {
     "mfl_id": 15923,
@@ -13124,8 +13321,8 @@
     "gsis_id": "00-0037309",
     "sleeper_id": 8490,
     "yahoo_id": 34172,
-    "pfr_id": "BrooCu00",
-    "espn_id": 4037474
+    "espn_id": 4037474,
+    "pfr_id": "BrooCu00"
   },
   {
     "mfl_id": 15928,
@@ -13226,6 +13423,7 @@
     "gsis_id": "00-0037319",
     "sleeper_id": 8521,
     "yahoo_id": 34188,
+    "espn_id": 4242333,
     "pfr_id": "HickFa00"
   },
   {
@@ -13241,6 +13439,7 @@
     "gsis_id": "00-0037094",
     "sleeper_id": 8344,
     "yahoo_id": 34190,
+    "espn_id": 4259762,
     "pfr_id": "FordJo00"
   },
   {
@@ -13248,8 +13447,8 @@
     "gsis_id": "00-0037843",
     "sleeper_id": 8520,
     "yahoo_id": 34191,
-    "pfr_id": "HardDa01",
-    "espn_id": 4365629
+    "espn_id": 4365629,
+    "pfr_id": "HardDa01"
   },
   {
     "mfl_id": 15944,
@@ -13287,14 +13486,15 @@
     "gsis_id": "00-0037324",
     "sleeper_id": 8413,
     "yahoo_id": 34197,
+    "espn_id": 4044111,
     "pfr_id": "OladCh00"
   },
   {
     "mfl_id": 15949,
     "gsis_id": "00-0037325",
     "sleeper_id": 8312,
-    "pfr_id": "BarnKa00",
-    "espn_id": 4373017
+    "espn_id": 4373017,
+    "pfr_id": "BarnKa00"
   },
   {
     "mfl_id": 15950,
@@ -13316,6 +13516,7 @@
     "gsis_id": "00-0037328",
     "sleeper_id": 8512,
     "yahoo_id": 34204,
+    "espn_id": 4035453,
     "pfr_id": "AnthAn00"
   },
   {
@@ -13375,14 +13576,15 @@
     "gsis_id": "00-0037331",
     "sleeper_id": 8428,
     "yahoo_id": 34216,
-    "pfr_id": "HorvZa00",
-    "espn_id": 4260406
+    "espn_id": 4260406,
+    "pfr_id": "HorvZa00"
   },
   {
     "mfl_id": 15961,
     "gsis_id": "00-0036156",
     "sleeper_id": 7202,
-    "yahoo_id": 33000
+    "yahoo_id": 33000,
+    "espn_id": 4037225
   },
   {
     "mfl_id": 15962,
@@ -13412,12 +13614,14 @@
     "mfl_id": 15966,
     "gsis_id": "00-0037226",
     "sleeper_id": 8233,
-    "yahoo_id": 34445
+    "yahoo_id": 34445,
+    "espn_id": 4360406
   },
   {
     "mfl_id": 15967,
     "sleeper_id": 8812,
-    "yahoo_id": 34575
+    "yahoo_id": 34575,
+    "espn_id": 4569390
   },
   {
     "mfl_id": 15968,
@@ -13463,7 +13667,8 @@
   {
     "mfl_id": 15974,
     "sleeper_id": 8775,
-    "yahoo_id": 34249
+    "yahoo_id": 34249,
+    "espn_id": 4247574
   },
   {
     "mfl_id": 15975,
@@ -13516,8 +13721,8 @@
     "gsis_id": "00-0037503",
     "sleeper_id": 8263,
     "yahoo_id": 34536,
-    "pfr_id": "ButlDa00",
-    "espn_id": 4360466
+    "espn_id": 4360466,
+    "pfr_id": "ButlDa00"
   },
   {
     "mfl_id": 15983,
@@ -13552,6 +13757,7 @@
     "gsis_id": "00-0037382",
     "sleeper_id": 8756,
     "yahoo_id": 34571,
+    "espn_id": 4035198,
     "pfr_id": "JohnBr23"
   },
   {
@@ -13565,6 +13771,7 @@
     "gsis_id": "00-0037137",
     "sleeper_id": 8275,
     "yahoo_id": 34383,
+    "espn_id": 4372020,
     "pfr_id": "JobeJo00"
   },
   {
@@ -13615,6 +13822,7 @@
     "gsis_id": "00-0037387",
     "sleeper_id": 8416,
     "yahoo_id": 34579,
+    "espn_id": 4036448,
     "pfr_id": "VirgJa00"
   },
   {
@@ -13626,28 +13834,31 @@
   {
     "mfl_id": 15998,
     "sleeper_id": 8274,
-    "yahoo_id": 34427
+    "yahoo_id": 34427,
+    "espn_id": 4241473
   },
   {
     "mfl_id": 16000,
     "gsis_id": "00-0037569",
     "sleeper_id": 8197,
     "yahoo_id": 34607,
-    "pfr_id": "HendPe01",
-    "espn_id": 4258248
+    "espn_id": 4258248,
+    "pfr_id": "HendPe01"
   },
   {
     "mfl_id": 16001,
     "gsis_id": "00-0037580",
     "sleeper_id": 8663,
     "yahoo_id": 34284,
+    "espn_id": 4911488,
     "pfr_id": "BernJa00"
   },
   {
     "mfl_id": 16002,
     "gsis_id": "00-0037471",
     "sleeper_id": 8577,
-    "yahoo_id": 34633
+    "yahoo_id": 34633,
+    "espn_id": 4033806
   },
   {
     "mfl_id": 16003,
@@ -13675,6 +13886,7 @@
     "gsis_id": "00-0037481",
     "sleeper_id": 8870,
     "yahoo_id": 34502,
+    "espn_id": 4259299,
     "pfr_id": "FatuOl00"
   },
   {
@@ -13688,6 +13900,7 @@
     "mfl_id": 16008,
     "gsis_id": "00-0037184",
     "sleeper_id": 8285,
+    "espn_id": 4258198,
     "pfr_id": "RossJo01"
   },
   {
@@ -13728,7 +13941,8 @@
     "mfl_id": 16015,
     "gsis_id": "00-0037422",
     "sleeper_id": 8783,
-    "yahoo_id": 34476
+    "yahoo_id": 34476,
+    "espn_id": 4035776
   },
   {
     "mfl_id": 16016,
@@ -13743,6 +13957,7 @@
     "gsis_id": "00-0037633",
     "sleeper_id": 8733,
     "yahoo_id": 34342,
+    "espn_id": 4241250,
     "pfr_id": "HummJa00"
   },
   {
@@ -13766,11 +13981,13 @@
     "pff_id": 43421,
     "sleeper_id": 7878,
     "yahoo_id": 33696,
+    "espn_id": 4371940,
     "pfr_id": "EiflMi00"
   },
   {
     "mfl_id": 16021,
-    "sleeper_id": 8725
+    "sleeper_id": 8725,
+    "espn_id": 4693173
   },
   {
     "mfl_id": 16022,
@@ -13829,6 +14046,7 @@
     "gsis_id": "00-0037112",
     "sleeper_id": 8698,
     "yahoo_id": 34374,
+    "espn_id": 4259147,
     "pfr_id": "TongJa00"
   },
   {
@@ -13855,7 +14073,8 @@
   },
   {
     "mfl_id": 16049,
-    "sleeper_id": 8564
+    "sleeper_id": 8564,
+    "espn_id": 4258183
   },
   {
     "mfl_id": 16050,
@@ -13869,6 +14088,7 @@
     "mfl_id": 16052,
     "gsis_id": "00-0037516",
     "sleeper_id": 8844,
+    "espn_id": 4700660,
     "pfr_id": "WebbSa00"
   },
   {
@@ -13889,6 +14109,7 @@
     "mfl_id": 16056,
     "gsis_id": "00-0037662",
     "sleeper_id": 8898,
+    "espn_id": 4052017,
     "pfr_id": "BrewCJ00"
   },
   {
@@ -13899,12 +14120,14 @@
   },
   {
     "mfl_id": 16059,
-    "sleeper_id": 8901
+    "sleeper_id": 8901,
+    "espn_id": 4240059
   },
   {
     "mfl_id": 16063,
     "gsis_id": "00-0037526",
-    "sleeper_id": 8618
+    "sleeper_id": 8618,
+    "espn_id": 4045299
   },
   {
     "mfl_id": 16064,
@@ -13918,12 +14141,14 @@
     "mfl_id": 16066,
     "gsis_id": "00-0037708",
     "sleeper_id": 8921,
-    "yahoo_id": 34712
+    "yahoo_id": 34712,
+    "espn_id": 3914307
   },
   {
     "mfl_id": 16068,
     "gsis_id": "00-0037660",
     "sleeper_id": 8899,
+    "espn_id": 4034335,
     "pfr_id": "EmilPr00"
   },
   {
@@ -13945,6 +14170,7 @@
     "mfl_id": 16077,
     "gsis_id": "00-0037602",
     "sleeper_id": 8540,
+    "espn_id": 4569497,
     "pfr_id": "OkuaSa00"
   },
   {
@@ -13959,12 +14185,14 @@
     "mfl_id": 16082,
     "gsis_id": "00-0037364",
     "sleeper_id": 8569,
+    "espn_id": 4242996,
     "pfr_id": "MosbAr00"
   },
   {
     "mfl_id": 16086,
     "sleeper_id": 8379,
-    "yahoo_id": 34254
+    "yahoo_id": 34254,
+    "espn_id": 4259346
   },
   {
     "mfl_id": 16087,
@@ -13975,7 +14203,8 @@
   },
   {
     "mfl_id": 16088,
-    "sleeper_id": 8641
+    "sleeper_id": 8641,
+    "espn_id": 4247944
   },
   {
     "mfl_id": 16091,
@@ -13999,26 +14228,30 @@
   {
     "mfl_id": 16095,
     "sleeper_id": 8893,
-    "yahoo_id": 34679
+    "yahoo_id": 34679,
+    "espn_id": 4362020
   },
   {
     "mfl_id": 16096,
     "gsis_id": "00-0037581",
     "sleeper_id": 8419,
     "yahoo_id": 34285,
+    "espn_id": 4245639,
     "pfr_id": "BerrSt00"
   },
   {
     "mfl_id": 16097,
     "gsis_id": "00-0037172",
     "sleeper_id": 8595,
-    "yahoo_id": 34276
+    "yahoo_id": 34276,
+    "espn_id": 4242270
   },
   {
     "mfl_id": 16098,
     "gsis_id": "00-0036148",
     "sleeper_id": 7390,
-    "yahoo_id": 33332
+    "yahoo_id": 33332,
+    "espn_id": 4590720
   },
   {
     "mfl_id": 16099,
@@ -14029,7 +14262,8 @@
   },
   {
     "mfl_id": 16101,
-    "sleeper_id": 8687
+    "sleeper_id": 8687,
+    "espn_id": 4071085
   },
   {
     "mfl_id": 16102,
@@ -14042,6 +14276,7 @@
     "mfl_id": 16103,
     "gsis_id": "00-0037341",
     "sleeper_id": 8794,
+    "espn_id": 4052609,
     "pfr_id": "PerrRo01"
   },
   {
@@ -14056,22 +14291,26 @@
     "mfl_id": 16114,
     "gsis_id": "00-0037153",
     "sleeper_id": 8691,
+    "espn_id": 4259636,
     "pfr_id": "JoneVi00"
   },
   {
     "mfl_id": 16115,
     "sleeper_id": 8536,
-    "yahoo_id": 34469
+    "yahoo_id": 34469,
+    "espn_id": 4036146
   },
   {
     "mfl_id": 16116,
     "gsis_id": "00-0037373",
-    "sleeper_id": 8765
+    "sleeper_id": 8765,
+    "espn_id": 4243808
   },
   {
     "mfl_id": 16117,
     "gsis_id": "00-0037222",
     "sleeper_id": 8719,
+    "espn_id": 4240155,
     "pfr_id": "ThomAJ00"
   },
   {
@@ -14085,7 +14324,8 @@
   {
     "mfl_id": 16119,
     "gsis_id": "00-0037464",
-    "sleeper_id": 8546
+    "sleeper_id": 8546,
+    "espn_id": 4039366
   },
   {
     "mfl_id": 16120,
@@ -14107,6 +14347,7 @@
     "gsis_id": "00-0037488",
     "sleeper_id": 8871,
     "yahoo_id": 34517,
+    "espn_id": 4035468,
     "pfr_id": "TurnNo00"
   },
   {
@@ -14120,21 +14361,25 @@
     "gsis_id": "00-0038147",
     "sleeper_id": 8928,
     "yahoo_id": 34713,
+    "espn_id": 4262900,
     "pfr_id": "BaldDa01"
   },
   {
     "mfl_id": 16127,
-    "sleeper_id": 8625
+    "sleeper_id": 8625,
+    "espn_id": 4256041
   },
   {
     "mfl_id": 16129,
     "gsis_id": "00-0037415",
-    "sleeper_id": 8788
+    "sleeper_id": 8788,
+    "espn_id": 4242655
   },
   {
     "mfl_id": 16131,
     "gsis_id": "00-0037375",
     "sleeper_id": 8288,
+    "espn_id": 4426583,
     "pfr_id": "HintCh01"
   },
   {
@@ -14146,13 +14391,15 @@
   },
   {
     "mfl_id": 16133,
-    "sleeper_id": 8748
+    "sleeper_id": 8748,
+    "espn_id": 4035044
   },
   {
     "mfl_id": 16135,
     "gsis_id": "00-0037031",
     "sleeper_id": 8107,
     "yahoo_id": 33950,
+    "espn_id": 4916349,
     "pfr_id": "KaliNi00"
   },
   {
@@ -14167,6 +14414,7 @@
     "mfl_id": 16137,
     "gsis_id": "00-0037181",
     "sleeper_id": 8552,
+    "espn_id": 4032721,
     "pfr_id": "NichRa00"
   },
   {
@@ -14187,12 +14435,14 @@
     "mfl_id": 16140,
     "gsis_id": "00-0037639",
     "sleeper_id": 8889,
+    "espn_id": 4044132,
     "pfr_id": "KwenWi00"
   },
   {
     "mfl_id": 16144,
     "gsis_id": "00-0037051",
     "sleeper_id": 8736,
+    "espn_id": 4039170,
     "pfr_id": "GarcEl00"
   },
   {
@@ -15259,6 +15509,7 @@
     "gsis_id": "00-0038561",
     "sleeper_id": 10931,
     "yahoo_id": 40104,
+    "espn_id": 4426440,
     "pfr_id": "IkaxSi00"
   },
   {
@@ -15314,6 +15565,7 @@
     "gsis_id": "00-0038567",
     "sleeper_id": 10955,
     "yahoo_id": 40159,
+    "espn_id": 4363538,
     "pfr_id": "RylaCh00"
   },
   {
@@ -15417,6 +15669,7 @@
     "mfl_id": 16306,
     "gsis_id": "00-0038581",
     "sleeper_id": 10991,
+    "espn_id": 4360308,
     "pfr_id": "HenrKJ00"
   },
   {
@@ -15470,6 +15723,7 @@
     "gsis_id": "00-0038391",
     "sleeper_id": 10983,
     "yahoo_id": 40173,
+    "espn_id": 4259592,
     "pfr_id": "ClifSe00"
   },
   {
@@ -15529,6 +15783,7 @@
     "mfl_id": 16321,
     "sleeper_id": 10967,
     "yahoo_id": 40178,
+    "espn_id": 4379413,
     "pfr_id": "SmitCh04"
   },
   {
@@ -15661,11 +15916,13 @@
     "gsis_id": "00-0038402",
     "sleeper_id": 11008,
     "yahoo_id": 40214,
+    "espn_id": 4242519,
     "pfr_id": "CarlAn00"
   },
   {
     "mfl_id": 16340,
     "sleeper_id": 11019,
+    "espn_id": 4373320,
     "pfr_id": "HallEr00"
   },
   {
@@ -15723,6 +15980,7 @@
     "mfl_id": 16348,
     "gsis_id": "00-0038405",
     "sleeper_id": 11054,
+    "espn_id": 4246741,
     "pfr_id": "BellTr01"
   },
   {
@@ -15757,6 +16015,7 @@
   {
     "mfl_id": 16353,
     "sleeper_id": 11047,
+    "espn_id": 4568682,
     "pfr_id": "VohaRa00"
   },
   {
@@ -15803,12 +16062,14 @@
     "gsis_id": "00-0038409",
     "sleeper_id": 9510,
     "yahoo_id": 40260,
+    "espn_id": 4428119,
     "pfr_id": "NichLe00"
   },
   {
     "mfl_id": 16360,
     "gsis_id": "00-0038638",
     "sleeper_id": 11038,
+    "espn_id": 4240261,
     "pfr_id": "PariDe00"
   },
   {
@@ -15823,6 +16084,7 @@
     "mfl_id": 16362,
     "sleeper_id": 11036,
     "yahoo_id": 40282,
+    "espn_id": 4361748,
     "pfr_id": "JohnAn08"
   },
   {
@@ -15844,6 +16106,7 @@
     "mfl_id": 16365,
     "gsis_id": "00-0038641",
     "sleeper_id": 11033,
+    "espn_id": 4711029,
     "pfr_id": "BoldIs00"
   },
   {
@@ -15907,6 +16170,7 @@
     "mfl_id": 16374,
     "sleeper_id": 11024,
     "yahoo_id": 40251,
+    "espn_id": 4879650,
     "pfr_id": "DuboGr00"
   },
   {
@@ -15937,7 +16201,8 @@
     "mfl_id": 16379,
     "gsis_id": "00-0038477",
     "sleeper_id": 9499,
-    "yahoo_id": 40529
+    "yahoo_id": 40529,
+    "espn_id": 4362227
   },
   {
     "mfl_id": 16380,
@@ -15949,7 +16214,8 @@
   {
     "mfl_id": 16381,
     "sleeper_id": 11146,
-    "yahoo_id": 40380
+    "yahoo_id": 40380,
+    "espn_id": 4361665
   },
   {
     "mfl_id": 16382,
@@ -15986,7 +16252,8 @@
     "mfl_id": 16386,
     "gsis_id": "00-0038727",
     "sleeper_id": 10861,
-    "yahoo_id": 40721
+    "yahoo_id": 40721,
+    "espn_id": 4240350
   },
   {
     "mfl_id": 16387,
@@ -16001,7 +16268,8 @@
   {
     "mfl_id": 16389,
     "gsis_id": "00-0038734",
-    "sleeper_id": 11505
+    "sleeper_id": 11505,
+    "espn_id": 4370374
   },
   {
     "mfl_id": 16390,
@@ -16109,7 +16377,8 @@
     "mfl_id": 16406,
     "gsis_id": "00-0037164",
     "sleeper_id": 8192,
-    "yahoo_id": 34274
+    "yahoo_id": 34274,
+    "espn_id": 4242896
   },
   {
     "mfl_id": 16408,
@@ -16201,7 +16470,8 @@
   {
     "mfl_id": 16422,
     "gsis_id": "00-0038519",
-    "sleeper_id": 11320
+    "sleeper_id": 11320,
+    "espn_id": 4372716
   },
   {
     "mfl_id": 16423,
@@ -16240,7 +16510,8 @@
     "mfl_id": 16428,
     "gsis_id": "00-0038359",
     "sleeper_id": 11168,
-    "yahoo_id": 40399
+    "yahoo_id": 40399,
+    "espn_id": 4386544
   },
   {
     "mfl_id": 16429,
@@ -16286,12 +16557,14 @@
     "mfl_id": 16435,
     "gsis_id": "00-0037506",
     "sleeper_id": 8840,
-    "yahoo_id": 34543
+    "yahoo_id": 34543,
+    "espn_id": 4361008
   },
   {
     "mfl_id": 16436,
     "gsis_id": "00-0038908",
-    "sleeper_id": 11108
+    "sleeper_id": 11108,
+    "espn_id": 4567535
   },
   {
     "mfl_id": 16437,
@@ -16303,7 +16576,8 @@
     "mfl_id": 16438,
     "gsis_id": "00-0038965",
     "sleeper_id": 11483,
-    "yahoo_id": 40748
+    "yahoo_id": 40748,
+    "espn_id": 4685016
   },
   {
     "mfl_id": 16439,
@@ -16337,7 +16611,8 @@
   {
     "mfl_id": 16443,
     "gsis_id": "00-0038764",
-    "sleeper_id": 11230
+    "sleeper_id": 11230,
+    "espn_id": 4364623
   },
   {
     "mfl_id": 16444,
@@ -16350,7 +16625,8 @@
     "mfl_id": 16445,
     "gsis_id": "00-0038902",
     "sleeper_id": 11105,
-    "yahoo_id": 40338
+    "yahoo_id": 40338,
+    "espn_id": 4579752
   },
   {
     "mfl_id": 16446,
@@ -16387,7 +16663,8 @@
     "mfl_id": 16451,
     "gsis_id": "00-0038679",
     "sleeper_id": 11377,
-    "yahoo_id": 40630
+    "yahoo_id": 40630,
+    "espn_id": 4241476
   },
   {
     "mfl_id": 16452,
@@ -16399,6 +16676,7 @@
     "gsis_id": "00-0038667",
     "sleeper_id": 11139,
     "yahoo_id": 40374,
+    "espn_id": 4241588,
     "pfr_id": "CookEl00"
   },
   {
@@ -16479,7 +16757,8 @@
   {
     "mfl_id": 16466,
     "gsis_id": "00-0037627",
-    "sleeper_id": 8887
+    "sleeper_id": 8887,
+    "espn_id": 4249596
   },
   {
     "mfl_id": 16467,
@@ -16530,7 +16809,8 @@
   {
     "mfl_id": 16482,
     "gsis_id": "00-0037608",
-    "sleeper_id": 8537
+    "sleeper_id": 8537,
+    "espn_id": 4240476
   },
   {
     "mfl_id": 16483,
@@ -16551,18 +16831,21 @@
     "mfl_id": 16485,
     "gsis_id": "00-0038791",
     "sleeper_id": 11441,
+    "espn_id": 4714157,
     "pfr_id": "IncoTh00"
   },
   {
     "mfl_id": 16486,
     "gsis_id": "00-0038694",
     "sleeper_id": 11396,
+    "espn_id": 4259651,
     "pfr_id": "PiliBr00"
   },
   {
     "mfl_id": 16490,
     "gsis_id": "00-0038827",
     "sleeper_id": 11425,
+    "espn_id": 4241884,
     "pfr_id": "PittDe01"
   },
   {
@@ -16605,6 +16888,7 @@
     "mfl_id": 16504,
     "gsis_id": "00-0038655",
     "sleeper_id": 11487,
+    "espn_id": 4374338,
     "pfr_id": "GilmSt01"
   },
   {
@@ -16639,6 +16923,7 @@
     "mfl_id": 16520,
     "gsis_id": "00-0038653",
     "sleeper_id": 11338,
+    "espn_id": 4240042,
     "pfr_id": "DurdCo00"
   },
   {
@@ -16674,6 +16959,7 @@
     "mfl_id": 16532,
     "gsis_id": "00-0038660",
     "sleeper_id": 11348,
+    "espn_id": 5144894,
     "pfr_id": "NowaTr00"
   },
   {
@@ -16681,6 +16967,7 @@
     "gsis_id": "00-0038891",
     "sleeper_id": 11257,
     "yahoo_id": 40491,
+    "espn_id": 4361332,
     "pfr_id": "JackSh01"
   },
   {
@@ -16719,315 +17006,393 @@
   },
   {
     "mfl_id": 13847,
-    "gsis_id": "00-0034439"
+    "gsis_id": "00-0034439",
+    "espn_id": 3122920
   },
   {
     "mfl_id": 16579,
-    "gsis_id": "00-0039918"
+    "gsis_id": "00-0039918",
+    "espn_id": 4431611
   },
   {
     "mfl_id": 16580,
-    "gsis_id": "00-0039851"
+    "gsis_id": "00-0039851",
+    "espn_id": 4431452
   },
   {
     "mfl_id": 16581,
-    "gsis_id": "00-0039910"
+    "gsis_id": "00-0039910",
+    "espn_id": 4426348
   },
   {
     "mfl_id": 16582,
-    "gsis_id": "00-0039732"
+    "gsis_id": "00-0039732",
+    "espn_id": 4426338
   },
   {
     "mfl_id": 16583,
-    "gsis_id": "00-0039917"
+    "gsis_id": "00-0039917",
+    "espn_id": 4360423
   },
   {
     "mfl_id": 16584,
-    "gsis_id": "00-0039923"
+    "gsis_id": "00-0039923",
+    "espn_id": 4433970
   },
   {
     "mfl_id": 16585,
-    "gsis_id": "00-0039398"
+    "gsis_id": "00-0039398",
+    "espn_id": 4360698
   },
   {
     "mfl_id": 16586,
-    "gsis_id": "00-0039376"
+    "gsis_id": "00-0039376",
+    "espn_id": 4426339
   },
   {
     "mfl_id": 16587,
-    "gsis_id": "00-0039677"
+    "gsis_id": "00-0039677",
+    "espn_id": 4361994
   },
   {
     "mfl_id": 16588,
-    "gsis_id": "00-0039238"
+    "gsis_id": "00-0039238",
+    "espn_id": 4685039
   },
   {
     "mfl_id": 16589,
-    "gsis_id": "00-0039797"
+    "gsis_id": "00-0039797",
+    "espn_id": 4360799
   },
   {
     "mfl_id": 16591,
-    "gsis_id": "00-0039801"
+    "gsis_id": "00-0039801",
+    "espn_id": 4361653
   },
   {
     "mfl_id": 16592,
-    "gsis_id": "00-0039501"
+    "gsis_id": "00-0039501",
+    "espn_id": 2961162
   },
   {
     "mfl_id": 16593,
-    "gsis_id": "00-0039738"
+    "gsis_id": "00-0039738",
+    "espn_id": 4429096
   },
   {
     "mfl_id": 16594,
-    "gsis_id": "00-0039921"
+    "gsis_id": "00-0039921",
+    "espn_id": 4429275
   },
   {
     "mfl_id": 16595,
-    "gsis_id": "00-0039373"
+    "gsis_id": "00-0039373",
+    "espn_id": 4569682
   },
   {
     "mfl_id": 16596,
-    "gsis_id": "00-0039794"
+    "gsis_id": "00-0039794",
+    "espn_id": 4685247
   },
   {
     "mfl_id": 16597,
-    "gsis_id": "00-0039344"
+    "gsis_id": "00-0039344",
+    "espn_id": 4678008
   },
   {
     "mfl_id": 16598,
-    "gsis_id": "00-0039361"
+    "gsis_id": "00-0039361",
+    "espn_id": 4596448
   },
   {
     "mfl_id": 16599,
-    "gsis_id": "00-0039471"
+    "gsis_id": "00-0039471",
+    "espn_id": 4429805
   },
   {
     "mfl_id": 16600,
-    "gsis_id": "00-0039703"
+    "gsis_id": "00-0039703",
+    "espn_id": 4391845
   },
   {
     "mfl_id": 16601,
-    "gsis_id": "00-0039746"
+    "gsis_id": "00-0039746",
+    "espn_id": 4431545
   },
   {
     "mfl_id": 16603,
-    "gsis_id": "00-0039875"
+    "gsis_id": "00-0039875",
+    "espn_id": 4429501
   },
   {
     "mfl_id": 16604,
-    "gsis_id": "00-0039811"
+    "gsis_id": "00-0039811",
+    "espn_id": 4429023
   },
   {
     "mfl_id": 16605,
-    "gsis_id": "00-0039393"
+    "gsis_id": "00-0039393",
+    "espn_id": 4429001
   },
   {
     "mfl_id": 16606,
-    "gsis_id": "00-0039266"
+    "gsis_id": "00-0039266",
+    "espn_id": 4429012
   },
   {
     "mfl_id": 16607,
-    "gsis_id": "00-0039652"
+    "gsis_id": "00-0039652",
+    "espn_id": 4432545
   },
   {
     "mfl_id": 16608,
-    "gsis_id": "00-0039299"
+    "gsis_id": "00-0039299",
+    "espn_id": 4429835
   },
   {
     "mfl_id": 16609,
-    "gsis_id": "00-0039647"
+    "gsis_id": "00-0039647",
+    "espn_id": 4689338
   },
   {
     "mfl_id": 16610,
-    "gsis_id": "00-0039874"
+    "gsis_id": "00-0039874",
+    "espn_id": 4682745
   },
   {
     "mfl_id": 16611,
-    "gsis_id": "00-0039311"
+    "gsis_id": "00-0039311",
+    "espn_id": 4565761
   },
   {
     "mfl_id": 16612,
-    "gsis_id": "00-0039325"
+    "gsis_id": "00-0039325",
+    "espn_id": 4714365
   },
   {
     "mfl_id": 16613,
-    "gsis_id": "00-0039407"
+    "gsis_id": "00-0039407",
+    "espn_id": 4366963
   },
   {
     "mfl_id": 16614,
-    "gsis_id": "00-0039849"
+    "gsis_id": "00-0039849",
+    "espn_id": 4432708
   },
   {
     "mfl_id": 16615,
-    "gsis_id": "00-0039337"
+    "gsis_id": "00-0039337",
+    "espn_id": 4595348
   },
   {
     "mfl_id": 16616,
-    "gsis_id": "00-0039919"
+    "gsis_id": "00-0039919",
+    "espn_id": 4431299
   },
   {
     "mfl_id": 16617,
-    "gsis_id": "00-0039901"
+    "gsis_id": "00-0039901",
+    "espn_id": 4635008
   },
   {
     "mfl_id": 16618,
-    "gsis_id": "00-0039893"
+    "gsis_id": "00-0039893",
+    "espn_id": 4432773
   },
   {
     "mfl_id": 16619,
-    "gsis_id": "00-0039868"
+    "gsis_id": "00-0039868",
+    "espn_id": 4431280
   },
   {
     "mfl_id": 16620,
-    "gsis_id": "00-0039894"
+    "gsis_id": "00-0039894",
+    "espn_id": 4683062
   },
   {
     "mfl_id": 16621,
-    "gsis_id": "00-0039792"
+    "gsis_id": "00-0039792",
+    "espn_id": 4696882
   },
   {
     "mfl_id": 16622,
-    "gsis_id": "00-0039916"
+    "gsis_id": "00-0039916",
+    "espn_id": 4428209
   },
   {
     "mfl_id": 16623,
-    "gsis_id": "00-0039415"
+    "gsis_id": "00-0039415",
+    "espn_id": 4686781
   },
   {
     "mfl_id": 16624,
-    "gsis_id": "00-0039379"
+    "gsis_id": "00-0039379",
+    "espn_id": 4428678
   },
   {
     "mfl_id": 16625,
-    "gsis_id": "00-0039236"
+    "gsis_id": "00-0039236",
+    "espn_id": 4686104
   },
   {
     "mfl_id": 16626,
-    "gsis_id": "00-0039890"
+    "gsis_id": "00-0039890",
+    "espn_id": 4597500
   },
   {
     "mfl_id": 16627,
-    "gsis_id": "00-0039915"
+    "gsis_id": "00-0039915",
+    "espn_id": 4612826
   },
   {
     "mfl_id": 16628,
-    "gsis_id": "00-0039855"
+    "gsis_id": "00-0039855",
+    "espn_id": 4430834
   },
   {
     "mfl_id": 16629,
-    "gsis_id": "00-0039739"
+    "gsis_id": "00-0039739",
+    "espn_id": 4431492
   },
   {
     "mfl_id": 16630,
-    "gsis_id": "00-0039451"
+    "gsis_id": "00-0039451",
+    "espn_id": 4569371
   },
   {
     "mfl_id": 16631,
-    "gsis_id": "00-0039907"
+    "gsis_id": "00-0039907",
+    "espn_id": 4430637
   },
   {
     "mfl_id": 16632,
-    "gsis_id": "00-0039810"
+    "gsis_id": "00-0039810",
+    "espn_id": 4429033
   },
   {
     "mfl_id": 16633,
-    "gsis_id": "00-0039751"
+    "gsis_id": "00-0039751",
+    "espn_id": 4569382
   },
   {
     "mfl_id": 16634,
-    "gsis_id": "00-0039521"
+    "gsis_id": "00-0039521",
+    "espn_id": 4428811
   },
   {
     "mfl_id": 16635,
-    "gsis_id": "00-0039355"
+    "gsis_id": "00-0039355",
+    "espn_id": 4426948
   },
   {
     "mfl_id": 16636,
-    "gsis_id": "00-0039920"
+    "gsis_id": "00-0039920",
+    "espn_id": 4613104
   },
   {
     "mfl_id": 16637,
-    "gsis_id": "00-0039853"
+    "gsis_id": "00-0039853",
+    "espn_id": 4692022
   },
   {
     "mfl_id": 16639,
-    "gsis_id": "00-0039342"
+    "gsis_id": "00-0039342",
+    "espn_id": 4430034
   },
   {
     "mfl_id": 16640,
-    "gsis_id": "00-0039365"
+    "gsis_id": "00-0039365",
+    "espn_id": 4575665
   },
   {
     "mfl_id": 16641,
-    "gsis_id": "00-0039338"
+    "gsis_id": "00-0039338",
+    "espn_id": 4432665
   },
   {
     "mfl_id": 16642,
-    "gsis_id": "00-0039359"
+    "gsis_id": "00-0039359",
+    "espn_id": 4426496
   },
   {
     "mfl_id": 16643,
-    "gsis_id": "00-0039356"
+    "gsis_id": "00-0039356",
+    "espn_id": 4431588
   },
   {
     "mfl_id": 16644,
-    "gsis_id": "00-0039912"
+    "gsis_id": "00-0039912",
+    "espn_id": 4690923
   },
   {
     "mfl_id": 16645,
-    "gsis_id": "00-0039814"
+    "gsis_id": "00-0039814",
+    "espn_id": 4427834
   },
   {
     "mfl_id": 16646,
-    "gsis_id": "00-0039420"
+    "gsis_id": "00-0039420",
+    "espn_id": 4429262
   },
   {
     "mfl_id": 16647,
-    "gsis_id": "00-0039530"
+    "gsis_id": "00-0039530",
+    "espn_id": 4360967
   },
   {
     "mfl_id": 16648,
-    "gsis_id": "00-0039824"
+    "gsis_id": "00-0039824",
+    "espn_id": 4430723
   },
   {
     "mfl_id": 16649,
-    "gsis_id": "00-0039847"
+    "gsis_id": "00-0039847",
+    "espn_id": 4429148
   },
   {
     "mfl_id": 16650,
-    "gsis_id": "00-0039924"
+    "gsis_id": "00-0039924",
+    "espn_id": 4565190
   },
   {
     "mfl_id": 16651,
-    "gsis_id": "00-0039340"
+    "gsis_id": "00-0039340",
+    "espn_id": 4426473
   },
   {
     "mfl_id": 16652,
-    "gsis_id": "00-0039837"
+    "gsis_id": "00-0039837",
+    "espn_id": 4428713
   },
   {
     "mfl_id": 16653,
-    "gsis_id": "00-0039852"
+    "gsis_id": "00-0039852",
+    "espn_id": 4578085
   },
   {
     "mfl_id": 16654,
-    "gsis_id": "00-0039809"
+    "gsis_id": "00-0039809",
+    "espn_id": 4687592
   },
   {
     "mfl_id": 16655,
-    "gsis_id": "00-0039911"
+    "gsis_id": "00-0039911",
+    "espn_id": 4431586
   },
   {
     "mfl_id": 16656,
-    "gsis_id": "00-0039902"
+    "gsis_id": "00-0039902",
+    "espn_id": 4428989
   },
   {
     "mfl_id": 16657,
-    "gsis_id": "00-0039859"
+    "gsis_id": "00-0039859",
+    "espn_id": 4427090
   },
   {
     "mfl_id": 16658,
-    "gsis_id": "00-0039367"
+    "gsis_id": "00-0039367",
+    "espn_id": 4360304
   },
   {
     "mfl_id": 16659,
@@ -17035,315 +17400,393 @@
   },
   {
     "mfl_id": 16660,
-    "gsis_id": "00-0039854"
+    "gsis_id": "00-0039854",
+    "espn_id": 4569480
   },
   {
     "mfl_id": 16661,
-    "gsis_id": "00-0039895"
+    "gsis_id": "00-0039895",
+    "espn_id": 4600415
   },
   {
     "mfl_id": 16662,
-    "gsis_id": "00-0039908"
+    "gsis_id": "00-0039908",
+    "espn_id": 4432301
   },
   {
     "mfl_id": 16663,
-    "gsis_id": "00-0039835"
+    "gsis_id": "00-0039835",
+    "espn_id": 4567138
   },
   {
     "mfl_id": 16664,
-    "gsis_id": "00-0039826"
+    "gsis_id": "00-0039826",
+    "espn_id": 4432777
   },
   {
     "mfl_id": 16665,
-    "gsis_id": "00-0039346"
+    "gsis_id": "00-0039346",
+    "espn_id": 4431212
   },
   {
     "mfl_id": 16666,
-    "gsis_id": "00-0039374"
+    "gsis_id": "00-0039374",
+    "espn_id": 4429560
   },
   {
     "mfl_id": 16667,
-    "gsis_id": "00-0039858"
+    "gsis_id": "00-0039858",
+    "espn_id": 4429834
   },
   {
     "mfl_id": 16668,
-    "gsis_id": "00-0039440"
+    "gsis_id": "00-0039440",
+    "espn_id": 4426482
   },
   {
     "mfl_id": 16669,
-    "gsis_id": "00-0039388"
+    "gsis_id": "00-0039388",
+    "espn_id": 4566088
   },
   {
     "mfl_id": 16670,
-    "gsis_id": "00-0039860"
+    "gsis_id": "00-0039860",
+    "espn_id": 4433975
   },
   {
     "mfl_id": 16671,
-    "gsis_id": "00-0039903"
+    "gsis_id": "00-0039903",
+    "espn_id": 4592837
   },
   {
     "mfl_id": 16672,
-    "gsis_id": "00-0039343"
+    "gsis_id": "00-0039343",
+    "espn_id": 4602699
   },
   {
     "mfl_id": 16673,
-    "gsis_id": "00-0039232"
+    "gsis_id": "00-0039232",
+    "espn_id": 4601278
   },
   {
     "mfl_id": 16674,
-    "gsis_id": "00-0039239"
+    "gsis_id": "00-0039239",
+    "espn_id": 4431433
   },
   {
     "mfl_id": 16675,
-    "gsis_id": "00-0039841"
+    "gsis_id": "00-0039841",
+    "espn_id": 4682618
   },
   {
     "mfl_id": 16676,
-    "gsis_id": "00-0039834"
+    "gsis_id": "00-0039834",
+    "espn_id": 4596363
   },
   {
     "mfl_id": 16677,
-    "gsis_id": "00-0039867"
+    "gsis_id": "00-0039867",
+    "espn_id": 4688930
   },
   {
     "mfl_id": 16678,
-    "gsis_id": "00-0039364"
+    "gsis_id": "00-0039364",
+    "espn_id": 4912274
   },
   {
     "mfl_id": 16679,
-    "gsis_id": "00-0039861"
+    "gsis_id": "00-0039861",
+    "espn_id": 4430261
   },
   {
     "mfl_id": 16680,
-    "gsis_id": "00-0039409"
+    "gsis_id": "00-0039409",
+    "espn_id": 4686361
   },
   {
     "mfl_id": 16681,
-    "gsis_id": "00-0039404"
+    "gsis_id": "00-0039404",
+    "espn_id": 4567104
   },
   {
     "mfl_id": 16682,
-    "gsis_id": "00-0039577"
+    "gsis_id": "00-0039577",
+    "espn_id": 4428512
   },
   {
     "mfl_id": 16683,
-    "gsis_id": "00-0039228"
+    "gsis_id": "00-0039228",
+    "espn_id": 5208436
   },
   {
     "mfl_id": 16684,
-    "gsis_id": "00-0039880"
+    "gsis_id": "00-0039880",
+    "espn_id": 4569603
   },
   {
     "mfl_id": 16686,
-    "gsis_id": "00-0039747"
+    "gsis_id": "00-0039747",
+    "espn_id": 4428532
   },
   {
     "mfl_id": 16687,
-    "gsis_id": "00-0039230"
+    "gsis_id": "00-0039230",
+    "espn_id": 4367510
   },
   {
     "mfl_id": 16688,
-    "gsis_id": "00-0039363"
+    "gsis_id": "00-0039363",
+    "espn_id": 4372561
   },
   {
     "mfl_id": 16689,
-    "gsis_id": "00-0039309"
+    "gsis_id": "00-0039309",
+    "espn_id": 4570040
   },
   {
     "mfl_id": 16690,
-    "gsis_id": "00-0039888"
+    "gsis_id": "00-0039888",
+    "espn_id": 4686273
   },
   {
     "mfl_id": 16691,
-    "gsis_id": "00-0039733"
+    "gsis_id": "00-0039733",
+    "espn_id": 4430271
   },
   {
     "mfl_id": 16692,
-    "gsis_id": "00-0039906"
+    "gsis_id": "00-0039906",
+    "espn_id": 4430560
   },
   {
     "mfl_id": 16693,
-    "gsis_id": "00-0039886"
+    "gsis_id": "00-0039886",
+    "espn_id": 4428617
   },
   {
     "mfl_id": 16694,
-    "gsis_id": "00-0039734"
+    "gsis_id": "00-0039734",
+    "espn_id": 4362245
   },
   {
     "mfl_id": 16695,
-    "gsis_id": "00-0039807"
+    "gsis_id": "00-0039807",
+    "espn_id": 4698113
   },
   {
     "mfl_id": 16696,
-    "gsis_id": "00-0039850"
+    "gsis_id": "00-0039850",
+    "espn_id": 4430438
   },
   {
     "mfl_id": 16697,
-    "gsis_id": "00-0039889"
+    "gsis_id": "00-0039889",
+    "espn_id": 4431567
   },
   {
     "mfl_id": 16698,
-    "gsis_id": "00-0039898"
+    "gsis_id": "00-0039898",
+    "espn_id": 4428414
   },
   {
     "mfl_id": 16699,
-    "gsis_id": "00-0039900"
+    "gsis_id": "00-0039900",
+    "espn_id": 4429996
   },
   {
     "mfl_id": 16700,
-    "gsis_id": "00-0039872"
+    "gsis_id": "00-0039872",
+    "espn_id": 4676004
   },
   {
     "mfl_id": 16701,
-    "gsis_id": "00-0039862"
+    "gsis_id": "00-0039862",
+    "espn_id": 4566092
   },
   {
     "mfl_id": 16702,
-    "gsis_id": "00-0039345"
+    "gsis_id": "00-0039345",
+    "espn_id": 4427325
   },
   {
     "mfl_id": 16703,
-    "gsis_id": "00-0039821"
+    "gsis_id": "00-0039821",
+    "espn_id": 4431321
   },
   {
     "mfl_id": 16704,
-    "gsis_id": "00-0039347"
+    "gsis_id": "00-0039347",
+    "espn_id": 4683815
   },
   {
     "mfl_id": 16705,
-    "gsis_id": "00-0039838"
+    "gsis_id": "00-0039838",
+    "espn_id": 4431517
   },
   {
     "mfl_id": 16706,
-    "gsis_id": "00-0039737"
+    "gsis_id": "00-0039737",
+    "espn_id": 4696700
   },
   {
     "mfl_id": 16707,
-    "gsis_id": "00-0039352"
+    "gsis_id": "00-0039352",
+    "espn_id": 4427816
   },
   {
     "mfl_id": 16708,
-    "gsis_id": "00-0039846"
+    "gsis_id": "00-0039846",
+    "espn_id": 4428522
   },
   {
     "mfl_id": 16709,
-    "gsis_id": "00-0039823"
+    "gsis_id": "00-0039823",
+    "espn_id": 4360203
   },
   {
     "mfl_id": 16710,
-    "gsis_id": "00-0039812"
+    "gsis_id": "00-0039812",
+    "espn_id": 4567406
   },
   {
     "mfl_id": 16711,
-    "gsis_id": "00-0039791"
+    "gsis_id": "00-0039791",
+    "espn_id": 4426372
   },
   {
     "mfl_id": 16712,
-    "gsis_id": "00-0039740"
+    "gsis_id": "00-0039740",
+    "espn_id": 4571162
   },
   {
     "mfl_id": 16713,
-    "gsis_id": "00-0039873"
+    "gsis_id": "00-0039873",
+    "espn_id": 4426883
   },
   {
     "mfl_id": 16714,
-    "gsis_id": "00-0039353"
+    "gsis_id": "00-0039353",
+    "espn_id": 4426448
   },
   {
     "mfl_id": 16715,
-    "gsis_id": "00-0039354"
+    "gsis_id": "00-0039354",
+    "espn_id": 4692680
   },
   {
     "mfl_id": 16716,
-    "gsis_id": "00-0039741"
+    "gsis_id": "00-0039741",
+    "espn_id": 4361652
   },
   {
     "mfl_id": 16717,
-    "gsis_id": "00-0039864"
+    "gsis_id": "00-0039864",
+    "espn_id": 4428633
   },
   {
     "mfl_id": 16718,
-    "gsis_id": "00-0039856"
+    "gsis_id": "00-0039856",
+    "espn_id": 4688806
   },
   {
     "mfl_id": 16719,
-    "gsis_id": "00-0039813"
+    "gsis_id": "00-0039813",
+    "espn_id": 4428863
   },
   {
     "mfl_id": 16720,
-    "gsis_id": "00-0039357"
+    "gsis_id": "00-0039357",
+    "espn_id": 4605498
   },
   {
     "mfl_id": 16721,
-    "gsis_id": "00-0039743"
+    "gsis_id": "00-0039743",
+    "espn_id": 4569448
   },
   {
     "mfl_id": 16722,
-    "gsis_id": "00-0039815"
+    "gsis_id": "00-0039815",
+    "espn_id": 4686540
   },
   {
     "mfl_id": 16723,
-    "gsis_id": "00-0039793"
+    "gsis_id": "00-0039793",
+    "espn_id": 4576297
   },
   {
     "mfl_id": 16724,
-    "gsis_id": "00-0039745"
+    "gsis_id": "00-0039745",
+    "espn_id": 4686889
   },
   {
     "mfl_id": 16725,
-    "gsis_id": "00-0039360"
+    "gsis_id": "00-0039360",
+    "espn_id": 4696211
   },
   {
     "mfl_id": 16726,
-    "gsis_id": "00-0039234"
+    "gsis_id": "00-0039234",
+    "espn_id": 4575483
   },
   {
     "mfl_id": 16727,
-    "gsis_id": "00-0039825"
+    "gsis_id": "00-0039825",
+    "espn_id": 4685232
   },
   {
     "mfl_id": 16728,
-    "gsis_id": "00-0039795"
+    "gsis_id": "00-0039795",
+    "espn_id": 4567222
   },
   {
     "mfl_id": 16729,
-    "gsis_id": "00-0039366"
+    "gsis_id": "00-0039366",
+    "espn_id": 4432571
   },
   {
     "mfl_id": 16730,
-    "gsis_id": "00-0039368"
+    "gsis_id": "00-0039368",
+    "espn_id": 4568617
   },
   {
     "mfl_id": 16731,
-    "gsis_id": "00-0039369"
+    "gsis_id": "00-0039369",
+    "espn_id": 4427404
   },
   {
     "mfl_id": 16732,
-    "gsis_id": "00-0039816"
+    "gsis_id": "00-0039816",
+    "espn_id": 4429684
   },
   {
     "mfl_id": 16733,
-    "gsis_id": "00-0039370"
+    "gsis_id": "00-0039370",
+    "espn_id": 4428872
   },
   {
     "mfl_id": 16734,
-    "gsis_id": "00-0039840"
+    "gsis_id": "00-0039840",
+    "espn_id": 4683553
   },
   {
     "mfl_id": 16735,
-    "gsis_id": "00-0039371"
+    "gsis_id": "00-0039371",
+    "espn_id": 4429193
   },
   {
     "mfl_id": 16736,
-    "gsis_id": "00-0039372"
+    "gsis_id": "00-0039372",
+    "espn_id": 4426817
   },
   {
     "mfl_id": 16737,
-    "gsis_id": "00-0039375"
+    "gsis_id": "00-0039375",
+    "espn_id": 4365319
   },
   {
     "mfl_id": 16738,
-    "gsis_id": "00-0039377"
+    "gsis_id": "00-0039377",
+    "espn_id": 4601021
   },
   {
     "mfl_id": 16739,
@@ -17351,187 +17794,233 @@
   },
   {
     "mfl_id": 16740,
-    "gsis_id": "00-0039836"
+    "gsis_id": "00-0039836",
+    "espn_id": 4373471
   },
   {
     "mfl_id": 16741,
-    "gsis_id": "00-0039380"
+    "gsis_id": "00-0039380",
+    "espn_id": 4697636
   },
   {
     "mfl_id": 16742,
-    "gsis_id": "00-0039877"
+    "gsis_id": "00-0039877",
+    "espn_id": 4427677
   },
   {
     "mfl_id": 16743,
-    "gsis_id": "00-0039878"
+    "gsis_id": "00-0039878",
+    "espn_id": 4374280
   },
   {
     "mfl_id": 16744,
-    "gsis_id": "00-0039381"
+    "gsis_id": "00-0039381",
+    "espn_id": 4361094
   },
   {
     "mfl_id": 16745,
-    "gsis_id": "00-0039383"
+    "gsis_id": "00-0039383",
+    "espn_id": 4567225
   },
   {
     "mfl_id": 16746,
-    "gsis_id": "00-0039796"
+    "gsis_id": "00-0039796",
+    "espn_id": 4690013
   },
   {
     "mfl_id": 16747,
-    "gsis_id": "00-0039384"
+    "gsis_id": "00-0039384",
+    "espn_id": 4360516
   },
   {
     "mfl_id": 16748,
-    "gsis_id": "00-0039385"
+    "gsis_id": "00-0039385",
+    "espn_id": 4567095
   },
   {
     "mfl_id": 16749,
-    "gsis_id": "00-0039879"
+    "gsis_id": "00-0039879",
+    "espn_id": 4428548
   },
   {
     "mfl_id": 16750,
-    "gsis_id": "00-0039818"
+    "gsis_id": "00-0039818",
+    "espn_id": 4374037
   },
   {
     "mfl_id": 16751,
-    "gsis_id": "00-0039386"
+    "gsis_id": "00-0039386",
+    "espn_id": 4427985
   },
   {
     "mfl_id": 16752,
-    "gsis_id": "00-0039798"
+    "gsis_id": "00-0039798",
+    "espn_id": 4695404
   },
   {
     "mfl_id": 16753,
-    "gsis_id": "00-0039387"
+    "gsis_id": "00-0039387",
+    "espn_id": 4431006
   },
   {
     "mfl_id": 16754,
-    "gsis_id": "00-0039789"
+    "gsis_id": "00-0039789",
+    "espn_id": 5208977
   },
   {
     "mfl_id": 16755,
-    "gsis_id": "00-0039389"
+    "gsis_id": "00-0039389",
+    "espn_id": 4569474
   },
   {
     "mfl_id": 16756,
-    "gsis_id": "00-0039390"
+    "gsis_id": "00-0039390",
+    "espn_id": 4875079
   },
   {
     "mfl_id": 16757,
-    "gsis_id": "00-0039391"
+    "gsis_id": "00-0039391",
+    "espn_id": 4430968
   },
   {
     "mfl_id": 16758,
-    "gsis_id": "00-0039392"
+    "gsis_id": "00-0039392",
+    "espn_id": 4427575
   },
   {
     "mfl_id": 16759,
-    "gsis_id": "00-0039829"
+    "gsis_id": "00-0039829",
+    "espn_id": 4428072
   },
   {
     "mfl_id": 16760,
-    "gsis_id": "00-0039394"
+    "gsis_id": "00-0039394",
+    "espn_id": 4428796
   },
   {
     "mfl_id": 16761,
-    "gsis_id": "00-0039395"
+    "gsis_id": "00-0039395",
+    "espn_id": 4427479
   },
   {
     "mfl_id": 16762,
-    "gsis_id": "00-0039396"
+    "gsis_id": "00-0039396",
+    "espn_id": 4586333
   },
   {
     "mfl_id": 16763,
-    "gsis_id": "00-0039397"
+    "gsis_id": "00-0039397",
+    "espn_id": 4875912
   },
   {
     "mfl_id": 16764,
-    "gsis_id": "00-0039800"
+    "gsis_id": "00-0039800",
+    "espn_id": 4429891
   },
   {
     "mfl_id": 16765,
-    "gsis_id": "00-0039399"
+    "gsis_id": "00-0039399",
+    "espn_id": 4384171
   },
   {
     "mfl_id": 16766,
-    "gsis_id": "00-0039748"
+    "gsis_id": "00-0039748",
+    "espn_id": 4685092
   },
   {
     "mfl_id": 16767,
-    "gsis_id": "00-0039749"
+    "gsis_id": "00-0039749",
+    "espn_id": 4568217
   },
   {
     "mfl_id": 16768,
-    "gsis_id": "00-0039400"
+    "gsis_id": "00-0039400",
+    "espn_id": 4427826
   },
   {
     "mfl_id": 16769,
-    "gsis_id": "00-0039881"
+    "gsis_id": "00-0039881",
+    "espn_id": 4430158
   },
   {
     "mfl_id": 16770,
-    "gsis_id": "00-0039401"
+    "gsis_id": "00-0039401",
+    "espn_id": 4384595
   },
   {
     "mfl_id": 16771,
-    "gsis_id": "00-0039402"
+    "gsis_id": "00-0039402",
+    "espn_id": 4362910
   },
   {
     "mfl_id": 16772,
-    "gsis_id": "00-0039403"
+    "gsis_id": "00-0039403",
+    "espn_id": 4427563
   },
   {
     "mfl_id": 16773,
-    "gsis_id": "00-0039405"
+    "gsis_id": "00-0039405",
+    "espn_id": 4429939
   },
   {
     "mfl_id": 16774,
-    "gsis_id": "00-0039406"
+    "gsis_id": "00-0039406",
+    "espn_id": 4362895
   },
   {
     "mfl_id": 16775,
-    "gsis_id": "00-0039750"
+    "gsis_id": "00-0039750",
+    "espn_id": 4566192
   },
   {
     "mfl_id": 16776,
-    "gsis_id": "00-0039831"
+    "gsis_id": "00-0039831",
+    "espn_id": 4427356
   },
   {
     "mfl_id": 16777,
-    "gsis_id": "00-0039752"
+    "gsis_id": "00-0039752",
+    "espn_id": 4430065
   },
   {
     "mfl_id": 16778,
-    "gsis_id": "00-0039410"
+    "gsis_id": "00-0039410",
+    "espn_id": 5083754
   },
   {
     "mfl_id": 16779,
-    "gsis_id": "00-0039883"
+    "gsis_id": "00-0039883",
+    "espn_id": 4429743
   },
   {
     "mfl_id": 16780,
-    "gsis_id": "00-0039412"
+    "gsis_id": "00-0039412",
+    "espn_id": 4361357
   },
   {
     "mfl_id": 16781,
-    "gsis_id": "00-0039413"
+    "gsis_id": "00-0039413",
+    "espn_id": 4693816
   },
   {
     "mfl_id": 16782,
-    "gsis_id": "00-0039414"
+    "gsis_id": "00-0039414",
+    "espn_id": 4874448
   },
   {
     "mfl_id": 16783,
-    "gsis_id": "00-0039416"
+    "gsis_id": "00-0039416",
+    "espn_id": 4426435
   },
   {
     "mfl_id": 16784,
-    "gsis_id": "00-0039417"
+    "gsis_id": "00-0039417",
+    "espn_id": 4695783
   },
   {
     "mfl_id": 16785,
-    "gsis_id": "00-0039418"
+    "gsis_id": "00-0039418",
+    "espn_id": 4427068
   },
   {
     "mfl_id": 16786,
@@ -17539,342 +18028,427 @@
   },
   {
     "mfl_id": 16787,
-    "gsis_id": "00-0039423"
+    "gsis_id": "00-0039423",
+    "espn_id": 4373956
   },
   {
     "mfl_id": 16788,
-    "gsis_id": "00-0039424"
+    "gsis_id": "00-0039424",
+    "espn_id": 4569559
   },
   {
     "mfl_id": 16789,
-    "gsis_id": "00-0039425"
+    "gsis_id": "00-0039425",
+    "espn_id": 4365303
   },
   {
     "mfl_id": 16790,
-    "gsis_id": "00-0039427"
+    "gsis_id": "00-0039427",
+    "espn_id": 4361689
   },
   {
     "mfl_id": 16791,
-    "gsis_id": "00-0039429"
+    "gsis_id": "00-0039429",
+    "espn_id": 4372062
   },
   {
     "mfl_id": 16792,
-    "gsis_id": "00-0039884"
+    "gsis_id": "00-0039884",
+    "espn_id": 4567506
   },
   {
     "mfl_id": 16793,
-    "gsis_id": "00-0039430"
+    "gsis_id": "00-0039430",
+    "espn_id": 4431613
   },
   {
     "mfl_id": 16794,
-    "gsis_id": "00-0039431"
+    "gsis_id": "00-0039431",
+    "espn_id": 4426676
   },
   {
     "mfl_id": 16795,
-    "gsis_id": "00-0039432"
+    "gsis_id": "00-0039432",
+    "espn_id": 4692185
   },
   {
     "mfl_id": 16796,
-    "gsis_id": "00-0039754"
+    "gsis_id": "00-0039754",
+    "espn_id": 4361112
   },
   {
     "mfl_id": 16797,
-    "gsis_id": "00-0039433"
+    "gsis_id": "00-0039433",
+    "espn_id": 4573152
   },
   {
     "mfl_id": 16798,
-    "gsis_id": "00-0039235"
+    "gsis_id": "00-0039235",
+    "espn_id": 4430118
   },
   {
     "mfl_id": 16799,
-    "gsis_id": "00-0039435"
+    "gsis_id": "00-0039435",
+    "espn_id": 4426698
   },
   {
     "mfl_id": 16800,
-    "gsis_id": "00-0039436"
+    "gsis_id": "00-0039436",
+    "espn_id": 4429058
   },
   {
     "mfl_id": 16801,
-    "gsis_id": "00-0039437"
+    "gsis_id": "00-0039437",
+    "espn_id": 4426479
   },
   {
     "mfl_id": 16802,
-    "gsis_id": "00-0039802"
+    "gsis_id": "00-0039802",
+    "espn_id": 4363417
   },
   {
     "mfl_id": 16803,
-    "gsis_id": "00-0039573"
+    "gsis_id": "00-0039573",
+    "espn_id": 4361604
   },
   {
     "mfl_id": 16804,
-    "gsis_id": "00-0039464"
+    "gsis_id": "00-0039464",
+    "espn_id": 4368343
   },
   {
     "mfl_id": 16805,
-    "gsis_id": "00-0039503"
+    "gsis_id": "00-0039503",
+    "espn_id": 4775270
   },
   {
     "mfl_id": 16806,
-    "gsis_id": "00-0039552"
+    "gsis_id": "00-0039552",
+    "espn_id": 4426893
   },
   {
     "mfl_id": 16807,
-    "gsis_id": "00-0039613"
+    "gsis_id": "00-0039613",
+    "espn_id": 4373634
   },
   {
     "mfl_id": 16808,
-    "gsis_id": "00-0039529"
+    "gsis_id": "00-0039529",
+    "espn_id": 4428211
   },
   {
     "mfl_id": 16809,
-    "gsis_id": "00-0039491"
+    "gsis_id": "00-0039491",
+    "espn_id": 4695883
   },
   {
     "mfl_id": 16810,
-    "gsis_id": "00-0039244"
+    "gsis_id": "00-0039244",
+    "espn_id": 4698191
   },
   {
     "mfl_id": 16811,
-    "gsis_id": "00-0039684"
+    "gsis_id": "00-0039684",
+    "espn_id": 4569156
   },
   {
     "mfl_id": 16812,
-    "gsis_id": "00-0039278"
+    "gsis_id": "00-0039278",
+    "espn_id": 4360818
   },
   {
     "mfl_id": 16813,
-    "gsis_id": "00-0039455"
+    "gsis_id": "00-0039455",
+    "espn_id": 4429610
   },
   {
     "mfl_id": 16814,
-    "gsis_id": "00-0039699"
+    "gsis_id": "00-0039699",
+    "espn_id": 4360271
   },
   {
     "mfl_id": 16815,
-    "gsis_id": "00-0039318"
+    "gsis_id": "00-0039318",
+    "espn_id": 4429097
   },
   {
     "mfl_id": 16816,
-    "gsis_id": "00-0039603"
+    "gsis_id": "00-0039603",
+    "espn_id": 4373273
   },
   {
     "mfl_id": 16817,
-    "gsis_id": "00-0039289"
+    "gsis_id": "00-0039289",
+    "espn_id": 4431598
   },
   {
     "mfl_id": 16819,
-    "gsis_id": "00-0039683"
+    "gsis_id": "00-0039683",
+    "espn_id": 4429019
   },
   {
     "mfl_id": 16820,
-    "gsis_id": "00-0039241"
+    "gsis_id": "00-0039241",
+    "espn_id": 4429291
   },
   {
     "mfl_id": 16821,
-    "gsis_id": "00-0039259"
+    "gsis_id": "00-0039259",
+    "espn_id": 4428763
   },
   {
     "mfl_id": 16822,
-    "gsis_id": "00-0039562"
+    "gsis_id": "00-0039562",
+    "espn_id": 5089537
   },
   {
     "mfl_id": 16823,
-    "gsis_id": "00-0039621"
+    "gsis_id": "00-0039621",
+    "espn_id": 5209803
   },
   {
     "mfl_id": 16824,
-    "gsis_id": "00-0039661"
+    "gsis_id": "00-0039661",
+    "espn_id": 4368315
   },
   {
     "mfl_id": 16825,
-    "gsis_id": "00-0039516"
+    "gsis_id": "00-0039516",
+    "espn_id": 4430404
   },
   {
     "mfl_id": 16826,
-    "gsis_id": "00-0039678"
+    "gsis_id": "00-0039678",
+    "espn_id": 4569330
   },
   {
     "mfl_id": 16827,
-    "gsis_id": "00-0039728"
+    "gsis_id": "00-0039728",
+    "espn_id": 4426367
   },
   {
     "mfl_id": 16828,
-    "gsis_id": "00-0039637"
+    "gsis_id": "00-0039637",
+    "espn_id": 4428125
   },
   {
     "mfl_id": 16829,
-    "gsis_id": "00-0039766"
+    "gsis_id": "00-0039766",
+    "espn_id": 4250013
   },
   {
     "mfl_id": 16830,
-    "gsis_id": "00-0039730"
+    "gsis_id": "00-0039730",
+    "espn_id": 4576845
   },
   {
     "mfl_id": 16831,
-    "gsis_id": "00-0039648"
+    "gsis_id": "00-0039648",
+    "espn_id": 4360978
   },
   {
     "mfl_id": 16832,
-    "gsis_id": "00-0039606"
+    "gsis_id": "00-0039606",
+    "espn_id": 4686263
   },
   {
     "mfl_id": 16833,
-    "gsis_id": "00-0039541"
+    "gsis_id": "00-0039541",
+    "espn_id": 4429153
   },
   {
     "mfl_id": 16834,
-    "gsis_id": "00-0039626"
+    "gsis_id": "00-0039626",
+    "espn_id": 5192448
   },
   {
     "mfl_id": 16835,
-    "gsis_id": "00-0039585"
+    "gsis_id": "00-0039585",
+    "espn_id": 4427291
   },
   {
     "mfl_id": 16836,
-    "gsis_id": "00-0039565"
+    "gsis_id": "00-0039565",
+    "espn_id": 4428241
   },
   {
     "mfl_id": 16837,
-    "gsis_id": "00-0039473"
+    "gsis_id": "00-0039473",
+    "espn_id": 4385430
   },
   {
     "mfl_id": 16838,
-    "gsis_id": "00-0039702"
+    "gsis_id": "00-0039702",
+    "espn_id": 4911517
   },
   {
     "mfl_id": 16839,
-    "gsis_id": "00-0039305"
+    "gsis_id": "00-0039305",
+    "espn_id": 4361100
   },
   {
     "mfl_id": 16840,
-    "gsis_id": "00-0039773"
+    "gsis_id": "00-0039773",
+    "espn_id": 4360282
   },
   {
     "mfl_id": 16841,
-    "gsis_id": "00-0039707"
+    "gsis_id": "00-0039707",
+    "espn_id": 4361348
   },
   {
     "mfl_id": 16842,
-    "gsis_id": "00-0039865"
+    "gsis_id": "00-0039865",
+    "espn_id": 5214652
   },
   {
     "mfl_id": 16843,
-    "gsis_id": "00-0039498"
+    "gsis_id": "00-0039498",
+    "espn_id": 4574716
   },
   {
     "mfl_id": 16844,
-    "gsis_id": "00-0039777"
+    "gsis_id": "00-0039777",
+    "espn_id": 4427822
   },
   {
     "mfl_id": 16845,
-    "gsis_id": "00-0039869"
+    "gsis_id": "00-0039869",
+    "espn_id": 5215032
   },
   {
     "mfl_id": 16847,
-    "gsis_id": "00-0039914"
+    "gsis_id": "00-0039914",
+    "espn_id": 5215426
   },
   {
     "mfl_id": 16848,
-    "gsis_id": "00-0039934"
+    "gsis_id": "00-0039934",
+    "espn_id": 5092436
   },
   {
     "mfl_id": 16849,
-    "gsis_id": "00-0039701"
+    "gsis_id": "00-0039701",
+    "espn_id": 4571579
   },
   {
     "mfl_id": 16851,
-    "gsis_id": "00-0039477"
+    "gsis_id": "00-0039477",
+    "espn_id": 4876013
   },
   {
     "mfl_id": 16853,
-    "gsis_id": "00-0039296"
+    "gsis_id": "00-0039296",
+    "espn_id": 4427265
   },
   {
     "mfl_id": 16854,
-    "gsis_id": "00-0039263"
+    "gsis_id": "00-0039263",
+    "espn_id": 4372741
   },
   {
     "mfl_id": 16857,
-    "gsis_id": "00-0039709"
+    "gsis_id": "00-0039709",
+    "espn_id": 4575116
   },
   {
     "mfl_id": 16858,
-    "gsis_id": "00-0039623"
+    "gsis_id": "00-0039623",
+    "espn_id": 4573697
   },
   {
     "mfl_id": 16860,
-    "gsis_id": "00-0039595"
+    "gsis_id": "00-0039595",
+    "espn_id": 4567216
   },
   {
     "mfl_id": 16863,
-    "gsis_id": "00-0039543"
+    "gsis_id": "00-0039543",
+    "espn_id": 4426399
   },
   {
     "mfl_id": 16865,
-    "gsis_id": "00-0039454"
+    "gsis_id": "00-0039454",
+    "espn_id": 4363052
   },
   {
     "mfl_id": 16867,
-    "gsis_id": "00-0039334"
+    "gsis_id": "00-0039334",
+    "espn_id": 4361607
   },
   {
     "mfl_id": 16869,
-    "gsis_id": "00-0039718"
+    "gsis_id": "00-0039718",
+    "espn_id": 4875564
   },
   {
     "mfl_id": 16870,
-    "gsis_id": "00-0039774"
+    "gsis_id": "00-0039774",
+    "espn_id": 4428550
   },
   {
     "mfl_id": 16871,
-    "gsis_id": "00-0039466"
+    "gsis_id": "00-0039466",
+    "espn_id": 4579554
   },
   {
     "mfl_id": 16872,
-    "gsis_id": "00-0039763"
+    "gsis_id": "00-0039763",
+    "espn_id": 4366349
   },
   {
     "mfl_id": 16873,
-    "gsis_id": "00-0039649"
+    "gsis_id": "00-0039649",
+    "espn_id": 4361765
   },
   {
     "mfl_id": 16874,
-    "gsis_id": "00-0039945"
+    "gsis_id": "00-0039945",
+    "espn_id": 4361831
   },
   {
     "mfl_id": 16875,
-    "gsis_id": "00-0039764"
+    "gsis_id": "00-0039764",
+    "espn_id": 4429392
   },
   {
     "mfl_id": 16876,
-    "gsis_id": "00-0039575"
+    "gsis_id": "00-0039575",
+    "espn_id": 4360900
   },
   {
     "mfl_id": 16878,
-    "gsis_id": "00-0039465"
+    "gsis_id": "00-0039465",
+    "espn_id": 4428584
   },
   {
     "mfl_id": 16880,
-    "gsis_id": "00-0039681"
+    "gsis_id": "00-0039681",
+    "espn_id": 4572460
   },
   {
     "mfl_id": 16882,
-    "gsis_id": "00-0039534"
+    "gsis_id": "00-0039534",
+    "espn_id": 4362260
   },
   {
     "mfl_id": 16883,
-    "gsis_id": "00-0039589"
+    "gsis_id": "00-0039589",
+    "espn_id": 5097554
   },
   {
     "mfl_id": 16884,
-    "gsis_id": "00-0039539"
+    "gsis_id": "00-0039539",
+    "espn_id": 4360469
   },
   {
     "mfl_id": 16885,
-    "gsis_id": "00-0039333"
+    "gsis_id": "00-0039333",
+    "espn_id": 4576069
   },
   {
     "mfl_id": 16886,
-    "gsis_id": "00-0039611"
+    "gsis_id": "00-0039611",
+    "espn_id": 4571597
   }
 ]


### PR DESCRIPTION
Used a process of meticulously joining and checking ESPN ID's from ffscrapr::mfl_players() to ffscrapr::espn_players(). Code below:

```
#Returns a full map of MFL & ESPN fantasy system players from a given season including NA values where one system omits the player
library(ffscrapr)
library(tidyverse)
ffscrapr::clear_cache()

load_mfl_espn_id_map_historical <- function(season_range) {
  
  # Initialize empty dataframes for raw MFL and ESPN data
  mfl_raw_list <- tibble()
  espn_raw_list <- tibble()
  
  # Loop through each season to collect raw data
  for (season in season_range) {
    
    # Create unique season conn objects
    mfl_conn <- ffscrapr::mfl_connect(season = season)
    espn_conn <- ffscrapr::espn_connect(season = season)
    
    # Fetch raw MFL player list
    mfl_raw_season <- ffscrapr::mfl_players(mfl_conn) %>%
      mutate(season = season) # Add season for reference
    
    # Fetch raw ESPN player list
    espn_raw_season <- ffscrapr::espn_players(espn_conn) %>%
      mutate(season = season) # Add season for reference
    
    # Append the raw data for each season to the full dataframes
    mfl_raw_list <- bind_rows(mfl_raw_list, mfl_raw_season)
    espn_raw_list <- bind_rows(espn_raw_list, espn_raw_season)
  }
  
  # First populate full MFL player list
  mfl_names_list <- mfl_raw_list %>%
    select(season,
           player_id,
           player_name,
           pos,
           team,
           espn_id) %>%
    rename(mfl_id = player_id,
           mfl_name = player_name,
           mfl_team = team,
           mfl_pos = pos) %>%
    mutate(player_name_clean = nflreadr::clean_player_names(mfl_name),
           team_clean = nflreadr::clean_team_abbrs(mfl_team),
           pos_clean = mfl_pos,
           mfl_id = as.integer(mfl_id),
           espn_id = as.integer(espn_id)) %>%
    filter(mfl_id > 999)
  
  # Clean ESPN player list for join
  espn_names_list <- espn_raw_list %>%
    rename(espn_id = player_id,
           espn_pos = pos,
           espn_name = player_name,
           espn_team = team) %>%
    mutate(player_name_clean = nflreadr::clean_player_names(espn_name),
           team_clean = nflreadr::clean_team_abbrs(espn_team),
           pos_clean = case_when(
             espn_pos == "K" ~ "PK",
             espn_pos == "P" ~ "PN",
             TRUE ~ espn_pos  # Keep the original name otherwise
           ))
  
  # Test 0.1: Check for any mis-matched name issues in known ID matches
  test_0_1_name_discrepancies <- mfl_names_list %>%
    inner_join(espn_names_list,
               by = c("season", "espn_id")) %>%
    filter(player_name_clean.x != player_name_clean.y)
  view(test_0_1_name_discrepancies)
  
  # Print the number of NA cases at start
  na_cases_start <- mfl_names_list %>%
    filter(is.na(espn_id)) %>%
    nrow()
  cat("NA Cases at Start: ", na_cases_start, "\n")
  
  #Join 1: Incorporate Test 1 findings & join by player, team, position
  mfl_espn_join_1 <- mfl_names_list %>%
    #Fix Name Discrepancies found in Test 1
    mutate(mfl_name = case_when(
      mfl_id == 16321 ~ "DiCaprio Bootle",
      mfl_id == 16321 ~ "Chris Smith",
      mfl_id == 16374 ~ "Grant DuBose",
      mfl_id == 14958 ~ "Shaq Quarterman",
      mfl_id == 14305 ~ "Bisi Johnson",
      mfl_id == 15888 ~ "Cobie Durant",
      mfl_id == 15446 ~ "TJ Slaton",
      mfl_id == 15866 ~ "CorDale Flott",
      mfl_id == 12647 ~ "William Fuller",
      mfl_id == 12647 ~ "Patrick O'Connor",
      mfl_id == 15485 ~ "Will Bradley-King",
      mfl_id == 15954 ~ "Jeff Gunter",
      mfl_id == 14252 ~ "Mike Jackson",
      mfl_id == 12733 ~ "Justin March-Lillard",
      mfl_id == 12822 ~ "Danny Vitale",
      mfl_id == 11270 ~ "Tank Carradine",
      mfl_id == 10906 ~ "Nate Stupar",
      mfl_id == 9475 ~ "Ziggy Hood",
      mfl_id == 9495 ~ "Mike Mitchell",
      mfl_id == 9674 ~ "Ricky Jean Francois",
      mfl_id == 11267 ~ "Ziggy Ansah",
      mfl_id == 11605 ~ "DeShawn Shead",
      mfl_id == 11717 ~ "Tim Jernigan",
      mfl_id == 11719 ~ "Dan McCullers",
      mfl_id == 12348 ~ "L.T. Walton",
      mfl_id == 12478 ~ "LaDarius Gunter",
      mfl_id == 11104 ~ "Joshua Bellamy",
      mfl_id == 9608 ~ "Don Juan Carey",
      mfl_id == 8677 ~ "Charles L. Johnson",
      mfl_id == 8548 ~ "Tony Dewayne McDaniel",
      mfl_id == 7422 ~ "Benjamin Watson",
      mfl_id == 9050 ~ "Andre Jerome Caldwell",
      mfl_id == 9495 ~ "Mike Mitchell",
      mfl_id == 9963 ~ "Arthur Jones",
      mfl_id == 10333 ~ "Rob Housler",
      mfl_id == 10676 ~ "Mike Morgan",
      mfl_id == 10822 ~ "John Lewis Hughes III",
      mfl_id == 11024 ~ "Valentino Blake",
      mfl_id == 11398 ~ "Chris Dwightstone Jones",
      mfl_id == 11725 ~ "Jerry Attaochu",
      mfl_id == 11995 ~ "Robert Chevis Nelson Jr.",
      mfl_id == 12283 ~ "Owa Odighizuwa",
      mfl_id == 12847 ~ "Devin Lewis Fuller",
      TRUE ~ mfl_name  # Keep the original name if no match
    )) %>%
    left_join(espn_names_list %>%
                select(season, player_name_clean, team_clean, pos_clean, espn_id),
              by = c("season", "player_name_clean", "team_clean", "pos_clean"))
  
  # Test 1.1: Check for duplicates of player/team/position
  test1_1_join_1_duplicates <- mfl_espn_join_1 %>%
    group_by(season, player_name_clean, team_clean, pos_clean) %>%
    filter(n() > 1) %>%
    arrange(season, player_name_clean, team_clean, pos_clean)
  view(test1_1_join_1_duplicates)
  
  # Test1.2: Check for ESPN ID contradictions in the two df's
  test1_2_join_1_id_contradictions <- mfl_espn_join_1 %>%
    filter(!is.na(espn_id.x) & !is.na(espn_id.y) & espn_id.x != espn_id.y)
  view(test1_2_join_1_id_contradictions)
  # View Join 2 successes & Print the number of NA cases resolved in the second join
  join_1_successes <- mfl_espn_join_1 %>%
    filter(is.na(espn_id.x) & !is.na(espn_id.y))
  view(join_1_successes)
  na_cases_resolved_join_1 <- join_1_successes %>%
    nrow()
  cat("Join 1 NA cases resolved: ", na_cases_resolved_join_1, "\n")
  # Resolve test issues and overwrite NA espn_id's
  mfl_espn_join_1 <- mfl_espn_join_1 %>%
    mutate(espn_id.x = case_when(
      mfl_id == 15276 ~ 4239768,
      mfl_id == 15589 ~ 4241983,
      mfl_id == 11994 ~ 15356,
      mfl_id == 10426 ~ 14216,
      mfl_id == 12816 ~ 2580052,
      mfl_id == 11797 ~ 16904,
      mfl_id == 12353 ~ 2577467,
      TRUE ~ espn_id.x  # Keep the original name if no match
    )) %>%
    mutate(espn_id = coalesce(espn_id.x, espn_id.y)) %>%
    select(-espn_id.x, -espn_id.y)
  
  #Join 2: Join by name and position only
  # Filter rows where espn_id is NA before performing the join
  na_rows_pre_join_2 <- mfl_espn_join_1 %>%
    filter(is.na(espn_id))
  
  na_rows_joined_2 <- na_rows_pre_join_2 %>%
    left_join(espn_names_list %>%
                select(season, player_name_clean, pos_clean, espn_id, espn_team),
              by = c("season", "player_name_clean", "pos_clean"))
  
  # Test 2.1: Check for duplicates of player/position after the second join
  test2_1_join_2_duplicates <- na_rows_joined_2 %>%
    group_by(season, player_name_clean, pos_clean) %>%
    filter(n() > 1) %>%
    arrange(season, player_name_clean, pos_clean)
  view(test2_1_join_2_duplicates)
  
  # View Join 2 successes & Print the number of NA cases resolved in the second join
  join_2_successes <- na_rows_joined_2 %>%
    filter(!is.na(espn_id.y))
  view(join_2_successes)
  na_cases_resolved_join_2 <- join_2_successes %>%
    nrow()
  cat("Join 2 NA cases resolved: ", na_cases_resolved_join_2, "\n")
  
  # Resolve test issues, overwrite NA espn_id's, and drop reference (espn_team) column
  na_rows_joined_2 <- na_rows_joined_2 %>%
    mutate(espn_id = coalesce(espn_id.x, espn_id.y)) %>%
    select(-espn_id.x, -espn_id.y, -espn_team)  # Drop unnecessary columns
  
  # Bind the updated NA rows back to the original dataframe
  mfl_espn_join_2 <- mfl_espn_join_1 %>%
    filter(!is.na(espn_id)) %>%  # Keep rows where espn_id.x is already filled
    bind_rows(na_rows_joined_2)    # Add the resolved NA rows
  
  #Join 3: Join by name and team only
  # Filter rows where espn_id is NA before performing the join
  na_rows_pre_join_3 <- mfl_espn_join_2 %>%
    filter(is.na(espn_id))
  
  na_rows_joined_3 <- na_rows_pre_join_3 %>%
    left_join(., y = espn_names_list %>%
                select(season, player_name_clean, team_clean, espn_pos, espn_id),
              by = c("season", "player_name_clean", "team_clean"))
  
  # Test 3.1: Check for duplicates of player/team after the second join
  test3_1_join_3_duplicates <- na_rows_joined_3 %>%
    group_by(season, player_name_clean, team_clean) %>%
    filter(n() > 1) %>%
    arrange(season, player_name_clean, team_clean)
  view(test3_1_join_3_duplicates)
  
  # View Join 3 successes & Print the number of NA cases resolved in the join
  join_3_successes <- na_rows_joined_3 %>%
    filter(!is.na(espn_id.y))
  view(join_3_successes)
  na_cases_resolved_join_3 <- join_3_successes %>%
    nrow()
  cat("Join 3 NA cases resolved: ", na_cases_resolved_join_3, "\n")
  
  # Resolve test issues, overwrite NA espn_id's, and drop reference (espn_team) column
  na_rows_joined_3 <- na_rows_joined_3 %>%
    mutate(espn_id = coalesce(espn_id.x, espn_id.y)) %>%
    select(-espn_id.x, -espn_id.y, -espn_pos)  # Drop unnecessary columns
  
  # Bind the updated NA rows back to the original dataframe
  mfl_espn_join_3 <- mfl_espn_join_2 %>%
    filter(!is.na(espn_id)) %>%  # Keep rows where espn_id.x is already filled
    bind_rows(na_rows_joined_3)    # Add the resolved NA rows
  
  #Join 4: Join by name only
  # Filter rows where espn_id is NA before performing the join
  na_rows_pre_join_4 <- mfl_espn_join_3 %>%
    filter(is.na(espn_id))
  
  na_rows_joined_4 <- na_rows_pre_join_4 %>%
    left_join(., y = espn_names_list %>%
                select(season, player_name_clean, espn_team, espn_pos, espn_id),
              by = c("season", "player_name_clean"))
  
  # Test 4.1: Check for duplicates of player_name after join
  test4_1_join_4_duplicates <- na_rows_joined_4 %>%
    group_by(season, player_name_clean) %>%
    filter(n() > 1) %>%
    arrange(season, player_name_clean)
  view(test4_1_join_4_duplicates)
  
  # View Join 4 successes & Print the number of NA cases resolved in the join
  join_4_successes <- na_rows_joined_4 %>%
    filter(!is.na(espn_id.y))
  view(join_4_successes)
  na_cases_resolved_join_4 <- join_4_successes %>%
    nrow()
  cat("Join 4 NA cases resolved: ", na_cases_resolved_join_4, "\n")
  
  # Resolve test issues, overwrite NA espn_id's, and drop reference (espn_team) column
  na_rows_joined_4 <- na_rows_joined_4 %>%
    mutate(espn_id = coalesce(espn_id.x, espn_id.y)) %>%
    select(-espn_id.x, -espn_id.y, -espn_team, -espn_pos)  # Drop unnecessary columns
  
  # Bind the updated NA rows back to the original dataframe
  mfl_espn_join_4 <- mfl_espn_join_3 %>%
    filter(!is.na(espn_id)) %>%                # Keep rows where espn_id.x is already filled
    bind_rows(na_rows_joined_4) %>%            # Add the resolved NA rows
    mutate(espn_id = as.integer(espn_id)) %>%  # Restore to int type from start
    arrange(season, mfl_id)                            # Restore row order
  
  return(mfl_espn_join_4)
}

map_2017_2014 <- load_mfl_espn_id_map_historical(2017:2024)

#Check for any espn_id disagreements to mfl_id joins across years
mfl_espn_conflicts <- map_2017_2014 %>%
  group_by(mfl_id) %>%
  filter(n_distinct(espn_id[!is.na(espn_id)]) > 1) %>%
  arrange(mfl_id)

view(mfl_espn_conflicts)

#Replace all NA espn_id's with known espn_id's from other years and keep one row per player (the most recent season)
map_2017_2014_final <- map_2017_2014 %>%
  group_by(mfl_id) %>%
  mutate(espn_id = coalesce(espn_id, first(espn_id[!is.na(espn_id)]))) %>%
  ungroup() %>%
  arrange(mfl_id, desc(season)) %>%
  distinct(mfl_id, .keep_all = TRUE)

```